### PR TITLE
Various cleanups to computation pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install numpy pandas pytest toolz numba datashape odo dask
+  - conda install numpy pandas pytest toolz numba datashape odo dask pillow
   - conda install -c dynd dynd-python
   # Temporary, until conda main channel gets updated
   - pip install --upgrade --no-deps dask

--- a/datashader/aggregates.py
+++ b/datashader/aggregates.py
@@ -5,7 +5,7 @@ from datashape import dshape, isnumeric, Record, Option, DataShape, maxtype
 from datashape import coretypes as ct
 from toolz import concat, unique, memoize, identity
 
-from .utils import ngjit
+from .utils import ngjit, is_missing
 
 
 # Dynd Missing Type Flags
@@ -14,15 +14,6 @@ _dynd_missing_types = {np.dtype('i2'): np.iinfo('i2').min,
                        np.dtype('i8'): np.iinfo('i8').min,
                        np.dtype('f4'): np.nan,
                        np.dtype('f8'): np.nan}
-
-
-def make_is_missing(m):
-    return ngjit(lambda x: x == m)
-
-# Lookup from dtype to function that checks if value is missing
-_dynd_is_missing = {}
-for dt, m in _dynd_missing_types.items():
-    _dynd_is_missing[dt] = np.isnan if m is np.nan else make_is_missing(m)
 
 
 def numpy_dtype(x):
@@ -103,7 +94,7 @@ class sum(Reduction):
         return dshape(optionify(maxtype(input_dshape.measure[self.column])))
 
     def _build_append(self, dshape):
-        return build_append_sum(dshape)
+        return append_sum
 
     def _build_combine(self, dshape):
         return combine_sum
@@ -256,19 +247,12 @@ def append_m2(x, y, m2, field, sum, count):
         m2[y, x] += (field - u1) * (field - u)
 
 
-@memoize
-def build_append_sum(dshape):
-    # sum needs specialization for each missing flag
-    dtype = numpy_dtype(dshape)
-    is_missing = _dynd_is_missing[dtype]
-
-    @ngjit
-    def append_sum(x, y, agg, field):
-        if is_missing(agg[y, x]):
-            agg[y, x] = field
-        else:
-            agg[y, x] += field
-    return append_sum
+@ngjit
+def append_sum(x, y, agg, field):
+    if is_missing(agg[y, x]):
+        agg[y, x] = field
+    else:
+        agg[y, x] += field
 
 
 # ============ Combiners ============
@@ -279,7 +263,6 @@ def combine_count(aggs):
 
 def combine_sum(aggs):
     missing_val = _dynd_missing_types[aggs.dtype]
-    is_missing = _dynd_is_missing[aggs.dtype]
     missing_vals = is_missing(aggs)
     all_empty = np.bitwise_and.reduce(missing_vals, axis=0)
     set_to_zero = missing_vals & ~all_empty
@@ -328,7 +311,6 @@ def build_finalize_max(dshape):
 
 
 def as_float64(arr):
-    is_missing = _dynd_is_missing[arr.dtype]
     return np.where(is_missing(arr), np.nan, arr.astype('f8'))
 
 

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -22,7 +22,7 @@ c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
 
 
 def eq(agg, b):
-    a = nd.as_numpy(agg.view_scalars(agg.dtype.value_type))
+    a = nd.as_numpy(agg.view_scalars(getattr(agg.dtype, 'value_type', agg.dtype)))
     assert np.allclose(a, b)
     assert a.dtype == b.dtype
 

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -16,7 +16,7 @@ c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
 
 
 def eq(agg, b):
-    a = nd.as_numpy(agg.view_scalars(agg.dtype.value_type))
+    a = nd.as_numpy(agg.view_scalars(getattr(agg.dtype, 'value_type', agg.dtype)))
     assert np.allclose(a, b)
     assert a.dtype == b.dtype
 

--- a/datashader/tests/test_utils.py
+++ b/datashader/tests/test_utils.py
@@ -1,7 +1,10 @@
 from datashape import dshape
 
-from datashader.utils import _exec, Dispatcher, isreal
+from datashader.utils import (_exec, Dispatcher, isreal, generated_jit,
+                              is_missing)
 
+import numba as nb
+import numpy as np
 from pytest import raises
 
 
@@ -43,3 +46,28 @@ def test_isreal():
     assert isreal('float64')
     assert not isreal('complex64')
     assert not isreal('{x: int64, y: float64}')
+
+
+@generated_jit
+def foo(x, y):
+    if isinstance(x, nb.types.Integer):
+        return lambda x, y: x + y
+    else:
+        return lambda x, y: x - y
+
+
+def test_generated_jit():
+    assert foo(1, 2) == 3
+    assert foo(1., 2) == -1.
+
+
+def test_is_missing():
+    x_i8 = np.array([np.iinfo('i8').min, 2, 3], dtype='i8')
+    x_i4 = np.array([np.iinfo('i4').min, 2, 3], dtype='i4')
+    x_f8 = np.array([np.nan, 2, 3], dtype='f8')
+    x_f4 = np.array([np.nan, 2, 3], dtype='f4')
+    res = np.array([True, False, False])
+    assert (is_missing(x_i8) == res).all()
+    assert (is_missing(x_i4) == res).all()
+    assert (is_missing(x_f8) == res).all()
+    assert (is_missing(x_f4) == res).all()

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -7,6 +7,7 @@ from dynd import nd
 from PIL.Image import fromarray
 
 from .colors import rgb
+from .utils import is_missing, is_option
 
 
 __all__ = ['Image', 'merge', 'stack', 'interpolate']
@@ -30,10 +31,6 @@ class Image(object):
         self.to_pil(origin).save(fp, format)
         fp.seek(0)
         return fp
-
-
-def _is_option(agg):
-    return hasattr(agg, 'value_type')
 
 
 def _to_channels(data):
@@ -83,10 +80,9 @@ def interpolate(agg, low, high, how='log'):
         f = lambda x: x
     else:
         raise ValueError("Unknown interpolation method: {0}".format(how))
-    if _is_option(agg.dtype):
+    if is_option(agg.dtype):
         buffer = nd.as_numpy(agg.view_scalars(agg.dtype.value_type))
-        missing = nd.as_numpy(nd.is_missing(agg))
-        offset = buffer[~missing].min()
+        offset = buffer[~is_missing(buffer)].min()
     else:
         buffer = nd.as_numpy(agg)
         offset = buffer.min()

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 from inspect import getmro
-from contextlib import contextmanager
 
 from datashape import Unit
 from datashape.predicates import launder
 from datashape.typesets import real
 import numba as nb
+import numpy as np
 
 
 ngjit = nb.jit(nopython=True, nogil=True)
@@ -64,3 +64,72 @@ class Dispatcher(object):
 def isreal(dt):
     dt = launder(dt)
     return isinstance(dt, Unit) and dt in real
+
+
+class GeneratedFunction(nb.dispatcher.Dispatcher):
+    def compile(self, sig):
+        with self._compile_lock:
+            args, return_type = nb.sigutils.normalize_signature(sig)
+            existing = self.overloads.get(tuple(args))
+            if existing is not None:
+                return existing
+
+            cres = self._cache.load_overload(sig, self.targetctx)
+            if cres is not None:
+                if not cres.objectmode and not cres.interpmode:
+                    self.targetctx.insert_user_function(cres.entry_point,
+                                                        cres.fndesc,
+                                                        [cres.library])
+                self.add_overload(cres)
+                return cres.entry_point
+
+            flags = nb.compiler.Flags()
+            self.targetdescr.options.parse_as_flags(flags, self.targetoptions)
+
+            cres = nb.compiler.compile_extra(self.typingctx, self.targetctx,
+                                             self.py_func(*args), args=args,
+                                             return_type=return_type,
+                                             flags=flags, locals=self.locals)
+
+            if cres.typing_error is not None and not flags.enable_pyobject:
+                raise cres.typing_error
+
+            self.add_overload(cres)
+            self._cache.save_overload(sig, cres)
+            return cres.entry_point
+
+
+class GeneratedCPUDispatcher(GeneratedFunction):
+    targetdescr = nb.targets.registry.CPUTarget()
+
+
+nb.targets.registry.dispatcher_registry['gen_cpu'] = GeneratedCPUDispatcher
+
+
+def generated_jit(*args, **kwargs):
+    kwargs['target'] = 'gen_' + kwargs.get('target', 'cpu')
+    return nb.jit(*args, **kwargs)
+
+
+@generated_jit(nopython=True, nogil=True)
+def is_missing(x):
+    """Returns if the value is missing, per dynd's missing value flag
+    semantics"""
+    if isinstance(x, nb.types.Array):
+        dt = x.dtype
+    else:
+        dt = x
+    if isinstance(dt, nb.types.Integer):
+        missing = np.iinfo(dt.name).min
+        return lambda x: x == missing
+    elif isinstance(dt, nb.types.Float):
+        return lambda x: np.isnan(x)
+    elif isinstance(x, nb.types.Array):
+        return lambda x: np.full_like(x, False)
+    else:
+        return lambda x: False
+
+
+def is_option(agg):
+    """Returns if the dshape of the dynd array is an option type"""
+    return hasattr(agg, 'value_type')


### PR DESCRIPTION
- Don't depend on dynd dev build only functions
- Add `generated_jit` implementation to ease some code generation stuff.
  This will be part of next numba release, but works fine for now.
- Implement `is_missing` in terms of `generated_jit`, much cleaner than
  a lookup table
- Few test fixes.