### PR TITLE
Added basemap opacity slider

### DIFF
--- a/examples/dashboard.py
+++ b/examples/dashboard.py
@@ -168,10 +168,14 @@ class AppView(object):
         basemap_select = Select.create(name='Basemap', value='Toner', options=self.model.basemaps)
         basemap_select.on_change('value', self.on_basemap_change)
 
-        opacity_slider = Slider(title="Opacity", value=100, start=0, end=100, step=1)
-        opacity_slider.on_change('value', self.on_opacity_slider_change)
+        basemap_opacity = Slider(title="Basemap opacity", value=100, start=0, end=100, step=1)
+        basemap_opacity.on_change('value', self.on_basemap_opacity_change)
 
-        self.controls = HBox(width=self.fig.plot_width, children=[location_select, field_select, aggregate_select, transfer_select, basemap_select, opacity_slider])
+        data_opacity = Slider(title="Data opacity", value=100, start=0, end=100, step=1)
+        data_opacity.on_change('value', self.on_data_opacity_change)
+
+        self.opacities = VBox(children=[basemap_opacity, data_opacity])
+        self.controls = HBox(width=self.fig.plot_width, children=[location_select, field_select, aggregate_select, transfer_select, basemap_select, self.opacities])
         self.layout = VBox(width=self.fig.plot_width, height=self.fig.plot_height, children=[self.controls, self.fig])
 
     def update_image(self):
@@ -205,7 +209,12 @@ class AppView(object):
         self.model.transfer_function = self.model.transfer_functions[new]
         self.update_image()
 
-    def on_opacity_slider_change(self, attr, old, new):
+    def on_basemap_opacity_change(self, attr, old, new):
+        for renderer in self.fig.renderers:
+            if hasattr(renderer, 'tile_source'):
+                renderer.alpha = new / 100
+
+    def on_data_opacity_change(self, attr, old, new):
         for renderer in self.fig.renderers:
             if hasattr(renderer, 'image_source'):
                 renderer.alpha = new / 100


### PR DESCRIPTION
To get some experience with the new dashboard.py, I added a basemap opacity slider alongside the data opacity slider (as requested in issue #11).  This was relatively simple to do, though I wish it could be more atomic, with changes required at only a single location in the code, instead of three locations spread out.  I think that making that work would require some fundamental changes to Bokeh's architecture, which I'd be happy to discuss with Bokeh devs at some point, but not as a priority right now.  In any case, it's already much cleaner than having to switch to JavaScript! 

The result works fine, but it's very wasteful of screen space, even after packing the two opacity sliders vertically so that they would fit on the page:

![image](https://cloud.githubusercontent.com/assets/1695496/12497659/c55ec52a-c062-11e5-8ac8-8ae5f7bd38a9.png)

Is there any way to change the CSS (presumably) to make the packing much tighter?  There are other controls that need to be added, such as a checkbox for turning labels on and off, and the controls are already taking up 1/3 of the page, mostly with whitespace!