### PR TITLE
Add count_categories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ install:
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install numpy pandas pytest toolz numba datashape odo dask pillow
-  - conda install -c dynd dynd-python
-  # Temporary, until conda main channel gets updated
-  - pip install --upgrade --no-deps dask
-  - pip install --upgrade --no-deps odo
+  - conda install -c dynd/channel/dev dynd-python
+  # Need a few fixes to odo and datashape that aren't in the latest release
+  - pip install --upgrade --no-deps git+https://github.com/Blaze/odo
+  - pip install --upgrade --no-deps git+https://github.com/jcrist/datashape@is_scalar_cat
 
   - python setup.py develop --no-deps
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install numpy pandas pytest toolz numba datashape odo dask pillow
-  - conda install -c dynd/channel/dev dynd-python
+  - conda install -c dynd dynd-python
   # Need a few fixes to odo and datashape that aren't in the latest release
   - pip install --upgrade --no-deps git+https://github.com/Blaze/odo
   - pip install --upgrade --no-deps git+https://github.com/jcrist/datashape@is_scalar_cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - conda install -c dynd dynd-python
   # Need a few fixes to odo and datashape that aren't in the latest release
   - pip install --upgrade --no-deps git+https://github.com/Blaze/odo
-  - pip install --upgrade --no-deps git+https://github.com/jcrist/datashape@is_scalar_cat
+  - pip install --upgrade --no-deps git+https://github.com/Blaze/datashape
 
   - python setup.py develop --no-deps
 

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 __version__ = '0.0.1'
 
 from .core import Canvas
-from .aggregates import count, sum, min, max, mean, std, var
+from .aggregates import count, sum, min, max, mean, std, var, count_cat
 
 # Needed to build the backend dispatch
 from .pandas import *

--- a/datashader/compiler.py
+++ b/datashader/compiler.py
@@ -89,7 +89,7 @@ def make_create(bases, dshapes):
 
 
 def make_info(cols):
-    return lambda df: tuple(df[c].values for c in cols)
+    return lambda df: tuple(c.apply(df) for c in cols)
 
 
 def make_append(bases, cols, calls):
@@ -145,8 +145,9 @@ def make_finalize(bases, summary, schema):
         out = nd.empty(shape, dshape)
         for path, finalizer, inds in zip(paths, finalizers, indices):
             arr = reduce(getattr, path, out)
-            view_as = getattr(arr.dtype, 'value_type', arr.dtype)
-            np_arr = nd.as_numpy(arr.view_scalars(view_as))
+            if hasattr(arr.dtype, 'value_type'):
+                arr = arr.view_scalars(arr.dtype.value_type)
+            np_arr = nd.as_numpy(arr)
             np_arr[:] = finalizer(*get(inds, bases))
         return out
 

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -14,11 +14,6 @@ from .glyphs import subselect, compute_x_bounds, compute_y_bounds
 __all__ = ()
 
 
-@discover.register(dd.DataFrame)
-def discover_dask_dataframe(df):
-    return var * Record(zip(df.columns, map(dshape_from_pandas, df.dtypes)))
-
-
 @pipeline.register(dd.DataFrame)
 def dask_pipeline(df, schema, canvas, glyph, summary):
     create, info, append, combine, finalize = compile_components(summary,

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -14,7 +14,9 @@ df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                    'i32': np.arange(20, dtype='i4'),
                    'i64': np.arange(20, dtype='i8'),
                    'f32': np.arange(20, dtype='f4'),
-                   'f64': np.arange(20, dtype='f8')})
+                   'f64': np.arange(20, dtype='f8'),
+                   'cat': ['a']*5 + ['b']*5 + ['c']*5 + ['d']*5})
+df.cat = df.cat.astype('category')
 
 ddf = dd.from_pandas(df, npartitions=3)
 
@@ -82,6 +84,14 @@ def test_std():
     eq(c.points(ddf, 'x', 'y', agg=ds.std('i64')).agg, out)
     eq(c.points(ddf, 'x', 'y', agg=ds.std('f32')).agg, out)
     eq(c.points(ddf, 'x', 'y', agg=ds.std('f64')).agg, out)
+
+
+def test_count_cat():
+    agg = c.points(df, 'x', 'y', agg=ds.count_cat('cat')).agg
+    assert (nd.as_numpy(agg.a) == np.array([[5, 0], [0, 0]])).all()
+    assert (nd.as_numpy(agg.b) == np.array([[0, 0], [5, 0]])).all()
+    assert (nd.as_numpy(agg.c) == np.array([[0, 5], [0, 0]])).all()
+    assert (nd.as_numpy(agg.d) == np.array([[0, 0], [0, 5]])).all()
 
 
 def test_multiple_aggregates():

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -10,7 +10,9 @@ df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                    'i32': np.arange(20, dtype='i4'),
                    'i64': np.arange(20, dtype='i8'),
                    'f32': np.arange(20, dtype='f4'),
-                   'f64': np.arange(20, dtype='f8')})
+                   'f64': np.arange(20, dtype='f8'),
+                   'cat': ['a']*5 + ['b']*5 + ['c']*5 + ['d']*5})
+df.cat = df.cat.astype('category')
 
 c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
 
@@ -76,6 +78,14 @@ def test_std():
     eq(c.points(df, 'x', 'y', agg=ds.std('i64')).agg, out)
     eq(c.points(df, 'x', 'y', agg=ds.std('f32')).agg, out)
     eq(c.points(df, 'x', 'y', agg=ds.std('f64')).agg, out)
+
+
+def test_count_cat():
+    agg = c.points(df, 'x', 'y', agg=ds.count_cat('cat')).agg
+    assert (nd.as_numpy(agg.a) == np.array([[5, 0], [0, 0]])).all()
+    assert (nd.as_numpy(agg.b) == np.array([[0, 0], [5, 0]])).all()
+    assert (nd.as_numpy(agg.c) == np.array([[0, 5], [0, 0]])).all()
+    assert (nd.as_numpy(agg.d) == np.array([[0, 0], [0, 5]])).all()
 
 
 def test_multiple_aggregates():


### PR DESCRIPTION
Add `count_cat` aggregate. This returns an array of records, with a field holding the count for each category in the column (e.g. a column with dshape ``categorical[['a', 'b', 'c']]`` has records of dshape ``{a: int32, b: int32, c: int32}``).

This required a few upstream fixes to datashape and odo - for now we depend on git repo versions of these.