### PR TITLE
Add colorize transfer function

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -25,20 +25,50 @@ nd.as_numpy(agg.c.view_scalars(agg.c.dtype.value_type))[:] = c
 def test_interpolate(attr):
     x = getattr(agg, attr)
     img = tf.interpolate(x, 'pink', 'red', how='log').img
-    sol_log = np.array([[0, 4291543295, 4289043711],
-                        [4286675711, 0, 4282268671],
-                        [4280163839, 4278190335, 0]])
-    assert (img == sol_log).all()
+    sol = np.array([[0, 4291543295, 4289043711],
+                    [4286675711, 0, 4282268671],
+                    [4280163839, 4278190335, 0]])
+    assert (img == sol).all()
     img = tf.interpolate(x, 'pink', 'red', how='cbrt').img
-    sol_cbrt = np.array([[0, 4291543295, 4289109503],
-                         [4286807295, 0, 4282399999],
-                         [4280229375, 4278190335, 0]])
-    assert (img == sol_cbrt).all()
+    sol = np.array([[0, 4291543295, 4289109503],
+                    [4286807295, 0, 4282399999],
+                    [4280229375, 4278190335, 0]])
+    assert (img == sol).all()
     img = tf.interpolate(x, 'pink', 'red', how='linear').img
-    sol_lin = np.array([[0, 4291543295, 4289306879],
-                        [4287070463, 0, 4282597631],
-                        [4280361215, 4278190335, 0]])
-    assert (img == sol_lin).all()
+    sol = np.array([[0, 4291543295, 4289306879],
+                    [4287070463, 0, 4282597631],
+                    [4280361215, 4278190335, 0]])
+    assert (img == sol).all()
+    img = tf.interpolate(x, 'pink', 'red', how=lambda x: x ** 2).img
+    sol = np.array([[0, 4291543295, 4289504255],
+                    [4287399423, 0, 4282992127],
+                    [4280624127, 4278190335, 0]])
+    assert (img == sol).all()
+
+
+def test_colorize():
+    colors = [(255, 0, 0), '#0000FF', 'orange']
+    agg = np.array([[(0, 12, 0), (3, 0, 3)],
+                    [(12, 12, 12), (24, 0, 0)]],
+                   dtype=[(i, 'uint8') for i in 'abc'])
+    agg = nd.asarray(agg)
+    img = tf.colorize(agg, colors, how='log').img
+    sol = np.array([[3137273856, 2449494783],
+                    [4266997674, 3841982719]])
+    assert (img == sol).all()
+    colors = dict(zip('abc', colors))
+    img = tf.colorize(agg, colors, how='cbrt').img
+    sol = np.array([[3070164992, 2499826431],
+                    [4283774890, 3774873855]])
+    assert (img == sol).all()
+    img = tf.colorize(agg, colors, how='linear').img
+    sol = np.array([[1660878848, 989876991],
+                    [4283774890, 2952790271]])
+    assert (img == sol).all()
+    img = tf.colorize(agg, colors, how=lambda x: x ** 2).img
+    sol = np.array([[788463616, 436228863],
+                    [4283774890, 2080375039]])
+    assert (img == sol).all()
 
 
 img1 = tf.Image(np.dstack([np.array([[255, 0], [0, 125]], 'uint8'),

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from io import BytesIO
 
 import numpy as np
+import datashape
 from dynd import nd
 from PIL.Image import fromarray
 
@@ -10,7 +11,7 @@ from .colors import rgb
 from .utils import is_missing, is_option
 
 
-__all__ = ['Image', 'merge', 'stack', 'interpolate']
+__all__ = ['Image', 'merge', 'stack', 'interpolate', 'colorize']
 
 
 class Image(object):
@@ -57,6 +58,19 @@ def stack(*imgs):
     return Image(out)
 
 
+_interpolate_lookup = {'log': np.log1p,
+                       'cbrt': lambda x: x ** (1/3.),
+                       'linear': lambda x: x}
+
+
+def _normalize_interpolate_how(how):
+    if callable(how):
+        return how
+    elif how in _interpolate_lookup:
+        return _interpolate_lookup[how]
+    raise ValueError("Unknown interpolation method: {0}".format(how))
+
+
 def interpolate(agg, low, high, how='log'):
     """Convert an aggregate to an image.
 
@@ -68,18 +82,12 @@ def interpolate(agg, low, high, how='log'):
         name, hexcode, or as a tuple of ``(red, green, blue)`` values.
     high : color name or tuple
         The color for the high end of the scale
-    how : string
-        The interpolation method to use. Options are 'log' [default], 'cbrt',
-        and 'linear'.
+    how : string or callable
+        The interpolation method to use. Valid strings are 'log' [default],
+        'cbrt', and 'linear'. Callables take a 2-dimensional array of
+        magnitudes at each pixel, and should return a numeric array of the same
+        shape.
     """
-    if how == 'log':
-        f = np.log1p
-    elif how == 'cbrt':
-        f = lambda x: x ** (1/3.)
-    elif how == 'linear':
-        f = lambda x: x
-    else:
-        raise ValueError("Unknown interpolation method: {0}".format(how))
     if is_option(agg.dtype):
         buffer = nd.as_numpy(agg.view_scalars(agg.dtype.value_type))
         missing = is_missing(buffer)
@@ -87,8 +95,7 @@ def interpolate(agg, low, high, how='log'):
         buffer = nd.as_numpy(agg)
         missing = (buffer == 0)
     offset = buffer[~missing].min()
-
-    data = f(buffer + offset)
+    data = _normalize_interpolate_how(how)(buffer + offset)
     span = [data[~missing].min(), data[~missing].max()]
     rspan, gspan, bspan = zip(rgb(low), rgb(high))
     r = np.interp(data, span, rspan, left=255).astype(np.uint8)
@@ -97,3 +104,46 @@ def interpolate(agg, low, high, how='log'):
     a = np.full_like(r, 255)
     img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
     return Image(np.where(missing, 0, img))
+
+
+def colorize(agg, color_key, how='log', min_alpha=20):
+    """Color a record aggregate by field.
+
+    Parameters
+    ----------
+    agg : dynd array
+    color_key : dict or iterable
+        A mapping of fields to colors. Can be either a ``dict`` mapping from
+        field name to colors, or an iterable of colors in the same order as the
+        record fields.
+    how : string or callable
+        The interpolation method to use. Valid strings are 'log' [default],
+        'cbrt', and 'linear'. Callables take a 2-dimensional array of
+        magnitudes at each pixel, and should return a numeric array of the same
+        shape.
+    min_alpha : float, optional
+        The minimum alpha value to use for non-empty pixels, in [0, 255].
+    """
+    agg_dshape = datashape.dshape(agg.dtype.dshape)
+    if not datashape.isrecord(agg_dshape):
+        raise ValueError("Datashape of aggregate must be record type")
+    if not isinstance(color_key, dict):
+        color_key = dict(zip(agg_dshape.measure.names, color_key))
+    if len(color_key) != len(agg_dshape.measure.names):
+        raise ValueError("Number of colors doesn't match number of fields")
+    if not (0 <= min_alpha <= 255):
+        raise ValueError("min_alpha must be between 0 and 255")
+    colors = [rgb(color_key[c]) for c in agg_dshape.measure.names]
+    rs, gs, bs = map(np.array, zip(*colors))
+    data = np.dstack([nd.as_numpy(getattr(agg, f)).astype('f8') for f in
+                      agg_dshape.measure.names])
+    total = data.sum(axis=2)
+    r = (data.dot(rs)/total).astype(np.uint8)
+    g = (data.dot(gs)/total).astype(np.uint8)
+    b = (data.dot(bs)/total).astype(np.uint8)
+    a = _normalize_interpolate_how(how)(total)
+    a = ((255 - min_alpha) * a/a.max() + min_alpha).astype(np.uint8)
+    white = (total == 0)
+    r[white] = g[white] = b[white] = 255
+    a[white] = 0
+    return Image(np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape))


### PR DESCRIPTION
Colorize colors record aggregates by field, mixing colors in same bin together by an interpolation function.

Also added support for user specified callables for the `how` keyword to `colorize` and `interpolate`.