### PR TITLE
Don't subselect data before passing to `extend`

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -13,8 +13,8 @@ class Canvas(object):
                  x_range=None, y_range=None, stretch=False):
         self.plot_width = plot_width
         self.plot_height = plot_height
-        self.x_range = x_range
-        self.y_range = y_range
+        self.x_range = tuple(x_range) if x_range else x_range
+        self.y_range = tuple(y_range) if y_range else y_range
         self.stretch = stretch
 
     def points(self, source, x, y, **kwargs):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division
 
 from toolz import memoize
-import numpy as np
 
 from .utils import ngjit, isreal
 from .dispatch import dispatch
@@ -38,9 +37,8 @@ class Point(Glyph):
             for i in range(xs.shape[0]):
                 x = xs[i]
                 y = ys[i]
-                if (not (np.isnan(x) or np.isnan(y)) and
-                        (xmin <= x <= xmax) and (ymin <= y <= ymax)):
-                    append(i, int(xs[i] * sx + tx), int(ys[i] * sy + ty),
+                if (xmin <= x <= xmax) and (ymin <= y <= ymax):
+                    append(i, int(x * sx + tx), int(y * sy + ty),
                            *aggs_and_cols)
 
         def extend(aggs, df, vt, bounds):

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from .core import pipeline
 from .compiler import compile_components
-from .glyphs import subselect, compute_x_bounds, compute_y_bounds
+from .glyphs import compute_x_bounds, compute_y_bounds
 
 __all__ = ()
 
@@ -18,6 +18,5 @@ def pandas_pipeline(df, schema, canvas, glyph, summary):
     x_range = canvas.x_range or compute_x_bounds(glyph, df)
     y_range = canvas.y_range or compute_y_bounds(glyph, df)
     vt = canvas.view_transform(x_range, y_range)
-    df = subselect(glyph, df, canvas)
-    extend(aggs, df, vt)
+    extend(aggs, df, vt, x_range + y_range)
     return finalize(aggs)


### PR DESCRIPTION
This results in between 2-6x performance improvement, depending on aggregation used, due to the reductions in pandas overhead (we were suffering due to allocations and poor cache performance). Memory usage is also decreased due to no extraneous pandas allocations. This also slightly improves resilience, as we're explicitly doing bounds checks in the numba kernel, instead of trusting that everything was inbounds. Wins all around.

Profiling plots for 7.5 GB census dataset:
Before: https://gist.github.com/jcrist/0eef615229b6db31aa3d
After: https://gist.github.com/jcrist/11e925d5c429275bafa2