### PR TITLE
Aggregate redesign & general improvements

### DIFF
--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 __version__ = '0.0.1'
 
 from .core import Canvas
-from .aggregates import count, sum, min, max, mean, std, var, count_cat
+from .reductions import (count, sum, min, max, mean, std, var, count_cat,
+                         summary)
 
 # Needed to build the backend dispatch
 from .pandas import *

--- a/datashader/aggregates.py
+++ b/datashader/aggregates.py
@@ -1,9 +1,18 @@
 from __future__ import division, absolute_import, print_function
 
+import operator
+
+import numpy as np
 from datashape import dshape, Record, DataShape
+from dynd import nd
+from toolz import get
 
 from .core import Axis
-from .utils import dshape_from_dynd
+from .utils import (dshape_from_dynd, is_valid_identifier, is_option,
+                    dynd_missing_types, dynd_to_np_mask)
+
+
+__all__ = ['ScalarAggregate', 'CategoricalAggregate', 'RecordAggregate']
 
 
 class Aggregate(object):
@@ -16,6 +25,67 @@ def _validate_axis(axis):
     if not isinstance(axis, Axis):
         raise TypeError("axis must be instance of Axis")
     return axis
+
+
+def dynd_op(op, left, right):
+    if isinstance(left, nd.array):
+        left_np, left_missing = dynd_to_np_mask(left)
+        left_option = is_option(left.dtype)
+    else:
+        left_np, left_missing = left, False
+        left_option = False
+    if isinstance(right, nd.array):
+        right_np, right_missing = dynd_to_np_mask(right)
+        right_option = is_option(right.dtype)
+    else:
+        right_np, right_missing = right, False
+        right_option = False
+    out = op(left_np, right_np)
+    if left_option or right_option:
+        if out.dtype in dynd_missing_types:
+            out[left_missing | right_missing] = dynd_missing_types[out.dtype]
+            out = nd.asarray(out)
+            return nd.asarray(out).view_scalars('?' + str(out.dtype))
+        else:
+            raise ValueError("Missing type unknown")
+    return nd.asarray(out)
+
+
+def make_binary_op(op, use_dynd=True):
+    agg_op = op if use_dynd else lambda l, r: dynd_op(op, l, r)
+    def f(self, other):
+        if isinstance(other, ScalarAggregate):
+            if (self.x_axis != other.x_axis or self.y_axis != other.y_axis or
+                    self.shape != other.shape):
+                raise NotImplementedError("operations between aggregates with "
+                                          "non-matching axis or shape")
+            res = agg_op(self._data, other._data)
+        elif isinstance(other, (np.generic, int, float, bool)):
+            res = agg_op(self._data, other)
+        else:
+            return NotImplemented
+        return ScalarAggregate(res, self.x_axis, self.y_axis)
+    return f
+
+
+def make_unary_op(op):
+    def f(self):
+        arr, missing = dynd_to_np_mask(self._data)
+        out = op(arr)
+        if is_option(self._data.dtype):
+            out[missing] = dynd_missing_types[out.dtype]
+            out = nd.asarray(out).view_scalars('?' + str(out.dtype))
+        else:
+            out = nd.asarray(out)
+        return ScalarAggregate(out, self.x_axis, self.y_axis)
+    return f
+
+
+def right(method):
+    """Wrapper to create 'right' version of operator given left version"""
+    def _inner(self, other):
+        return method(other, self)
+    return _inner
 
 
 class ScalarAggregate(Aggregate):
@@ -36,13 +106,80 @@ class ScalarAggregate(Aggregate):
             self._shape = self._data.shape
         return self._shape
 
+    __add__ = make_binary_op(operator.add)
+    __sub__ = make_binary_op(operator.sub)
+    __mul__ = make_binary_op(operator.mul)
+    __floordiv__ = make_binary_op(operator.floordiv, False)
+    __div__ = __floordiv__
+    __truediv__ = make_binary_op(operator.truediv, False)
+    __eq__ = make_binary_op(operator.eq)
+    __ne__ = make_binary_op(operator.ne)
+    __lt__ = make_binary_op(operator.lt)
+    __le__ = make_binary_op(operator.le)
+    __gt__ = make_binary_op(operator.gt)
+    __ge__ = make_binary_op(operator.ge)
+    __and__ = make_binary_op(operator.and_, False)
+    __or__ = make_binary_op(operator.or_, False)
+    __xor__ = make_binary_op(operator.xor, False)
+    __radd__ = make_binary_op(right(operator.add))
+    __rsub__ = make_binary_op(right(operator.sub))
+    __rmul__ = make_binary_op(right(operator.mul))
+    __rfloordiv__ = make_binary_op(right(operator.floordiv), False)
+    __rdiv__ = __rfloordiv__
+    __rtruediv__ = make_binary_op(right(operator.truediv), False)
+    __req__ = make_binary_op(right(operator.eq))
+    __rne__ = make_binary_op(right(operator.ne))
+    __rlt__ = make_binary_op(right(operator.lt))
+    __rle__ = make_binary_op(right(operator.le))
+    __rgt__ = make_binary_op(right(operator.gt))
+    __rge__ = make_binary_op(right(operator.ge))
+    __rand__ = make_binary_op(right(operator.and_), False)
+    __ror__ = make_binary_op(right(operator.or_), False)
+    __rxor__ = make_binary_op(right(operator.xor), False)
+    __abs__ = make_unary_op(operator.abs)
+    __neg__ = make_unary_op(operator.neg)
+    __pos__ = make_unary_op(operator.pos)
+    __invert__ = make_unary_op(operator.inv)
 
-class ByCategoriesAggregate(Aggregate):
+
+class CategoricalAggregate(Aggregate):
     def __init__(self, data, cats, x_axis=None, y_axis=None):
         self._data = data
         self._cats = cats
         self.x_axis = _validate_axis(x_axis)
         self.y_axis = _validate_axis(y_axis)
+
+    def __dir__(self):
+        return sorted(set(dir(type(self)) + list(self.__dict__) +
+                      list(filter(is_valid_identifier, self._cats))))
+
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError("'CategoricalAggregate' object has no "
+                                 "attribute '{0}'".format(key))
+
+    def __getitem__(self, key):
+        try:
+            if isinstance(key, list):
+                # List of categories
+                inds = [self._cats.index(k) for k in key]
+                dtype = self._data.dtype
+                if is_option(dtype):
+                    out = nd.as_numpy(self._data.view_scalars(
+                                      dtype.value_type))
+                else:
+                    out = nd.as_numpy(self._data)
+                out = nd.asarray(out[:, :, inds]).view_scalars(dtype)
+                return CategoricalAggregate(out, key, self.x_axis, self.y_axis)
+            else:
+                # Single category
+                i = self._cats.index(key)
+                return ScalarAggregate(self._data[:, :, i],
+                                       self.x_axis, self.y_axis)
+        except ValueError:
+            raise KeyError("'{0}'".format(key))
 
     @property
     def dshape(self):
@@ -85,21 +222,27 @@ class RecordAggregate(Aggregate):
         return self._shape
 
     def keys(self):
-        return self._data.keys()
+        return list(sorted(self._data.keys()))
 
     def values(self):
-        return self._data.values()
+        return list(sorted(self._data.values()))
 
     def items(self):
-        return self._data.items()
+        return list(sorted(self._data.items()))
 
     def __dir__(self):
         return sorted(set(dir(type(self)) + list(self.__dict__) +
                       list(self.keys())))
 
+    def __getitem__(self, key):
+        if isinstance(key, list):
+            return RecordAggregate(dict(zip(key, get(key, self._data))),
+                                   self.x_axis, self.y_axis)
+        return self._data[key]
+
     def __getattr__(self, key):
-        if key in self._data:
-            return self._data[key]
-        else:
+        try:
+            return self[key]
+        except KeyError:
             raise AttributeError("'RecordAggregate' object has no attribute"
                                  "'{0}'".format(key))

--- a/datashader/aggregates.py
+++ b/datashader/aggregates.py
@@ -182,6 +182,10 @@ class CategoricalAggregate(Aggregate):
             raise KeyError("'{0}'".format(key))
 
     @property
+    def cats(self):
+        return self._cats
+
+    @property
     def dshape(self):
         if not hasattr(self, '_dshape'):
             self._dshape = DataShape(len(self._cats), 'int32')

--- a/datashader/aggregates.py
+++ b/datashader/aggregates.py
@@ -218,7 +218,7 @@ class RecordAggregate(Aggregate):
     def dshape(self):
         if not hasattr(self, '_dshape'):
             self._dshape = dshape(Record([(k, v.dshape) for (k, v) in
-                                          self._data.items()]))
+                                          sorted(self._data.items())]))
         return self._dshape
 
     @property

--- a/datashader/colors.py
+++ b/datashader/colors.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, division, print_function
+
+
 color_lookup = {'aliceblue': '#F0F8FF', 'antiquewhite': '#FAEBD7',
                 'aqua': '#00FFFF', 'aquamarine': '#7FFFD4',
                 'azure': '#F0FFFF', 'beige': '#F5F5DC',

--- a/datashader/compatibility.py
+++ b/datashader/compatibility.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    def apply(func, args, kwargs=None):
+        if kwargs:
+            return func(*args, **kwargs)
+        else:
+            return func(*args)
+else:
+    apply = apply

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -16,6 +16,9 @@ class Axis(object):
                 self.start == other.start and
                 self.end == other.end)
 
+    def __hash__(self):
+        return hash((type(self), self.start, self.end))
+
     def view_transform(self, d):
         start = self.mapper(self.start)
         end = self.mapper(self.end)

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -3,22 +3,46 @@ from __future__ import absolute_import, division, print_function
 from datashape.predicates import istabular
 from odo import discover
 
-from .aggregates import Summary
-from .glyphs import Point
-from .utils import Dispatcher, isreal
+from .utils import Dispatcher
+
+
+class Axis(object):
+    def __eq__(self, other):
+        return (type(self) == type(other) and
+                self.start == other.start and
+                self.end == other.end)
+
+
+class LinearAxis(Axis):
+    def __init__(self, range):
+        self.start, self.end = range
+
+
+class LogAxis(Axis):
+    def __init__(self, range):
+        self.start, self.end = range
+
+
+_axis_types = {'linear': LinearAxis,
+               'log': LogAxis}
 
 
 class Canvas(object):
     def __init__(self, plot_width=600, plot_height=600,
-                 x_range=None, y_range=None, stretch=False):
+                 x_range=None, y_range=None,
+                 x_axis_type='linear', y_axis_type='linear',
+                 stretch=False):
         self.plot_width = plot_width
         self.plot_height = plot_height
         self.x_range = tuple(x_range) if x_range else x_range
         self.y_range = tuple(y_range) if y_range else y_range
+        self.x_axis_type = _axis_types[x_axis_type]
+        self.y_axis_type = _axis_types[y_axis_type]
         self.stretch = stretch
 
-    def points(self, source, x, y, **kwargs):
-        return bypixel(source, self, Point(x, y), Summary(**kwargs))
+    def points(self, source, x, y, agg):
+        from .glyphs import Point
+        return bypixel(source, self, Point(x, y), agg)
 
     def view_transform(self, x_range=None, y_range=None):
         w = self.plot_width

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from datashape.predicates import istabular
 from odo import discover
 
-from .utils import Dispatcher
+from .utils import Dispatcher, ngjit
 
 
 class Axis(object):
@@ -17,46 +17,34 @@ class LinearAxis(Axis):
     def __init__(self, range):
         self.start, self.end = range
 
+    def view_transform(self, d):
+        s = (d - 1)/(self.end - self.start)
+        t = -self.start * s
+        return s, t
 
-class LogAxis(Axis):
-    def __init__(self, range):
-        self.start, self.end = range
+    @staticmethod
+    @ngjit
+    def mapper(x):
+        return x
 
 
-_axis_types = {'linear': LinearAxis,
-               'log': LogAxis}
+_axis_types = {'linear': LinearAxis}
 
 
 class Canvas(object):
     def __init__(self, plot_width=600, plot_height=600,
                  x_range=None, y_range=None,
-                 x_axis_type='linear', y_axis_type='linear',
-                 stretch=False):
+                 x_axis_type='linear', y_axis_type='linear'):
         self.plot_width = plot_width
         self.plot_height = plot_height
         self.x_range = tuple(x_range) if x_range else x_range
         self.y_range = tuple(y_range) if y_range else y_range
         self.x_axis_type = _axis_types[x_axis_type]
         self.y_axis_type = _axis_types[y_axis_type]
-        self.stretch = stretch
 
     def points(self, source, x, y, agg):
         from .glyphs import Point
         return bypixel(source, self, Point(x, y), agg)
-
-    def view_transform(self, x_range=None, y_range=None):
-        w = self.plot_width
-        h = self.plot_height
-        xmin, xmax = x_range or self.x_range
-        ymin, ymax = y_range or self.y_range
-        # Compute vt
-        sx = (w - 1)/(xmax - xmin)
-        sy = (h - 1)/(ymax - ymin)
-        if not self.stretch:
-            sx = sy = min(sx, sy)
-        tx = -xmin * sx
-        ty = -ymin * sy
-        return (sx, sy, tx, ty)
 
 
 pipeline = Dispatcher()

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -5,6 +5,7 @@ from dask.base import tokenize, compute
 from dask.context import _globals
 
 from .core import pipeline
+from .compatibility import apply
 from .compiler import compile_components
 from .glyphs import compute_x_bounds, compute_y_bounds
 

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -16,7 +16,7 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
     create, info, append, combine, finalize = compile_components(summary,
                                                                  schema)
     x_mapper = canvas.x_axis_type.mapper
-    y_mapper = canvas.x_axis_type.mapper
+    y_mapper = canvas.y_axis_type.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
     x_range = canvas.x_range or compute_x_bounds(glyph, df)

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -15,7 +15,9 @@ __all__ = ()
 def dask_pipeline(df, schema, canvas, glyph, summary):
     create, info, append, combine, finalize = compile_components(summary,
                                                                  schema)
-    extend = glyph._build_extend(info, append)
+    x_mapper = canvas.x_axis_type.mapper
+    y_mapper = canvas.x_axis_type.mapper
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
     x_range = canvas.x_range or compute_x_bounds(glyph, df)
     y_range = canvas.y_range or compute_y_bounds(glyph, df)
@@ -24,7 +26,9 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
     x_axis = canvas.x_axis_type(x_range)
     y_axis = canvas.y_axis_type(y_range)
 
-    vt = canvas.view_transform(x_range, y_range)
+    xvt = x_axis.view_transform(canvas.plot_width)
+    yvt = y_axis.view_transform(canvas.plot_height)
+    vt = xvt + yvt
     shape = (canvas.plot_height, canvas.plot_width)
 
     def chunk(df):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -26,19 +26,21 @@ class Point(Glyph):
         return self.x, self.y
 
     @memoize
-    def _build_extend(self, info, append):
+    def _build_extend(self, x_mapper, y_mapper, info, append):
         x_name = self.x
         y_name = self.y
 
         @ngjit
         def _extend(vt, bounds, xs, ys, *aggs_and_cols):
-            sx, sy, tx, ty = vt
+            sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds
             for i in range(xs.shape[0]):
                 x = xs[i]
                 y = ys[i]
                 if (xmin <= x <= xmax) and (ymin <= y <= ymax):
-                    append(i, int(x * sx + tx), int(y * sy + ty),
+                    append(i,
+                           int(x_mapper(x) * sx + tx),
+                           int(y_mapper(y) * sy + ty),
                            *aggs_and_cols)
 
         def extend(aggs, df, vt, bounds):

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -12,13 +12,19 @@ __all__ = ()
 @pipeline.register(pd.DataFrame)
 def pandas_pipeline(df, schema, canvas, glyph, summary):
     create, info, append, _, finalize = compile_components(summary, schema)
-    extend = glyph._build_extend(info, append)
+    x_mapper = canvas.x_axis_type.mapper
+    y_mapper = canvas.x_axis_type.mapper
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
-    bases = create((canvas.plot_height, canvas.plot_width))
     x_range = canvas.x_range or compute_x_bounds(glyph, df)
     y_range = canvas.y_range or compute_y_bounds(glyph, df)
-    vt = canvas.view_transform(x_range, y_range)
-    extend(bases, df, vt, x_range + y_range)
-    return finalize(bases,
-                    x_axis=canvas.x_axis_type(x_range),
-                    y_axis=canvas.y_axis_type(y_range))
+    x_axis = canvas.x_axis_type(x_range)
+    y_axis = canvas.y_axis_type(y_range)
+
+    xvt = x_axis.view_transform(canvas.plot_width)
+    yvt = y_axis.view_transform(canvas.plot_height)
+
+    bases = create((canvas.plot_height, canvas.plot_width))
+    extend(bases, df, xvt + yvt, x_range + y_range)
+
+    return finalize(bases, x_axis=x_axis, y_axis=y_axis)

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -13,7 +13,7 @@ __all__ = ()
 def pandas_pipeline(df, schema, canvas, glyph, summary):
     create, info, append, _, finalize = compile_components(summary, schema)
     x_mapper = canvas.x_axis_type.mapper
-    y_mapper = canvas.x_axis_type.mapper
+    y_mapper = canvas.y_axis_type.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
     x_range = canvas.x_range or compute_x_bounds(glyph, df)

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -14,9 +14,11 @@ def pandas_pipeline(df, schema, canvas, glyph, summary):
     create, info, append, _, finalize = compile_components(summary, schema)
     extend = glyph._build_extend(info, append)
 
-    aggs = create((canvas.plot_height, canvas.plot_width))
+    bases = create((canvas.plot_height, canvas.plot_width))
     x_range = canvas.x_range or compute_x_bounds(glyph, df)
     y_range = canvas.y_range or compute_y_bounds(glyph, df)
     vt = canvas.view_transform(x_range, y_range)
-    extend(aggs, df, vt, x_range + y_range)
-    return finalize(aggs)
+    extend(bases, df, vt, x_range + y_range)
+    return finalize(bases,
+                    x_axis=canvas.x_axis_type(x_range),
+                    y_axis=canvas.y_axis_type(y_range))

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -1,0 +1,412 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+from dynd import nd
+from datashape import dshape, isnumeric, Record, Option, DataShape, maxtype
+from datashape import coretypes as ct
+from toolz import concat, unique, memoize
+
+from .aggregates import ScalarAggregate, ByCategoriesAggregate
+from .utils import ngjit, is_missing
+
+
+# Dynd Missing Type Flags
+_dynd_missing_types = {np.dtype('i2'): np.iinfo('i2').min,
+                       np.dtype('i4'): np.iinfo('i4').min,
+                       np.dtype('i8'): np.iinfo('i8').min,
+                       np.dtype('f4'): np.nan,
+                       np.dtype('f8'): np.nan}
+
+
+def numpy_dtype(x):
+    if hasattr(x, 'ty'):
+        return numpy_dtype(x.ty)
+    return x.to_numpy_dtype()
+
+
+def optionify(d):
+    if isinstance(d, DataShape):
+        return DataShape(*(optionify(i) for i in d.parameters))
+    return d if isinstance(d, Option) else Option(d)
+
+
+class Expr(object):
+    def __init__(self, column):
+        self.column = column
+
+    def __hash__(self):
+        return hash((type(self), self.inputs))
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.inputs == other.inputs
+
+
+class Preprocess(Expr):
+    def __init__(self, column):
+        self.column = column
+
+    @property
+    def inputs(self):
+        return (self.column,)
+
+
+class extract(Preprocess):
+    def apply(self, df):
+        return df[self.column].values
+
+
+class category_codes(Preprocess):
+    def apply(self, df):
+        return df[self.column].cat.codes.values
+
+
+class Reduction(Expr):
+    def validate(self, in_dshape):
+        if not isnumeric(in_dshape.measure[self.column]):
+            raise ValueError("input must be numeric")
+
+    def out_dshape(self, in_dshape):
+        if hasattr(self, '_dshape'):
+            return self._dshape
+        return dshape(optionify(in_dshape.measure[self.column]))
+
+    @property
+    def inputs(self):
+        return (extract(self.column),)
+
+    @property
+    def _bases(self):
+        return (self,)
+
+    @property
+    def _temps(self):
+        return ()
+
+    @memoize
+    def _build_create(self, dshape):
+        dtype = numpy_dtype(dshape.measure)
+        value = _dynd_missing_types[dtype]
+        return lambda shape: np.full(shape, value, dtype=dtype)
+
+
+class count(Reduction):
+    _dshape = dshape(ct.int32)
+
+    def validate(self, in_dshape):
+        pass
+
+    @memoize
+    def _build_create(self, dshape):
+        return lambda shape: np.zeros(shape, dtype='i4')
+
+    def _build_append(self, dshape):
+        return append_count
+
+    def _build_combine(self, dshape):
+        return combine_count
+
+    def _build_finalize(self, dshape):
+        return build_finalize_identity(ct.int32)
+
+
+class sum(Reduction):
+    def out_dshape(self, input_dshape):
+        return dshape(optionify(maxtype(input_dshape.measure[self.column])))
+
+    def _build_append(self, dshape):
+        return append_sum
+
+    def _build_combine(self, dshape):
+        return combine_sum
+
+    def _build_finalize(self, dshape):
+        return build_finalize_identity(self.out_dshape(dshape))
+
+
+class min(Reduction):
+    @memoize
+    def _build_create(self, dshape):
+        dtype = numpy_dtype(dshape.measure)
+        if np.issubdtype(dtype, np.floating):
+            value = np.inf
+        else:
+            value = np.iinfo(dtype).max
+        return lambda shape: np.full(shape, value, dtype=dtype)
+
+    def _build_append(self, dshape):
+        return append_min
+
+    def _build_combine(self, dshape):
+        return combine_min
+
+    def _build_finalize(self, dshape):
+        return build_finalize_min(dshape.measure[self.column])
+
+
+class max(Reduction):
+    @memoize
+    def _build_create(self, dshape):
+        dtype = numpy_dtype(dshape.measure)
+        if np.issubdtype(dtype, np.floating):
+            value = -np.inf
+        else:
+            value = np.iinfo(dtype).min
+        return lambda shape: np.full(shape, value, dtype=dtype)
+
+    def _build_append(self, dshape):
+        return append_max
+
+    def _build_combine(self, dshape):
+        return combine_max
+
+    def _build_finalize(self, dshape):
+        return build_finalize_max(dshape.measure[self.column])
+
+
+class m2(Reduction):
+    """Second moment"""
+    _dshape = dshape(ct.float64)
+
+    @property
+    def _temps(self):
+        return (sum(self.column), count(self.column))
+
+    def _build_append(self, dshape):
+        return append_m2
+
+    def _build_combine(self, dshape):
+        return combine_m2
+
+    def _build_finalize(self, dshape):
+        return build_finalize_identity(ct.float64)
+
+
+class count_cat(Reduction):
+    def validate(self, in_dshape):
+        if not isinstance(in_dshape.measure[self.column], ct.Categorical):
+            raise ValueError("input must be categorical")
+
+    def out_dshape(self, input_dshape):
+        cats = input_dshape.measure[self.column].categories
+        return dshape(Record([(c, ct.int32) for c in cats]))
+
+    @property
+    def inputs(self):
+        return (category_codes(self.column),)
+
+    def _build_create(self, out_dshape):
+        n_cats = len(out_dshape.measure.fields)
+        return lambda shape: np.zeros(shape + (n_cats,), dtype='i4')
+
+    def _build_append(self, dshape):
+        return append_count_cat
+
+    def _build_combine(self, dshape):
+        return combine_count_cat
+
+    def _build_finalize(self, dshape):
+        cats = dshape[self.column].categories
+        def finalize(bases, **kwargs):
+            return ByCategoriesAggregate(nd.asarray(bases[0]), cats, **kwargs)
+        return finalize
+
+
+class mean(Reduction):
+    _dshape = dshape(Option(ct.float64))
+
+    @property
+    def _bases(self):
+        return (sum(self.column), count(self.column))
+
+    def _build_finalize(self, dshape):
+        return finalize_mean
+
+
+class var(Reduction):
+    _dshape = dshape(Option(ct.float64))
+
+    @property
+    def _bases(self):
+        return (sum(self.column), count(self.column), m2(self.column))
+
+    def _build_finalize(self, dshape):
+        return finalize_var
+
+
+class std(Reduction):
+    _dshape = dshape(Option(ct.float64))
+
+    @property
+    def _bases(self):
+        return (sum(self.column), count(self.column), m2(self.column))
+
+    def _build_finalize(self, dshape):
+        return finalize_std
+
+
+class summary(Expr):
+    def __init__(self, **kwargs):
+        ks, vs = zip(*sorted(kwargs.items()))
+        self.keys = ks
+        self.values = vs
+
+    def __hash__(self):
+        return hash((type(self), tuple(self.keys), tuple(self.values)))
+
+    def validate(self, input_dshape):
+        for v in self.values:
+            v.validate(input_dshape)
+
+    def out_dshape(self, in_dshape):
+        return dshape(Record([(k, v.out_dshape(in_dshape)) for (k, v)
+                              in zip(self.keys, self.values)]))
+
+    @property
+    def inputs(self):
+        return tuple(unique(concat(v.inputs for v in self.values)))
+
+
+# ============ Appenders ============
+
+@ngjit
+def append_count(x, y, agg, field):
+    agg[y, x] += 1
+
+
+@ngjit
+def append_max(x, y, agg, field):
+    if agg[y, x] < field:
+        agg[y, x] = field
+
+
+@ngjit
+def append_min(x, y, agg, field):
+    if agg[y, x] > field:
+        agg[y, x] = field
+
+
+@ngjit
+def append_m2(x, y, m2, field, sum, count):
+    # sum & count are the results of sum[y, x], count[y, x] before being
+    # updated by field
+    if count == 0:
+        m2[y, x] = 0
+    else:
+        u1 = np.float64(sum) / count
+        u = np.float64(sum + field) / (count + 1)
+        m2[y, x] += (field - u1) * (field - u)
+
+
+@ngjit
+def append_sum(x, y, agg, field):
+    if is_missing(agg[y, x]):
+        agg[y, x] = field
+    else:
+        agg[y, x] += field
+
+
+@ngjit
+def append_count_cat(x, y, agg, field):
+    agg[y, x, field] += 1
+
+
+# ============ Combiners ============
+
+def combine_count(aggs):
+    return aggs.sum(axis=0, dtype='i4')
+
+
+def combine_sum(aggs):
+    missing_val = _dynd_missing_types[aggs.dtype]
+    missing_vals = is_missing(aggs)
+    all_empty = np.bitwise_and.reduce(missing_vals, axis=0)
+    set_to_zero = missing_vals & ~all_empty
+    out = np.where(set_to_zero, 0, aggs).sum(axis=0)
+    if missing_val is not np.nan:
+        out[all_empty] = missing_val
+    return out
+
+
+def combine_min(aggs):
+    return np.nanmin(aggs, axis=0)
+
+
+def combine_max(aggs):
+    return np.nanmax(aggs, axis=0)
+
+
+def combine_m2(Ms, sums, ns):
+    sums = as_float64(sums)
+    mu = np.nansum(sums, axis=0) / ns.sum(axis=0)
+    return np.nansum(Ms + ns*(sums/ns - mu)**2, axis=0)
+
+
+def combine_count_cat(aggs):
+    return aggs.sum(axis=0, dtype='i4')
+
+
+# ============ Finalizers ============
+
+def build_finalize_identity(dshape):
+    dshape = str(dshape)
+    def finalize(bases, **kwargs):
+        return ScalarAggregate(nd.asarray(bases[0]).view_scalars(dshape),
+                               **kwargs)
+    return finalize
+
+
+@memoize
+def build_finalize_min(dshape):
+    dtype = numpy_dtype(dshape.measure)
+    missing = _dynd_missing_types[dtype]
+    if np.issubdtype(dtype, np.floating):
+        is_missing = np.isposinf
+    else:
+        value = np.iinfo(dtype).max
+        is_missing = lambda x: x == value
+    dshape = str(dshape)
+    def finalize(bases, **kwargs):
+        x = np.where(is_missing(bases[0]), missing, bases[0])
+        return ScalarAggregate(nd.asarray(x).view_scalars(dshape), **kwargs)
+    return finalize
+
+
+@memoize
+def build_finalize_max(dshape):
+    dtype = numpy_dtype(dshape.measure)
+    missing = _dynd_missing_types[dtype]
+    if np.issubdtype(dtype, np.floating):
+        is_missing = np.isneginf
+    else:
+        value = np.iinfo(dtype).max
+        is_missing = lambda x: x == value
+    dshape = str(dshape)
+    def finalize(bases, **kwargs):
+        x = np.where(is_missing(bases[0]), missing, bases[0])
+        return ScalarAggregate(nd.asarray(x).view_scalars(dshape), **kwargs)
+    return finalize
+
+
+def as_float64(arr):
+    return np.where(is_missing(arr), np.nan, arr.astype('f8'))
+
+
+def finalize_mean(bases, **kwargs):
+    sums, counts = bases
+    with np.errstate(divide='ignore', invalid='ignore'):
+        x = as_float64(sums)/counts
+    return ScalarAggregate(nd.asarray(x).view_scalars('?float64'), **kwargs)
+
+
+def finalize_var(bases, **kwargs):
+    sums, counts, m2s = bases
+    with np.errstate(divide='ignore', invalid='ignore'):
+        x = as_float64(m2s)/counts
+    return ScalarAggregate(nd.asarray(x).view_scalars('?float64'), **kwargs)
+
+
+def finalize_std(bases, **kwargs):
+    sums, counts, m2s = bases
+    with np.errstate(divide='ignore', invalid='ignore'):
+        x = np.sqrt(as_float64(m2s)/counts)
+    return ScalarAggregate(nd.asarray(x).view_scalars('?float64'), **kwargs)

--- a/datashader/tests/test_aggregates.py
+++ b/datashader/tests/test_aggregates.py
@@ -1,0 +1,155 @@
+from __future__ import division
+import operator as op
+
+from datashape import dshape
+from dynd import nd
+import numpy as np
+
+from datashader.aggregates import (ScalarAggregate, CategoricalAggregate,
+                                   RecordAggregate)
+from datashader.core import LinearAxis, LogAxis
+
+import pytest
+
+
+x_axis = LinearAxis((0, 10))
+y_axis = LinearAxis((1, 5))
+
+a = nd.array([[0, 1, 2], [3, 4, None]], '2 * 3 * ?int64')
+b = nd.array([[2, 2, None], [0, 3, 3]], '2 * 3 * ?float64')
+c = nd.array([True, False, True])
+d = nd.array([True, True, False])
+s_a = ScalarAggregate(a, x_axis=x_axis, y_axis=y_axis)
+s_b = ScalarAggregate(b, x_axis=x_axis, y_axis=y_axis)
+s_c = ScalarAggregate(c, x_axis=x_axis, y_axis=y_axis)
+s_d = ScalarAggregate(d, x_axis=x_axis, y_axis=y_axis)
+
+
+def assert_dynd_eq(a, b, check_dtype=True):
+    if check_dtype:
+        assert a.dtype == b.dtype
+    assert np.all((a == b).view_scalars('bool'))
+
+
+def test_scalar_agg():
+    assert s_a.dshape == dshape('?int64')
+    assert s_b.dshape == dshape('?float64')
+    assert s_a.shape == s_b.shape == (2, 3)
+
+
+@pytest.mark.parametrize('op', [op.add, op.sub, op.mul, op.eq, op.ne,
+                                op.lt, op.le, op.gt, op.ge])
+def test_scalar_agg_binops(op):
+    assert_dynd_eq(op(s_a, s_b)._data, op(a, b))
+    assert_dynd_eq(op(s_a, 2)._data, op(a, 2))
+    assert_dynd_eq(op(s_b, 2)._data, op(b, 2))
+    assert_dynd_eq(op(s_a, 2.)._data, op(a, 2.))
+    assert_dynd_eq(op(s_b, 2.)._data, op(b, 2.))
+    assert_dynd_eq(op(2, s_a)._data, op(2, a))
+    assert_dynd_eq(op(2, s_b)._data, op(2, b))
+    assert_dynd_eq(op(2., s_a)._data, op(2., a))
+    assert_dynd_eq(op(2., s_b)._data, op(2., b))
+
+
+def test_binop_consistent_axis():
+    # If/when non_aligned axis become supported, these can be removed
+    with pytest.raises(NotImplementedError):
+        s_a + ScalarAggregate(a, x_axis=x_axis, y_axis=LinearAxis((2, 5)))
+    with pytest.raises(NotImplementedError):
+        s_a + ScalarAggregate(a, x_axis=x_axis, y_axis=LogAxis((1, 5)))
+
+
+def test_scalar_agg_truediv():
+    assert_dynd_eq((s_a/s_b)._data, a/b)
+    assert_dynd_eq((s_a/2)._data, a/2.)
+    assert_dynd_eq((s_b/2)._data, b/2)
+    assert_dynd_eq((s_a/2.)._data, a/2.)
+    assert_dynd_eq((s_b/2.)._data, b/2.)
+    assert_dynd_eq((2/s_a)._data, 2./a)
+    assert_dynd_eq((2/s_b)._data, 2/b)
+    assert_dynd_eq((2./s_a)._data, 2./a)
+    assert_dynd_eq((2./s_b)._data, 2./b)
+
+
+def test_scalar_agg_floordiv():
+    def floordiv(a, b, out_type):
+        o = np.floor((a/b).view_scalars('float64'))
+        return nd.array(o, '2 * 3 * ' + out_type)
+    assert_dynd_eq((s_a//s_b)._data, floordiv(a, b, '?float64'))
+    assert_dynd_eq((s_a//2)._data, floordiv(a, 2., '?int64'))
+    assert_dynd_eq((s_b//2)._data, floordiv(b, 2, '?float64'))
+    assert_dynd_eq((s_a//2.)._data, floordiv(a, 2., '?float64'))
+    assert_dynd_eq((s_b//2.)._data, floordiv(b, 2., '?float64'))
+    assert_dynd_eq((2//s_a)._data, nd.array([[0, 2, 1], [0, 0, None]],
+                                            '2 * 3 * ?int64'))
+    assert_dynd_eq((2//s_b)._data, floordiv(2, b, '?float64'))
+    assert_dynd_eq((2.//s_a)._data, nd.array([[nd.inf, 2, 1], [0, 0, None]]))
+    assert_dynd_eq((2.//s_b)._data, floordiv(2., b, '?float64'))
+
+
+@pytest.mark.parametrize('op', [op.and_, op.or_, op.xor])
+def test_scalar_agg_bool(op):
+    np_c = nd.as_numpy(c)
+    np_d = nd.as_numpy(d)
+    assert_dynd_eq(op(s_c, s_d)._data, op(np_c, np_d), False)
+    assert_dynd_eq(op(s_c, True)._data, op(np_c, True), False)
+    assert_dynd_eq(op(s_d, True)._data, op(np_d, True), False)
+    assert_dynd_eq(op(s_c, True)._data, op(np_c, True), False)
+    assert_dynd_eq(op(s_d, True)._data, op(np_d, True), False)
+    assert_dynd_eq(op(True, s_c)._data, op(True, np_c), False)
+    assert_dynd_eq(op(True, s_d)._data, op(True, np_d), False)
+    assert_dynd_eq(op(True, s_c)._data, op(True, np_c), False)
+    assert_dynd_eq(op(True, s_d)._data, op(True, np_d), False)
+
+
+def test_scalar_agg_unops():
+    assert_dynd_eq((+s_a)._data, a)
+    assert_dynd_eq((+s_b)._data, b)
+    assert_dynd_eq((-s_a)._data, -1 * a)
+    assert_dynd_eq((-s_b)._data, -1 * b)
+    # Hack around dynd's limited supported ops
+    assert_dynd_eq((~s_a)._data, -1*a - 1)
+    assert_dynd_eq(abs(s_a)._data, a)
+    assert_dynd_eq(abs(s_b)._data, b)
+
+
+def test_categorical_agg():
+    data = np.array([[(0, 12, 0), (3, 0, 3)],
+                     [(12, 12, 12), (24, 0, 0)]], dtype='i4')
+    cats = ['a', 'b', 'c']
+    agg = CategoricalAggregate(nd.asarray(data), cats, x_axis, y_axis)
+    assert agg.shape == (2, 2)
+    assert agg.dshape == dshape('3 * int32')
+    assert all(hasattr(agg, c) for c in cats)
+    assert isinstance(agg['a'], ScalarAggregate)
+    assert_dynd_eq(agg['a']._data, np.array([[0, 3], [12, 24]]), False)
+    assert_dynd_eq(agg[['a', 'c']]._data, data[:, :, [0, 2]], False)
+    with pytest.raises(KeyError):
+        agg['d']
+    with pytest.raises(KeyError):
+        agg[['a', 'd']]
+    with pytest.raises(AttributeError):
+        agg.d
+
+
+def test_record_agg():
+    e = nd.array([[1, 2, 1.5], [3, 4, 5]], '2 * 3 * float64')
+    s_e = ScalarAggregate(e, x_axis=x_axis, y_axis=y_axis)
+    agg = RecordAggregate(dict(a=s_a, b=s_b, e=s_e), x_axis, y_axis)
+    assert agg.shape == (2, 3)
+    assert agg.dshape == dshape('{a: ?int64, b: ?float64, e: float64}')
+    assert agg.keys() == ['a', 'b', 'e']
+    assert all(hasattr(agg, c) for c in 'abe')
+    assert isinstance(agg['a'], ScalarAggregate)
+    sub = agg[['a', 'e']]
+    assert isinstance(sub, RecordAggregate)
+    assert hasattr(sub, 'a') and hasattr(sub, 'e')
+    with pytest.raises(KeyError):
+        agg['c']
+    with pytest.raises(AttributeError):
+        agg.c
+    with pytest.raises(ValueError):
+        agg = RecordAggregate(dict(a=s_a, b=s_b, c=s_c), x_axis, y_axis)
+    temp = ScalarAggregate(e, x_axis=x_axis, y_axis=LogAxis((1, 5)))
+    with pytest.raises(ValueError):
+        agg = RecordAggregate(dict(a=s_a, b=s_b, temp=temp), x_axis, y_axis)

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -4,10 +4,10 @@ from dynd import nd
 import dask.dataframe as dd
 from dask.context import set_options
 from dask.async import get_sync
-set_options(get=get_sync)
 
 import datashader as ds
 
+set_options(get=get_sync)
 
 df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                    'y': np.array(([0.] * 5 + [1] * 5 + [0] * 5 + [1] * 5)),
@@ -24,6 +24,7 @@ c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
 
 
 def eq(agg, b):
+    agg = agg._data
     a = nd.as_numpy(agg.view_scalars(getattr(agg.dtype, 'value_type', agg.dtype)))
     assert np.allclose(a, b)
     assert a.dtype == b.dtype
@@ -31,74 +32,77 @@ def eq(agg, b):
 
 def test_count():
     out = np.array([[5, 5], [5, 5]], dtype='i4')
-    eq(c.points(ddf, 'x', 'y', agg=ds.count('i32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.count('i64')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.count('f32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.count('i64')).agg, out)
+    eq(c.points(ddf, 'x', 'y', ds.count('i32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.count('i64')), out)
+    eq(c.points(ddf, 'x', 'y', ds.count('f32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.count('i64')), out)
 
 
 def test_sum():
     out = df.i32.reshape((2, 2, 5)).sum(axis=2, dtype='i8').T
-    eq(c.points(ddf, 'x', 'y', agg=ds.sum('i32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.sum('i64')).agg, out)
+    eq(c.points(ddf, 'x', 'y', ds.sum('i32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.sum('i64')), out)
     out = out.astype('f8')
-    eq(c.points(ddf, 'x', 'y', agg=ds.sum('f32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.sum('f64')).agg, out)
+    eq(c.points(ddf, 'x', 'y', ds.sum('f32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.sum('f64')), out)
 
 
 def test_min():
     out = df.i32.reshape((2, 2, 5)).min(axis=2).T
-    eq(c.points(ddf, 'x', 'y', agg=ds.min('i32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.min('i64')).agg, out.astype('i8'))
-    eq(c.points(ddf, 'x', 'y', agg=ds.min('f32')).agg, out.astype('f4'))
-    eq(c.points(ddf, 'x', 'y', agg=ds.min('f64')).agg, out.astype('f8'))
+    eq(c.points(ddf, 'x', 'y', ds.min('i32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.min('i64')), out.astype('i8'))
+    eq(c.points(ddf, 'x', 'y', ds.min('f32')), out.astype('f4'))
+    eq(c.points(ddf, 'x', 'y', ds.min('f64')), out.astype('f8'))
 
 
 def test_max():
     out = df.i32.reshape((2, 2, 5)).max(axis=2).T
-    eq(c.points(ddf, 'x', 'y', agg=ds.max('i32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.max('i64')).agg, out.astype('i8'))
-    eq(c.points(ddf, 'x', 'y', agg=ds.max('f32')).agg, out.astype('f4'))
-    eq(c.points(ddf, 'x', 'y', agg=ds.max('f64')).agg, out.astype('f8'))
+    eq(c.points(ddf, 'x', 'y', ds.max('i32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.max('i64')), out.astype('i8'))
+    eq(c.points(ddf, 'x', 'y', ds.max('f32')), out.astype('f4'))
+    eq(c.points(ddf, 'x', 'y', ds.max('f64')), out.astype('f8'))
 
 
 def test_mean():
     out = df.i32.reshape((2, 2, 5)).mean(axis=2).T
-    eq(c.points(ddf, 'x', 'y', agg=ds.mean('i32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.mean('i64')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.mean('f32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.mean('f64')).agg, out)
+    eq(c.points(ddf, 'x', 'y', ds.mean('i32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.mean('i64')), out)
+    eq(c.points(ddf, 'x', 'y', ds.mean('f32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.mean('f64')), out)
 
 
 def test_var():
     out = df.i32.reshape((2, 2, 5)).var(axis=2).T
-    eq(c.points(ddf, 'x', 'y', agg=ds.var('i32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.var('i64')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.var('f32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.var('f64')).agg, out)
+    eq(c.points(ddf, 'x', 'y', ds.var('i32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.var('i64')), out)
+    eq(c.points(ddf, 'x', 'y', ds.var('f32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.var('f64')), out)
 
 
 def test_std():
     out = df.i32.reshape((2, 2, 5)).std(axis=2).T
-    eq(c.points(ddf, 'x', 'y', agg=ds.std('i32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.std('i64')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.std('f32')).agg, out)
-    eq(c.points(ddf, 'x', 'y', agg=ds.std('f64')).agg, out)
+    eq(c.points(ddf, 'x', 'y', ds.std('i32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.std('i64')), out)
+    eq(c.points(ddf, 'x', 'y', ds.std('f32')), out)
+    eq(c.points(ddf, 'x', 'y', ds.std('f64')), out)
 
 
 def test_count_cat():
-    agg = c.points(df, 'x', 'y', agg=ds.count_cat('cat')).agg
-    assert (nd.as_numpy(agg.a) == np.array([[5, 0], [0, 0]])).all()
-    assert (nd.as_numpy(agg.b) == np.array([[0, 0], [5, 0]])).all()
-    assert (nd.as_numpy(agg.c) == np.array([[0, 5], [0, 0]])).all()
-    assert (nd.as_numpy(agg.d) == np.array([[0, 0], [0, 5]])).all()
+    agg = c.points(df, 'x', 'y', ds.count_cat('cat'))
+    sol = np.array([[[5, 0, 0, 0],
+                     [0, 0, 5, 0]],
+                    [[0, 5, 0, 0],
+                     [0, 0, 0, 5]]])
+    assert (nd.as_numpy(agg._data) == sol).all()
+    assert agg._cats == ('a', 'b', 'c', 'd')
 
 
 def test_multiple_aggregates():
     agg = c.points(ddf, 'x', 'y',
-                   f64=dict(std=ds.std('f64'), mean=ds.mean('f64')),
-                   i32_sum=ds.sum('i32'),
-                   i32_count=ds.count('i32'))
+                   ds.summary(f64=ds.summary(std=ds.std('f64'),
+                                             mean=ds.mean('f64')),
+                              i32_sum=ds.sum('i32'),
+                              i32_count=ds.count('i32')))
 
     eq(agg.f64.std, df.f64.reshape((2, 2, 5)).std(axis=2).T)
     eq(agg.f64.mean, df.f64.reshape((2, 2, 5)).mean(axis=2).T)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -18,6 +18,7 @@ c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
 
 
 def eq(agg, b):
+    agg = agg._data
     a = nd.as_numpy(agg.view_scalars(getattr(agg.dtype, 'value_type', agg.dtype)))
     assert np.allclose(a, b)
     assert a.dtype == b.dtype
@@ -25,74 +26,77 @@ def eq(agg, b):
 
 def test_count():
     out = np.array([[5, 5], [5, 5]], dtype='i4')
-    eq(c.points(df, 'x', 'y', agg=ds.count('i32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.count('i64')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.count('f32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.count('i64')).agg, out)
+    eq(c.points(df, 'x', 'y', ds.count('i32')), out)
+    eq(c.points(df, 'x', 'y', ds.count('i64')), out)
+    eq(c.points(df, 'x', 'y', ds.count('f32')), out)
+    eq(c.points(df, 'x', 'y', ds.count('i64')), out)
 
 
 def test_sum():
     out = df.i32.reshape((2, 2, 5)).sum(axis=2, dtype='i8').T
-    eq(c.points(df, 'x', 'y', agg=ds.sum('i32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.sum('i64')).agg, out)
+    eq(c.points(df, 'x', 'y', ds.sum('i32')), out)
+    eq(c.points(df, 'x', 'y', ds.sum('i64')), out)
     out = out.astype('f8')
-    eq(c.points(df, 'x', 'y', agg=ds.sum('f32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.sum('f64')).agg, out)
+    eq(c.points(df, 'x', 'y', ds.sum('f32')), out)
+    eq(c.points(df, 'x', 'y', ds.sum('f64')), out)
 
 
 def test_min():
     out = df.i32.reshape((2, 2, 5)).min(axis=2).T
-    eq(c.points(df, 'x', 'y', agg=ds.min('i32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.min('i64')).agg, out.astype('i8'))
-    eq(c.points(df, 'x', 'y', agg=ds.min('f32')).agg, out.astype('f4'))
-    eq(c.points(df, 'x', 'y', agg=ds.min('f64')).agg, out.astype('f8'))
+    eq(c.points(df, 'x', 'y', ds.min('i32')), out)
+    eq(c.points(df, 'x', 'y', ds.min('i64')), out.astype('i8'))
+    eq(c.points(df, 'x', 'y', ds.min('f32')), out.astype('f4'))
+    eq(c.points(df, 'x', 'y', ds.min('f64')), out.astype('f8'))
 
 
 def test_max():
     out = df.i32.reshape((2, 2, 5)).max(axis=2).T
-    eq(c.points(df, 'x', 'y', agg=ds.max('i32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.max('i64')).agg, out.astype('i8'))
-    eq(c.points(df, 'x', 'y', agg=ds.max('f32')).agg, out.astype('f4'))
-    eq(c.points(df, 'x', 'y', agg=ds.max('f64')).agg, out.astype('f8'))
+    eq(c.points(df, 'x', 'y', ds.max('i32')), out)
+    eq(c.points(df, 'x', 'y', ds.max('i64')), out.astype('i8'))
+    eq(c.points(df, 'x', 'y', ds.max('f32')), out.astype('f4'))
+    eq(c.points(df, 'x', 'y', ds.max('f64')), out.astype('f8'))
 
 
 def test_mean():
     out = df.i32.reshape((2, 2, 5)).mean(axis=2).T
-    eq(c.points(df, 'x', 'y', agg=ds.mean('i32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.mean('i64')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.mean('f32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.mean('f64')).agg, out)
+    eq(c.points(df, 'x', 'y', ds.mean('i32')), out)
+    eq(c.points(df, 'x', 'y', ds.mean('i64')), out)
+    eq(c.points(df, 'x', 'y', ds.mean('f32')), out)
+    eq(c.points(df, 'x', 'y', ds.mean('f64')), out)
 
 
 def test_var():
     out = df.i32.reshape((2, 2, 5)).var(axis=2).T
-    eq(c.points(df, 'x', 'y', agg=ds.var('i32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.var('i64')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.var('f32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.var('f64')).agg, out)
+    eq(c.points(df, 'x', 'y', ds.var('i32')), out)
+    eq(c.points(df, 'x', 'y', ds.var('i64')), out)
+    eq(c.points(df, 'x', 'y', ds.var('f32')), out)
+    eq(c.points(df, 'x', 'y', ds.var('f64')), out)
 
 
 def test_std():
     out = df.i32.reshape((2, 2, 5)).std(axis=2).T
-    eq(c.points(df, 'x', 'y', agg=ds.std('i32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.std('i64')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.std('f32')).agg, out)
-    eq(c.points(df, 'x', 'y', agg=ds.std('f64')).agg, out)
+    eq(c.points(df, 'x', 'y', ds.std('i32')), out)
+    eq(c.points(df, 'x', 'y', ds.std('i64')), out)
+    eq(c.points(df, 'x', 'y', ds.std('f32')), out)
+    eq(c.points(df, 'x', 'y', ds.std('f64')), out)
 
 
 def test_count_cat():
-    agg = c.points(df, 'x', 'y', agg=ds.count_cat('cat')).agg
-    assert (nd.as_numpy(agg.a) == np.array([[5, 0], [0, 0]])).all()
-    assert (nd.as_numpy(agg.b) == np.array([[0, 0], [5, 0]])).all()
-    assert (nd.as_numpy(agg.c) == np.array([[0, 5], [0, 0]])).all()
-    assert (nd.as_numpy(agg.d) == np.array([[0, 0], [0, 5]])).all()
+    agg = c.points(df, 'x', 'y', ds.count_cat('cat'))
+    sol = np.array([[[5, 0, 0, 0],
+                     [0, 0, 5, 0]],
+                    [[0, 5, 0, 0],
+                     [0, 0, 0, 5]]])
+    assert (nd.as_numpy(agg._data) == sol).all()
+    assert agg._cats == ('a', 'b', 'c', 'd')
 
 
 def test_multiple_aggregates():
     agg = c.points(df, 'x', 'y',
-                   f64=dict(std=ds.std('f64'), mean=ds.mean('f64')),
-                   i32_sum=ds.sum('i32'),
-                   i32_count=ds.count('i32'))
+                   ds.summary(f64=ds.summary(std=ds.std('f64'),
+                                             mean=ds.mean('f64')),
+                              i32_sum=ds.sum('i32'),
+                              i32_count=ds.count('i32')))
 
     eq(agg.f64.std, df.f64.reshape((2, 2, 5)).std(axis=2).T)
     eq(agg.f64.mean, df.f64.reshape((2, 2, 5)).mean(axis=2).T)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -7,6 +7,8 @@ import datashader as ds
 
 df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                    'y': np.array(([0.] * 5 + [1] * 5 + [0] * 5 + [1] * 5)),
+                   'log_x': np.array(([1.] * 10 + [10] * 10)),
+                   'log_y': np.array(([1.] * 5 + [10] * 5 + [1] * 5 + [10] * 5)),
                    'i32': np.arange(20, dtype='i4'),
                    'i64': np.arange(20, dtype='i8'),
                    'f32': np.arange(20, dtype='f4'),
@@ -15,6 +17,12 @@ df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
 df.cat = df.cat.astype('category')
 
 c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
+c_logx = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 10),
+                   y_range=(0, 1), x_axis_type='log')
+c_logy = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1),
+                   y_range=(1, 10), y_axis_type='log')
+c_logxy = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 10),
+                    y_range=(1, 10), x_axis_type='log', y_axis_type='log')
 
 
 def eq(agg, b):
@@ -102,3 +110,10 @@ def test_multiple_aggregates():
     eq(agg.f64.mean, df.f64.reshape((2, 2, 5)).mean(axis=2).T)
     eq(agg.i32_sum, df.i32.reshape((2, 2, 5)).sum(axis=2).T)
     eq(agg.i32_count, np.array([[5, 5], [5, 5]], dtype='i4'))
+
+
+def test_log_axis():
+    out = np.array([[5, 5], [5, 5]], dtype='i4')
+    eq(c_logx.points(df, 'log_x', 'y', ds.count('i32')), out)
+    eq(c_logy.points(df, 'x', 'log_y', ds.count('i32')), out)
+    eq(c_logxy.points(df, 'log_x', 'log_y', ds.count('i32')), out)

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -5,20 +5,27 @@ import numpy as np
 import PIL
 import pytest
 
+from datashader.aggregates import (ScalarAggregate, CategoricalAggregate,
+                                   RecordAggregate)
+from datashader.core import LinearAxis
 import datashader.transfer_functions as tf
 
 
+x_axis = LinearAxis((0, 10))
+y_axis = LinearAxis((1, 5))
+
 a = np.arange(10, 19, dtype='i4').reshape((3, 3))
 a[[0, 1, 2], [0, 1, 2]] = 0
+s_a = ScalarAggregate(nd.asarray(a), x_axis=x_axis, y_axis=y_axis)
 b = np.arange(10, 19, dtype='f8').reshape((3, 3))
 b[[0, 1, 2], [0, 1, 2]] = np.nan
+s_b = ScalarAggregate(nd.array(b, '3 * 3 * ?float64'),
+                      x_axis=x_axis, y_axis=y_axis)
 c = np.arange(10, 19, dtype='i8').reshape((3, 3))
 c[[0, 1, 2], [0, 1, 2]] = np.iinfo('i8').min
-
-agg = nd.empty((3, 3), '{a: int32, b: ?float64, c: ?int64}')
-agg.a = a
-agg.b = b
-nd.as_numpy(agg.c.view_scalars(agg.c.dtype.value_type))[:] = c
+s_c = ScalarAggregate(nd.asarray(c).view_scalars('?int64'),
+                      x_axis=x_axis, y_axis=y_axis)
+agg = RecordAggregate(dict(a=s_a, b=s_b, c=s_c), x_axis, y_axis)
 
 
 @pytest.mark.parametrize(['attr'], ['a', 'b', 'c'])
@@ -46,26 +53,28 @@ def test_interpolate(attr):
     assert (img == sol).all()
 
 
+cat_agg = CategoricalAggregate(nd.array([[(0, 12, 0), (3, 0, 3)],
+                                         [(12, 12, 12), (24, 0, 0)]]),
+                               ['a', 'b', 'c'], x_axis, y_axis)
+
+
 def test_colorize():
     colors = [(255, 0, 0), '#0000FF', 'orange']
-    agg = np.array([[(0, 12, 0), (3, 0, 3)],
-                    [(12, 12, 12), (24, 0, 0)]],
-                   dtype=[(i, 'uint8') for i in 'abc'])
-    agg = nd.asarray(agg)
-    img = tf.colorize(agg, colors, how='log').img
+
+    img = tf.colorize(cat_agg, colors, how='log').img
     sol = np.array([[3137273856, 2449494783],
                     [4266997674, 3841982719]])
     assert (img == sol).all()
     colors = dict(zip('abc', colors))
-    img = tf.colorize(agg, colors, how='cbrt').img
+    img = tf.colorize(cat_agg, colors, how='cbrt').img
     sol = np.array([[3070164992, 2499826431],
                     [4283774890, 3774873855]])
     assert (img == sol).all()
-    img = tf.colorize(agg, colors, how='linear').img
+    img = tf.colorize(cat_agg, colors, how='linear').img
     sol = np.array([[1660878848, 989876991],
                     [4283774890, 2952790271]])
     assert (img == sol).all()
-    img = tf.colorize(agg, colors, how=lambda x: x ** 2).img
+    img = tf.colorize(cat_agg, colors, how=lambda x: x ** 2).img
     sol = np.array([[788463616, 436228863],
                     [4283774890, 2080375039]])
     assert (img == sol).all()
@@ -75,17 +84,18 @@ img1 = tf.Image(np.dstack([np.array([[255, 0], [0, 125]], 'uint8'),
                            np.array([[255, 0], [0, 255]], 'uint8'),
                            np.array([[0, 0], [0, 0]], 'uint8'),
                            np.array([[255, 0], [0, 255]], 'uint8')])
-                .view(np.uint32).reshape((2, 2)))
+                .view(np.uint32).reshape((2, 2)), x_axis, y_axis)
 
 img2 = tf.Image(np.dstack([np.array([[0, 0], [0, 255]], 'uint8'),
                            np.array([[0, 0], [0, 125]], 'uint8'),
                            np.array([[0, 0], [0, 125]], 'uint8'),
                            np.array([[0, 0], [255, 125]], 'uint8')])
-                .view(np.uint32).reshape((2, 2)))
+                .view(np.uint32).reshape((2, 2)), x_axis, y_axis)
 
 
 def test_stack():
     img = tf.stack(img1, img2)
+    assert img.x_axis == img1.x_axis and img.y_axis == img1.y_axis
     chan = img.img.view([('r', 'uint8'), ('g', 'uint8'),
                          ('b', 'uint8'), ('a', 'uint8')])
     assert (chan['r'] == np.array([[255, 0], [0, 255]])).all()
@@ -96,6 +106,7 @@ def test_stack():
 
 def test_merge():
     img = tf.merge(img1, img2)
+    assert img.x_axis == img1.x_axis and img.y_axis == img1.y_axis
     chan = img.img.view([('r', 'uint8'), ('g', 'uint8'),
                          ('b', 'uint8'), ('a', 'uint8')])
     assert (chan['r'] == np.array([[127, 0], [0, 190]])).all()
@@ -103,6 +114,22 @@ def test_merge():
     assert (chan['b'] == np.array([[0, 0], [0, 62]])).all()
     assert (chan['a'] == np.array([[127, 0], [127, 190]])).all()
     assert (tf.merge(img2, img1).img == img.img).all()
+
+
+def test_stack_merge_aligned_axis():
+    # If/when non_aligned axis become supported, these can be removed
+    img3 = tf.Image(np.arange(4, dtype='uint32').reshape((2, 2)),
+                    x_axis=x_axis, y_axis=LinearAxis((1, 20)))
+    img4 = tf.Image(np.arange(9, dtype='uint32').reshape((3, 3)),
+                    x_axis=x_axis, y_axis=y_axis)
+    with pytest.raises(NotImplementedError):
+        tf.stack(img1, img3)
+    with pytest.raises(NotImplementedError):
+        tf.stack(img1, img4)
+    with pytest.raises(NotImplementedError):
+        tf.merge(img1, img3)
+    with pytest.raises(NotImplementedError):
+        tf.merge(img1, img4)
 
 
 def test_Image_to_pil():

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -8,7 +8,7 @@ from dynd import nd
 from PIL.Image import fromarray
 
 from .colors import rgb
-from .utils import is_missing, is_option
+from .utils import is_missing, is_option, dynd_to_np_mask
 
 
 __all__ = ['Image', 'merge', 'stack', 'interpolate', 'colorize']
@@ -88,12 +88,7 @@ def interpolate(agg, low, high, how='log'):
         magnitudes at each pixel, and should return a numeric array of the same
         shape.
     """
-    if is_option(agg.dtype):
-        buffer = nd.as_numpy(agg.view_scalars(agg.dtype.value_type))
-        missing = is_missing(buffer)
-    else:
-        buffer = nd.as_numpy(agg)
-        missing = (buffer == 0)
+    buffer, missing = dynd_to_np_mask(agg)
     offset = buffer[~missing].min()
     data = _normalize_interpolate_how(how)(buffer + offset)
     span = [data[~missing].min(), data[~missing].max()]

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -3,20 +3,29 @@ from __future__ import absolute_import, division, print_function
 from io import BytesIO
 
 import numpy as np
-import datashape
 from dynd import nd
 from PIL.Image import fromarray
 
+from .aggregates import ScalarAggregate, CategoricalAggregate, _validate_axis
 from .colors import rgb
-from .utils import is_missing, is_option, dynd_to_np_mask
+from .utils import dynd_to_np_mask
 
 
 __all__ = ['Image', 'merge', 'stack', 'interpolate', 'colorize']
 
 
 class Image(object):
-    def __init__(self, img):
+    def __init__(self, img, x_axis=None, y_axis=None):
         self.img = img
+        self.x_axis = _validate_axis(x_axis)
+        self.y_axis = _validate_axis(y_axis)
+
+    @property
+    def shape(self):
+        return self.img.shape
+
+    def __repr__(self):
+        return 'Image<shape={0}>'.format(self.shape)
 
     def _repr_png_(self):
         return self.to_pil()._repr_png_()
@@ -39,23 +48,45 @@ def _to_channels(data):
                       ('a', 'uint8')])
 
 
+def _validate_images(imgs):
+    if not imgs:
+        raise ValueError("No images passed in")
+    for i in imgs:
+        if not isinstance(i, Image):
+            raise TypeError("Expected `Image`, got: `{0}`".format(type(i)))
+    shapes = set(i.shape for i in imgs)
+    x_axis = set(i.x_axis for i in imgs)
+    y_axis = set(i.y_axis for i in imgs)
+    if len(shapes) > 1 or len(x_axis) > 1 or len(y_axis) > 1:
+        raise NotImplementedError("Operations between images with "
+                                  "non-matching axis or shape")
+
+
 def merge(*imgs):
     """Merge a number of images together, averaging the channels"""
+    _validate_images(imgs)
+    if len(imgs) == 1:
+        return imgs[0]
+    x_axis, y_axis = imgs[0].x_axis, imgs[0].y_axis
     imgs = _to_channels(np.stack([i.img for i in imgs]))
     r = imgs['r'].mean(axis=0, dtype='f8').astype('uint8')
     g = imgs['g'].mean(axis=0, dtype='f8').astype('uint8')
     b = imgs['b'].mean(axis=0, dtype='f8').astype('uint8')
     a = imgs['a'].mean(axis=0, dtype='f8').astype('uint8')
-    return Image(np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape))
+    return Image(np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape),
+                 x_axis, y_axis)
 
 
 def stack(*imgs):
     """Merge a number of images together, overlapping earlier images with
     later ones."""
+    _validate_images(imgs)
+    if len(imgs) == 1:
+        return imgs[0]
     out = imgs[0].img.copy()
     for img in imgs[1:]:
         out = np.where(_to_channels(img.img)['a'] == 0, out, img.img)
-    return Image(out)
+    return Image(out, imgs[0].x_axis, imgs[0].y_axis)
 
 
 _interpolate_lookup = {'log': np.log1p,
@@ -72,11 +103,11 @@ def _normalize_interpolate_how(how):
 
 
 def interpolate(agg, low, high, how='log'):
-    """Convert an aggregate to an image.
+    """Convert a ScalarAggregate to an image.
 
     Parameters
     ----------
-    agg : A dynd array
+    agg : ScalarAggregate
     low : color name or tuple
         The color for the low end of the scale. Can be specified either by
         name, hexcode, or as a tuple of ``(red, green, blue)`` values.
@@ -88,7 +119,9 @@ def interpolate(agg, low, high, how='log'):
         magnitudes at each pixel, and should return a numeric array of the same
         shape.
     """
-    buffer, missing = dynd_to_np_mask(agg)
+    if not isinstance(agg, ScalarAggregate):
+        raise TypeError("agg must be instance of ScalarAggregate")
+    buffer, missing = dynd_to_np_mask(agg._data)
     offset = buffer[~missing].min()
     data = _normalize_interpolate_how(how)(buffer + offset)
     span = [data[~missing].min(), data[~missing].max()]
@@ -98,15 +131,16 @@ def interpolate(agg, low, high, how='log'):
     b = np.interp(data, span, bspan, left=255).astype(np.uint8)
     a = np.full_like(r, 255)
     img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
-    return Image(np.where(missing, 0, img))
+    return Image(np.where(missing, 0, img),
+                 agg.x_axis, agg.y_axis)
 
 
 def colorize(agg, color_key, how='log', min_alpha=20):
-    """Color a record aggregate by field.
+    """Color a CategoricalAggregate by field.
 
     Parameters
     ----------
-    agg : dynd array
+    agg : CategoricalAggregate
     color_key : dict or iterable
         A mapping of fields to colors. Can be either a ``dict`` mapping from
         field name to colors, or an iterable of colors in the same order as the
@@ -119,19 +153,17 @@ def colorize(agg, color_key, how='log', min_alpha=20):
     min_alpha : float, optional
         The minimum alpha value to use for non-empty pixels, in [0, 255].
     """
-    agg_dshape = datashape.dshape(agg.dtype.dshape)
-    if not datashape.isrecord(agg_dshape):
-        raise ValueError("Datashape of aggregate must be record type")
+    if not isinstance(agg, CategoricalAggregate):
+        raise TypeError("agg must be instance of CategoricalAggregate")
     if not isinstance(color_key, dict):
-        color_key = dict(zip(agg_dshape.measure.names, color_key))
-    if len(color_key) != len(agg_dshape.measure.names):
+        color_key = dict(zip(agg.cats, color_key))
+    if len(color_key) != len(agg.cats):
         raise ValueError("Number of colors doesn't match number of fields")
     if not (0 <= min_alpha <= 255):
         raise ValueError("min_alpha must be between 0 and 255")
-    colors = [rgb(color_key[c]) for c in agg_dshape.measure.names]
+    colors = [rgb(color_key[c]) for c in agg.cats]
     rs, gs, bs = map(np.array, zip(*colors))
-    data = np.dstack([nd.as_numpy(getattr(agg, f)).astype('f8') for f in
-                      agg_dshape.measure.names])
+    data = nd.as_numpy(agg._data).astype('f8')
     total = data.sum(axis=2)
     r = (data.dot(rs)/total).astype(np.uint8)
     g = (data.dot(gs)/total).astype(np.uint8)
@@ -141,4 +173,5 @@ def colorize(agg, color_key, how='log', min_alpha=20):
     white = (total == 0)
     r[white] = g[white] = b[white] = 255
     a[white] = 0
-    return Image(np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape))
+    return Image(np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape),
+                 agg.x_axis, agg.y_axis)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import sys
 from inspect import getmro
 
-from datashape import Unit
+from datashape import Unit, dshape
 from datashape.predicates import launder
 from datashape.typesets import real
 import numba as nb
@@ -133,3 +133,7 @@ def is_missing(x):
 def is_option(agg):
     """Returns if the dshape of the dynd array is an option type"""
     return hasattr(agg, 'value_type')
+
+
+def dshape_from_dynd(ds):
+    return dshape(str(ds))

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -50,8 +50,8 @@ class GetDataset(RequestHandler):
         agg = cvs.points(self.model.df,
                          self.model.active_axes[1],
                          self.model.active_axes[2],
-                         agg=self.model.aggregate_function(self.model.field))
-        pix = tf.interpolate(agg.agg, (255, 204, 204), 'red',
+                         self.model.aggregate_function(self.model.field))
+        pix = tf.interpolate(agg, (255, 204, 204), 'red',
                              how=self.model.transfer_function)
 
         # serialize to image

--- a/examples/nyc_taxi.ipynb
+++ b/examples/nyc_taxi.ipynb
@@ -36,7 +36,8 @@
    "outputs": [],
    "source": [
     "df = pd.read_csv('data/nyc_taxi.csv')\n",
-    "df = df[['pickup_longitude', 'pickup_latitude', 'dropoff_longitude', 'dropoff_latitude', 'passenger_count']]\n",
+    "df = df[['pickup_longitude', 'pickup_latitude', 'dropoff_longitude',\n",
+    "         'dropoff_latitude', 'passenger_count']]\n",
     "xmin = -8240227.037\n",
     "ymin = 4974203\n",
     "xmax = -8231283.905\n",
@@ -61,10 +62,12 @@
    "source": [
     "a_few_points = df.sample(n=1000)\n",
     "\n",
-    "p = figure(tools='pan,wheel_zoom', plot_width=800, plot_height=500, x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
+    "p = figure(tools='pan,wheel_zoom', plot_width=800, plot_height=500,\n",
+    "           x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
     "p.add_tile(STAMEN_TONER)\n",
     "p.axis.visible = False\n",
-    "p.circle(x=a_few_points['pickup_longitude'], y=a_few_points['pickup_latitude'], line_color='black', fill_color='red')"
+    "p.circle(x=a_few_points['pickup_longitude'], y=a_few_points['pickup_latitude'],\n",
+    "         line_color='black', fill_color='red')"
    ]
   },
   {
@@ -96,10 +99,12 @@
     "output_notebook()\n",
     "a_few_points_more = df.sample(n=10000)\n",
     "\n",
-    "p = figure(tools='pan,wheel_zoom', plot_width=800, plot_height=500, x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
+    "p = figure(tools='pan,wheel_zoom', plot_width=800, plot_height=500,\n",
+    "           x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
     "p.add_tile(STAMEN_TONER)\n",
     "p.axis.visible = False\n",
-    "p.circle(x=a_few_points_more['pickup_longitude'], y=a_few_points_more['pickup_latitude'], line_color='black', fill_color='red')"
+    "p.circle(x=a_few_points_more['pickup_longitude'], y=a_few_points_more['pickup_latitude'],\n",
+    "         line_color='black', fill_color='red')"
    ]
   },
   {
@@ -179,7 +184,8 @@
     "\"\"\"\n",
     "\n",
     "\n",
-    "p = figure(tools='pan,wheel_zoom', plot_width=800, plot_height=500, x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
+    "p = figure(tools='pan,wheel_zoom', plot_width=800, plot_height=500,\n",
+    "           x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
     "p.add_tile(STAMEN_TONER)\n",
     "p.axis.visible = False\n",
     "p.tags = ['datashader-plot']\n",
@@ -188,8 +194,8 @@
     "    xmin, ymin, xmax, ymax = ranges['xmin'], ranges['ymin'], ranges['xmax'], ranges['ymax']\n",
     "    h, w = ranges['h'], ranges['w']\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
-    "    agg = cvs.points(df, 'pickup_longitude', 'pickup_latitude', count=ds.count('passenger_count'))\n",
-    "    pix = tf.interpolate(agg.count, (255, 204, 204), 'red', how='log')\n",
+    "    agg = cvs.points(df, 'pickup_longitude', 'pickup_latitude', ds.count('passenger_count'))\n",
+    "    pix = tf.interpolate(agg, (255, 204, 204), 'red', how='log')\n",
     "    dh = ymax - ymin\n",
     "    dw = xmax - xmin\n",
     "    p.image_rgba(image=[pix.img], x=xmin, y=ymin, dw=dw, dh=dh, dilate=False)\n",


### PR DESCRIPTION
Previously we were outputting raw dynd arrays after the aggregation step. This was not a good design decision for a few reasons:

1. Enforced array storage for aggregates. Currently all aggregates are arrays, but in general that's limiting.
2. Dynd is currently buggy (but at least in predictable ways). Without encapsulating these arrays in our own objects, we exposed users to issues in dynd.
3. Prevented being able to (easily) attach metadata and relevant methods to the aggregates.

Downsides are that we have to reimplement operations to make aggregates feel natural to work with. However, as most aggregate level operations are simple, aligned elementwise operations, these are fairly trivial to write.

In the act of making this change, I found lots of other things that were related that needed fixing. This PR:

- Defines 3 new aggregate types, and provides common operations on them, and updates the library to work with them. 
- Removes the previous requirement of having aggregates be fields in a larger enclosing record aggregate. Now you can do multiple aggregations by passing in a `summary` object explicitly, or a single aggregate alone (e.g. `mean('field')`).
- Adds `Axis` types, initially defining both `LinearAxis` and `LogAxis`. These are attached to an aggregate upon creation, and serve as relevant metadata describing its location in space.

Note that pretty much all of this is still undocumented. However, I'd like to handle the documentation for the whole library in a separate PR.