### PR TITLE
Implement `where` for aggregates

### DIFF
--- a/datashader/aggregates.py
+++ b/datashader/aggregates.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import operator
 
 import numpy as np
-from datashape import dshape, Record, DataShape
+from datashape import dshape, Record, DataShape, isboolean
 from dynd import nd
 from toolz import get
 
@@ -25,6 +25,12 @@ def _validate_axis(axis):
     if not isinstance(axis, Axis):
         raise TypeError("axis must be instance of Axis")
     return axis
+
+
+def _validate_aligned(a, b):
+    if (a.x_axis != b.x_axis or a.y_axis != b.y_axis or a.shape != b.shape):
+        raise NotImplementedError("operations between aggregates with "
+                                  "non-matching axis or shape")
 
 
 def dynd_op(op, left, right):
@@ -55,10 +61,7 @@ def make_binary_op(op, use_dynd=True):
     agg_op = op if use_dynd else lambda l, r: dynd_op(op, l, r)
     def f(self, other):
         if isinstance(other, ScalarAggregate):
-            if (self.x_axis != other.x_axis or self.y_axis != other.y_axis or
-                    self.shape != other.shape):
-                raise NotImplementedError("operations between aggregates with "
-                                          "non-matching axis or shape")
+            _validate_aligned(self, other)
             res = agg_op(self._data, other._data)
         elif isinstance(other, (np.generic, int, float, bool)):
             res = agg_op(self._data, other)
@@ -124,21 +127,16 @@ class ScalarAggregate(Aggregate):
         """
         if not isinstance(cond, ScalarAggregate):
             raise TypeError("cond must be instance of ScalarAggregate")
-        elif cond.dshape != dshape('bool') and cond.dshape != dshape('?bool'):
+        elif not isboolean(cond.dshape):
             raise TypeError("cond must be a boolean aggregate")
-        elif not (cond.shape == self.shape and cond.x_axis == self.x_axis and
-                  cond.y_axis == self.y_axis):
-            raise NotImplementedError("operations between aggregates with "
-                                      "non-matching axis or shape")
+        _validate_aligned(self, cond)
+        cond_arr, _ = dynd_to_np_mask(cond._data)
         arr, arr_mask = dynd_to_np_mask(self._data)
+        arr_missing = is_option(self._data.dtype)
         if isinstance(otherwise, ScalarAggregate):
-            if (cond.shape == self.shape and cond.x_axis == self.x_axis and
-                    cond.y_axis == self.y_axis):
-                otherwise_arr, otherwise_mask = dynd_to_np_mask(otherwise._data)
-                otherwise_missing = is_option(otherwise._data.dtype)
-            else:
-                raise NotImplementedError("operations between aggregates with "
-                                          "non-matching axis or shape")
+            _validate_aligned(self, otherwise)
+            otherwise_arr, otherwise_mask = dynd_to_np_mask(otherwise._data)
+            otherwise_missing = is_option(otherwise._data.dtype)
         elif isinstance(otherwise, (int, float, np.generic)):
             otherwise_arr = otherwise
             otherwise_mask = otherwise_missing = False
@@ -149,8 +147,6 @@ class ScalarAggregate(Aggregate):
         else:
             raise TypeError("`otherwise` got unknown"
                             " type: {0}".format(type(otherwise)))
-        arr_missing = is_option(self._data.dtype)
-        cond_arr, _ = dynd_to_np_mask(cond._data)
         out = np.where(cond_arr, arr, otherwise_arr)
         if arr_missing or otherwise_missing:
             out[arr_mask | otherwise_mask] = dynd_missing_types[out.dtype]
@@ -242,7 +238,8 @@ class CategoricalAggregate(Aggregate):
     @property
     def dshape(self):
         if not hasattr(self, '_dshape'):
-            self._dshape = DataShape(len(self._cats), 'int32')
+            self._dshape = DataShape(len(self._cats),
+                                     dshape_from_dynd(self._data.dtype))
         return self._dshape
 
     @property
@@ -250,6 +247,62 @@ class CategoricalAggregate(Aggregate):
         if not hasattr(self, '_shape'):
             self._shape = self._data.shape[:2]
         return self._shape
+
+    def where(self, cond, otherwise=None):
+        """Return elements from `self` or `otherwise`, depending on `cond`.
+
+        Parameters
+        ----------
+        cond : CategoricalAggregate, ScalarAggregate
+            A boolean aggregate of the same shape as `self`.
+        otherwise : Aggregate, numeric, None, optional
+            The value to use in each element if `cond` is `False`. If an
+            aggregate, must have same shape as `self` and `cond`. If `None`
+            [default], yields a missing value for the given datashape.
+
+        Returns
+        -------
+        CategoricalAggregate
+        """
+        if (self.cats != getattr(cond, 'cats', self.cats) !=
+                getattr(otherwise, 'cats', self.cats)):
+            raise ValueError("Categoricals not aligned")
+        if not isinstance(cond, (CategoricalAggregate, ScalarAggregate)):
+            raise TypeError("cond must be instance of ScalarAggregate "
+                            "or CategoricalAggregate")
+        elif not isboolean(cond.dshape):
+            raise TypeError("cond must be a boolean aggregate")
+        _validate_aligned(self, cond)
+        cond_arr, _ = dynd_to_np_mask(cond._data)
+        if isinstance(cond, ScalarAggregate):
+            cond_arr = np.expand_dims(cond_arr, 2)
+        arr, arr_mask = dynd_to_np_mask(self._data)
+        arr_missing = is_option(self._data.dtype)
+        if isinstance(otherwise, (CategoricalAggregate, ScalarAggregate)):
+            _validate_aligned(self, otherwise)
+            otherwise_arr, otherwise_mask = dynd_to_np_mask(otherwise._data)
+            if isinstance(otherwise, ScalarAggregate):
+                otherwise_arr = np.expand_dims(otherwise_arr, 2)
+                otherwise_mask = np.expand_dims(otherwise_mask, 2)
+            otherwise_missing = is_option(otherwise._data.dtype)
+        elif isinstance(otherwise, (int, float, np.generic)):
+            otherwise_arr = otherwise
+            otherwise_mask = otherwise_missing = False
+        elif otherwise is None:
+            otherwise_arr = dynd_missing_types[arr.dtype]
+            otherwise_mask = False
+            otherwise_missing = True
+        else:
+            raise TypeError("`otherwise` got unknown"
+                            " type: {0}".format(type(otherwise)))
+        out = np.where(cond_arr, arr, otherwise_arr)
+        if arr_missing or otherwise_missing:
+            out[arr_mask | otherwise_mask] = dynd_missing_types[out.dtype]
+            out = nd.asarray(out)
+            out = out.view_scalars('?' + str(out.dtype))
+        else:
+            out = nd.asarray(out)
+        return CategoricalAggregate(out, self.cats, self.x_axis, self.y_axis)
 
 
 class RecordAggregate(Aggregate):

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -122,6 +122,8 @@ def interpolate(agg, low, high, how='log'):
     if not isinstance(agg, ScalarAggregate):
         raise TypeError("agg must be instance of ScalarAggregate")
     buffer, missing = dynd_to_np_mask(agg._data)
+    if buffer.min() == 0:
+        missing = (missing | (buffer == 0))
     offset = buffer[~missing].min()
     data = _normalize_interpolate_how(how)(buffer + offset)
     span = [data[~missing].min(), data[~missing].max()]

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -148,7 +148,7 @@ def dynd_to_np_mask(x):
         missing = is_missing(arr)
     else:
         arr = nd.as_numpy(x)
-        missing = (arr == 0)
+        missing = np.full_like(arr, False, dtype='bool')
     return arr, missing
 
 


### PR DESCRIPTION
Implements `where` for both scalar and categorical aggregates. Syntax:

```python
# `agg` where cond is True, NA everywhere else
agg.where(cond)
# `agg` where cond is True, 2 everywhere else
agg.where(cond, 2)
# `agg` where cond is True, other_agg everywhere else
agg.where(cond, other_agg)
```

Allows for filtering based on elementwise conditionals in aggregates.