### PR TITLE
Added DatashaderPipeline and updated examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install numpy pandas pytest toolz numba datashape odo dask pillow
+  - conda install numpy pandas pytest toolz numba datashape odo dask pillow param
   - conda install -c dynd dynd-python
   # Need a few fixes to odo and datashape that aren't in the latest release
   - pip install --upgrade --no-deps git+https://github.com/Blaze/odo

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -5,6 +5,7 @@ __version__ = '0.0.1'
 from .core import Canvas
 from .reductions import (count, sum, min, max, mean, std, var, count_cat,
                          summary)
+from .glyphs import Point
 
 # Needed to build the backend dispatch
 from .pandas import *

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -6,6 +6,7 @@ from .core import Canvas
 from .reductions import (count, sum, min, max, mean, std, var, count_cat,
                          summary)
 from .glyphs import Point
+from .pipeline import Pipeline, Interpolate
 
 # Needed to build the backend dispatch
 from .pandas import *

--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -29,7 +29,7 @@ class Interpolate(param.Parameterized):
         Color string or tuple specifying the ending point for interpolation.""")
 
     how = param.Parameter(default="log", doc="""
-        Function object or string specifying how to map from a scalar into color space.""")
+        Function object or string specifying how to map a scalar into color space.""")
 
     def __call__(self, agg):
         return tf.interpolate(agg, self.low, self.high, self.how)
@@ -42,12 +42,12 @@ class DatashaderPipeline(param.Parameterized):
     effect of varying that element while keeping the rest of the pipeline
     constant.
 
-    The pipeline is roughly:
+    The supported pipeline is roughly:
 
-    1. create canvas of the requested size
+    1. create canvas of the requested size (in data space) and resolution
     2. aggregate using the specified x and y fields, aggregate field, and agg_fn
-    3. apply the specified transfer_fns, if any, in order
-    4. apply the specified color_fn to translate each resulting aggregate into a color
+    3. apply specified transfer_fns, if any, in order
+    4. apply specified color_fn to translate each resulting aggregate into a color
     5. return the result as an image
     """
 
@@ -86,7 +86,9 @@ class DatashaderPipeline(param.Parameterized):
         x_range, y_range = ranges['x_range'], ranges['y_range']
         h, w = ranges['h'], ranges['w']
 
-        cvs = core.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)
+        cvs = core.Canvas(plot_width=w, plot_height=h,
+                          x_range=x_range, y_range=y_range)
+
         agg = cvs.points(ps.data, ps.x, ps.y, ps.agg_fn(ps.agg))
         for f in ps.transfer_fns:
             agg = f(agg)
@@ -94,4 +96,5 @@ class DatashaderPipeline(param.Parameterized):
 
         dh = y_range[1] - y_range[0]
         dw = x_range[1] - x_range[0]
-        plot.image_rgba(image=[pix.img], x=x_range[0], y=y_range[0], dw=dw, dh=dh, dilate=False)
+        plot.image_rgba(image=[pix.img], x=x_range[0], y=y_range[0],
+                        dw=dw, dh=dh, dilate=False)

--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 """
-Declarative interface to Datashader.  
+Declarative interface to Datashader.
 
 Provides a configurable pipeline that makes it simpler to specify
 individual stages independently from the others, Currently does not
@@ -38,17 +38,17 @@ class Interpolate(param.Parameterized):
 class DatashaderPipeline(param.Parameterized):
     """
     Configurable datashading pipeline.  Allows each element of the pipeline
-    to be specified independently without code duplication, e.g. to show the 
-    effect of varying that element while keeping the rest of the pipeline 
-    constant.  
-    
+    to be specified independently without code duplication, e.g. to show the
+    effect of varying that element while keeping the rest of the pipeline
+    constant.
+
     The pipeline is roughly:
 
     1. create canvas of the requested size
     2. aggregate using the specified x and y fields, aggregate field, and agg_fn
     3. apply the specified transfer_fns, if any, in order
     4. apply the specified color_fn to translate each resulting aggregate into a color
-    5. return the result as an image    
+    5. return the result as an image
     """
 
     data = param.Parameter(doc="""
@@ -79,7 +79,7 @@ class DatashaderPipeline(param.Parameterized):
         """
         Accepts a Bokeh plot and a viewport specified via a ranges dictionary
         (which should contain x_range, y_range, h, and w).  Returns an image
-        rendered at the specified location, using the current parameter values.        
+        rendered at the specified location, using the current parameter values.
         """
         ps = param.ParamOverrides(self,params)
 

--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -15,6 +15,7 @@ import param
 from . import transfer_functions as tf
 from . import reductions
 from . import core
+from . import glyphs
 
 
 class Interpolate(param.Parameterized):
@@ -37,64 +38,63 @@ class Interpolate(param.Parameterized):
 
 class DatashaderPipeline(param.Parameterized):
     """
-    Configurable datashading pipeline.  Allows each element of the pipeline
-    to be specified independently without code duplication, e.g. to show the
-    effect of varying that element while keeping the rest of the pipeline
-    constant.
+    Configurable datashading pipeline for use with Bokeh.  Allows each
+    element of the pipeline to be specified independently without code
+    duplication, e.g. to show the effect of varying that element while
+    keeping the rest of the pipeline constant.
 
-    The supported pipeline is roughly:
+    Given a dataframe-like object df, the supported pipeline is roughly:
 
     1. create canvas of the requested size (in data space) and resolution
-    2. aggregate using the specified x and y fields, aggregate field, and agg_fn
-    3. apply specified transfer_fns, if any, in order
-    4. apply specified color_fn to translate each resulting aggregate into a color
+    2. aggregate df into pixel-shaped bins using the glyph and agg specifications
+    3. apply specified transfer_fns, if any, in order, on the set of bin values
+    4. apply specified color_fn to translate each resulting bin value into a color
     5. return the result as an image
     """
 
-    data = param.Parameter(doc="""
+    df = param.Parameter(doc="""
         Object supporting columnar-style data access, such as a Pandas
         dataframe.""")
 
-    x = param.String("x", doc="""
-        Name of the field in the supplied data object to use for the x coordinate.""")
+    glyph = param.ClassSelector(glyphs.Glyph,default=glyphs.Point("x","y"), doc="""
+        Marker shape for each point, specified using fields for the data object.""")
 
-    y = param.String("y", doc="""
-        Name of the field in the supplied data object to use for the y coordinate.""")
-
-    agg = param.String("count", doc="""
-        Name of the field in the supplied data object to use for aggregation.""")
-
-    agg_fn = param.Callable(reductions.count, doc="""
-        Function for aggregating pixel-bin contents into a scalar.""")
+    agg = param.ClassSelector(reductions.Reduction, default=reductions.count("count"), 
+        doc="""Function for incrementally reducing a bin's values into a scalar.""")
 
     transfer_fns = param.HookList(default=[], doc="""
-        Optional function(s) to apply to the aggregate after it has been created
-        and before it has been converted into a color.""")
+        Optional function(s) to apply to the aggregated bin values, before
+        they each get converted into a color.""")
 
     color_fn = param.Callable(default=Interpolate(), doc="""
-        Function to convert a scalar value into a color.""")
+        Function to convert a scalar aggregated bin value into a color.""")
 
 
     def __call__(self, plot, ranges, **params):
         """
         Accepts a Bokeh plot and a viewport specified via a ranges dictionary
-        (which should contain x_range, y_range, h, and w).  Returns an image
-        rendered at the specified location, using the current parameter values.
+        (which should contain x_range and y_range specifying the viewport in
+        data space, and h and w specifying the resolution).
+
+        Returns an image of the specified height and width, rendered
+        over the specified range in data space, using the current
+        parameter values.
         """
         ps = param.ParamOverrides(self,params)
 
         x_range, y_range = ranges['x_range'], ranges['y_range']
         h, w = ranges['h'], ranges['w']
 
-        cvs = core.Canvas(plot_width=w, plot_height=h,
-                          x_range=x_range, y_range=y_range)
+        canvas = core.Canvas(plot_width=w, plot_height=h,
+                             x_range=x_range, y_range=y_range)
 
-        agg = cvs.points(ps.data, ps.x, ps.y, ps.agg_fn(ps.agg))
+        bins = core.bypixel(ps.df, canvas, ps.glyph, ps.agg)
+
         for f in ps.transfer_fns:
-            agg = f(agg)
-        pix = ps.color_fn(agg)
+            agg = f(bins)
+        pixels = ps.color_fn(bins)
 
         dh = y_range[1] - y_range[0]
         dw = x_range[1] - x_range[0]
-        plot.image_rgba(image=[pix.img], x=x_range[0], y=y_range[0],
+        plot.image_rgba(image=[pixels.img], x=x_range[0], y=y_range[0],
                         dw=dw, dh=dh, dilate=False)

--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import, division, print_function
+
+"""
+Declarative interface to Datashader.  
+
+Provides a configurable pipeline that makes it simpler to specify
+individual stages independently from the others, Currently does not
+add any new underlying capabilities, with all functionality also
+available using the default imperative interface provided by other
+files.
+"""
+
+import param
+
+from . import transfer_functions as tf
+from . import reductions
+from . import core
+
+
+class Interpolate(param.Parameterized):
+    """
+    Parameterized function object to interpolate colors from a scalar input.
+    """
+
+    low = param.Parameter(default="lightpink", doc="""
+         Color string or tuple specifying the starting point for interpolation.""")
+
+    high = param.Parameter(default="red", doc="""
+         Color string or tuple specifying the ending point for interpolation.""")
+
+    how = param.Parameter(default="log", doc="""
+         Function object or string specifying how to map from a scalar into color space.""")
+
+    def __call__(self, agg):
+            return tf.interpolate(agg, self.low, self.high, self.how)
+
+
+class DatashaderPipeline(param.Parameterized):
+    """
+    Configurable datashading pipeline.  Allows each element of the pipeline
+    to be specified independently without code duplication, e.g. to show the 
+    effect of varying that element while keeping the rest of the pipeline 
+    constant.  
+    
+    The pipeline is roughly:
+
+    1. create canvas of the requested size
+    2. aggregate using the specified x and y fields, aggregate field, and agg_fn
+    3. apply the specified transfer_fns, if any, in order
+    4. apply the specified color_fn to translate each resulting aggregate into a color
+    5. return the result as an image    
+    """
+
+    data = param.Parameter(doc="""
+        Object supporting columnar-style data access, such as a Pandas
+        dataframe.""")
+
+    x = param.String("x", doc="""
+        Name of the field in the supplied data object to use for the x coordinate.""")
+
+    y = param.String("y", doc="""
+        Name of the field in the supplied data object to use for the y coordinate.""")
+
+    agg = param.String("count", doc="""
+        Name of the field in the supplied data object to use for aggregation.""")
+
+    agg_fn = param.Callable(reductions.count, doc="""
+        Function for aggregating pixel-bin contents into a scalar.""")
+
+    transfer_fns = param.HookList(default=[], doc="""
+        Optional function(s) to apply to the aggregate after it has been created
+        and before it has been converted into a color.""")
+
+    color_fn = param.Callable(default=Interpolate(), doc="""
+        Function to convert a scalar value into a color.""")
+
+
+    def __call__(self, plot, ranges, **params):
+        """
+        Accepts a Bokeh plot and a viewport specified via a ranges dictionary
+        (which should contain x_range, y_range, h, and w).  Returns an image
+        rendered at the specified location, using the current parameter values.        
+        """
+        ps = param.ParamOverrides(self,params)
+
+        x_range, y_range = ranges['x_range'], ranges['y_range']
+        h, w = ranges['h'], ranges['w']
+
+        cvs = core.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)
+        agg = cvs.points(ps.data, ps.x, ps.y, ps.agg_fn(ps.agg))
+        for f in ps.transfer_fns:
+            agg = f(agg)
+        pix = ps.color_fn(agg)
+
+        dh = y_range[1] - y_range[0]
+        dw = x_range[1] - x_range[0]
+        plot.image_rgba(image=[pix.img], x=x_range[0], y=y_range[0], dw=dw, dh=dh, dilate=False)

--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -23,16 +23,16 @@ class Interpolate(param.Parameterized):
     """
 
     low = param.Parameter(default="lightpink", doc="""
-         Color string or tuple specifying the starting point for interpolation.""")
+        Color string or tuple specifying the starting point for interpolation.""")
 
     high = param.Parameter(default="red", doc="""
-         Color string or tuple specifying the ending point for interpolation.""")
+        Color string or tuple specifying the ending point for interpolation.""")
 
     how = param.Parameter(default="log", doc="""
-         Function object or string specifying how to map from a scalar into color space.""")
+        Function object or string specifying how to map from a scalar into color space.""")
 
     def __call__(self, agg):
-            return tf.interpolate(agg, self.low, self.high, self.how)
+        return tf.interpolate(agg, self.low, self.high, self.how)
 
 
 class DatashaderPipeline(param.Parameterized):

--- a/examples/nyc_taxi.ipynb
+++ b/examples/nyc_taxi.ipynb
@@ -1,6 +1,15 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plotting very large datasets\n",
+    "\n",
+    "There are a variety of approaches for plotting large datasets, but most of them are very unsatisfactory. Here we first show some of the issues, then demonstrate how the Datashader library helps make large datasets practical."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -8,15 +17,15 @@
    },
    "outputs": [],
    "source": [
-    "import datashader as ds\n",
-    "import datashader.transfer_functions as tf\n",
-    "\n",
     "import pandas as pd\n",
     "\n",
     "from bokeh.plotting import figure, output_notebook, show\n",
     "from bokeh.models import ColumnDataSource, CustomJS, Range1d\n",
     "from bokeh.io import push_notebook\n",
     "from bokeh.tile_providers import STAMEN_TONER\n",
+    "\n",
+    "from datashader.pipeline import DatashaderPipeline, Interpolate\n",
+    "from datashader.callbacks import IPythonKernelCallback\n",
     "\n",
     "output_notebook()"
    ]
@@ -71,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## A few points are fine"
+    "## A few points are fine using a Bokeh scatterplot"
    ]
   },
   {
@@ -111,11 +120,79 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Making the points tiny and partially transparent helps a bit\n",
+    "  \n",
+    "However, it is tricky to set the size and alpha parameters.  The correct value of both depends on zoom level and number of points; at higher zooms you need larger sizes and higher alpha values, which requires editing the code each time.\n",
+    "\n",
+    "Plotting also starts getting very slow for > 10000 points.  With some browsers you can use Bokeh's WebGL support to render additional points relatively quickly, but there will always be a limit on the number of points that will work well in a web browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "options = dict(line_color='red', fill_color='red', size=1, alpha=0.2)\n",
+    "samples = df.sample(n=10000)\n",
+    "p = base_plot()\n",
+    "p.circle(x=samples['pickup_x'], y=samples['pickup_y'], **options)\n",
+    "show(p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false
    },
    "source": [
-    "## Using datashader, you can easily aggregate points and conquer over-saturation"
+    "## Using datashader, you can easily aggregate points and conquer over-saturation\n",
+    "\n",
+    "Datashader renders the entire dataset into a buffer in a separate Python process, always providing a fixed-size image to the browser.  The number of points is no longer a limiting factor, so you can use the entire dataset, and there is no need to set the alpha parameter.  This way you can zoom very far in interactively, seeing all the points available in that viewport, without ever needing to change the plot parameters.  Each time you zoom or pan, a new image is rendered (which takes a few seconds for large datasets), and displayed overlaid the other plot elements, providing full access to all of your data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "p = base_plot()\n",
+    "pipeline = DatashaderPipeline(data=df, x=\"pickup_x\", y=\"pickup_y\", agg=\"passenger_count\")\n",
+    "IPythonKernelCallback(p, pipeline)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "p = base_plot()\n",
+    "pipeline = DatashaderPipeline(data=df,x=\"pickup_x\",y=\"pickup_y\",agg=\"passenger_count\",\n",
+    "                              color_fn=Interpolate(low=\"lightblue\",high=\"blue\"))\n",
+    "IPythonKernelCallback(p, pipeline)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Unpacking the steps involved in the Datashader Pipeline\n",
+    "\n",
+    "The above functions use a configurable interface to make it simpler to specify individual bits of a standard scatterplot-like pipeline. If you want, you can do the same process with your own custom code to do whatever you like; anything that results in an image is fine!"
    ]
   },
   {
@@ -128,32 +205,21 @@
    "outputs": [],
    "source": [
     "from datashader.callbacks import IPythonKernelCallback\n",
+    "import datashader as ds\n",
+    "from datashader import transfer_functions as tf\n",
     "\n",
     "def create_image(p, ranges, agg_fn=ds.count):\n",
     "    x_range, y_range = ranges['x_range'], ranges['y_range']\n",
     "    h, w = ranges['h'], ranges['w']\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
     "    agg = cvs.points(df, 'pickup_x', 'pickup_y', agg_fn('passenger_count'))\n",
-    "    pix = tf.interpolate(agg, (255, 204, 204), 'red', how='log')\n",
+    "    pix = tf.interpolate(agg, \"lightpink\", 'red', how='log')\n",
     "    dh = y_range[1] - y_range[0]\n",
     "    dw = x_range[1] - x_range[0]\n",
     "    p.image_rgba(image=[pix.img], x=x_range[0], y=y_range[0], dw=dw, dh=dh, dilate=False)\n",
     "\n",
     "p = base_plot()\n",
-    "IPythonKernelCallback(p, create_image, throttle=100, agg_fn=ds.count)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "p = base_plot()\n",
-    "IPythonKernelCallback(p, create_image, throttle=100, agg_fn=ds.std)"
+    "IPythonKernelCallback(p, create_image, agg_fn=ds.count)"
    ]
   }
  ],

--- a/examples/nyc_taxi.ipynb
+++ b/examples/nyc_taxi.ipynb
@@ -24,9 +24,6 @@
     "from bokeh.io import push_notebook\n",
     "from bokeh.tile_providers import STAMEN_TONER\n",
     "\n",
-    "from datashader.pipeline import DatashaderPipeline, Interpolate\n",
-    "from datashader.callbacks import IPythonKernelCallback\n",
-    "\n",
     "output_notebook()"
    ]
   },
@@ -165,23 +162,10 @@
    "outputs": [],
    "source": [
     "import datashader as ds\n",
+    "from datashader.callbacks import IPythonKernelCallback\n",
+    "\n",
     "p = base_plot()\n",
-    "pipeline = DatashaderPipeline(df=df, glyph=ds.Point(\"pickup_x\", \"pickup_y\"), agg=ds.count(\"passenger_count\"))\n",
-    "IPythonKernelCallback(p, pipeline)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "p = base_plot()\n",
-    "pipeline = DatashaderPipeline(df=df, glyph=ds.Point(\"pickup_x\", \"pickup_y\"), agg=ds.count(\"passenger_count\"),\n",
-    "                              color_fn=Interpolate(low=\"lightblue\",high=\"blue\"))\n",
+    "pipeline = ds.Pipeline(df=df, glyph=ds.Point(\"pickup_x\", \"pickup_y\"), agg=ds.count(\"passenger_count\"))\n",
     "IPythonKernelCallback(p, pipeline)"
    ]
   },
@@ -193,7 +177,7 @@
    "source": [
     "## Unpacking the steps involved in the Datashader pipeline\n",
     "\n",
-    "The above functions use a configurable interface to make it simpler to specify individual bits of a standard scatterplot-like pipeline. If you want, you can do the same process with your own custom code to do whatever you like; anything that results in an image is fine!"
+    "The above functions use a configurable interface to make it simpler to specify individual bits of a standard scatterplot-like pipeline. If you want, you can do the same process with your own custom code to do whatever you like.  The supplied pipeline object just generates an image, given a specified viewport:"
    ]
   },
   {
@@ -205,22 +189,40 @@
    },
    "outputs": [],
    "source": [
-    "from datashader.callbacks import IPythonKernelCallback\n",
+    "p = base_plot()\n",
+    "pipeline = ds.Pipeline(df=df, glyph=ds.Point(\"pickup_x\", \"pickup_y\"), agg=ds.count(\"passenger_count\"),\n",
+    "                       color_fn=ds.Interpolate(low=\"lightblue\",high=\"blue\"))\n",
+    "pipeline(x_range, y_range, 800, 500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So you can simply substitute any function that will create an image, when given x and y ranges, a resolution (w x h), and zero or more optional arguments.  For instance, here's what the Pipeline object does, more or less:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
     "import datashader as ds\n",
+    "from datashader.callbacks import IPythonKernelCallback\n",
     "from datashader import transfer_functions as tf\n",
     "\n",
-    "def create_image(p, ranges, agg_fn=ds.count):\n",
-    "    x_range, y_range = ranges['x_range'], ranges['y_range']\n",
-    "    h, w = ranges['h'], ranges['w']\n",
+    "def create_image(x_range, y_range, w, h, how='log'):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    agg = cvs.points(df, 'pickup_x', 'pickup_y', agg_fn('passenger_count'))\n",
-    "    pix = tf.interpolate(agg, \"lightpink\", 'red', how='log')\n",
-    "    dh = y_range[1] - y_range[0]\n",
-    "    dw = x_range[1] - x_range[0]\n",
-    "    p.image_rgba(image=[pix.img], x=x_range[0], y=y_range[0], dw=dw, dh=dh, dilate=False)\n",
+    "    agg = cvs.points(df, 'pickup_x', 'pickup_y', ds.count('passenger_count'))\n",
+    "    image = tf.interpolate(agg, \"lightpink\", 'red', how=how)\n",
+    "    return image\n",
     "\n",
     "p = base_plot()\n",
-    "IPythonKernelCallback(p, create_image, agg_fn=ds.count)"
+    "IPythonKernelCallback(p, create_image, how='linear')"
    ]
   }
  ],

--- a/examples/nyc_taxi.ipynb
+++ b/examples/nyc_taxi.ipynb
@@ -164,8 +164,9 @@
    },
    "outputs": [],
    "source": [
+    "import datashader as ds\n",
     "p = base_plot()\n",
-    "pipeline = DatashaderPipeline(data=df, x=\"pickup_x\", y=\"pickup_y\", agg=\"passenger_count\")\n",
+    "pipeline = DatashaderPipeline(df=df, glyph=ds.Point(\"pickup_x\", \"pickup_y\"), agg=ds.count(\"passenger_count\"))\n",
     "IPythonKernelCallback(p, pipeline)"
    ]
   },
@@ -179,7 +180,7 @@
    "outputs": [],
    "source": [
     "p = base_plot()\n",
-    "pipeline = DatashaderPipeline(data=df,x=\"pickup_x\",y=\"pickup_y\",agg=\"passenger_count\",\n",
+    "pipeline = DatashaderPipeline(df=df, glyph=ds.Point(\"pickup_x\", \"pickup_y\"), agg=ds.count(\"passenger_count\"),\n",
     "                              color_fn=Interpolate(low=\"lightblue\",high=\"blue\"))\n",
     "IPythonKernelCallback(p, pipeline)"
    ]
@@ -190,7 +191,7 @@
     "collapsed": true
    },
    "source": [
-    "## Unpacking the steps involved in the Datashader Pipeline\n",
+    "## Unpacking the steps involved in the Datashader pipeline\n",
     "\n",
     "The above functions use a configurable interface to make it simpler to specify individual bits of a standard scatterplot-like pipeline. If you want, you can do the same process with your own custom code to do whatever you like; anything that results in an image is fine!"
    ]


### PR DESCRIPTION
Adds a configurable pipeline object and examples of using it in the Jupyter notebook.  Should be ready to merge, based on the discussion today, but it would be nice if someone looked at how the agg_fn is specified and think about whether that's the most general way to do it.