### PR TITLE
Fix comparison operators for Axis and Reduction

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -16,6 +16,9 @@ class Axis(object):
                 self.start == other.start and
                 self.end == other.end)
 
+    def __ne__(self, other):
+        return not self == other
+
     def __hash__(self):
         return hash((type(self), self.start, self.end))
 

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -32,6 +32,9 @@ class Expr(object):
     def __eq__(self, other):
         return type(self) is type(other) and self.inputs == other.inputs
 
+    def __ne__(self, other):
+        return not self == other
+
 
 class Preprocess(Expr):
     def __init__(self, column):

--- a/datashader/tests/test_aggregates.py
+++ b/datashader/tests/test_aggregates.py
@@ -14,15 +14,17 @@ import pytest
 
 x_axis = LinearAxis((0, 10))
 y_axis = LinearAxis((1, 5))
+x_axis2 = LinearAxis((0, 10))
+y_axis2 = LinearAxis((1, 5))
 
 a = nd.array([[0, 1, 2], [3, 4, None]], '2 * 3 * ?int64')
 b = nd.array([[2, 2, None], [0, 3, 3]], '2 * 3 * ?float64')
 c = nd.array([True, False, True])
 d = nd.array([True, True, False])
 s_a = ScalarAggregate(a, x_axis=x_axis, y_axis=y_axis)
-s_b = ScalarAggregate(b, x_axis=x_axis, y_axis=y_axis)
+s_b = ScalarAggregate(b, x_axis=x_axis2, y_axis=y_axis2)
 s_c = ScalarAggregate(c, x_axis=x_axis, y_axis=y_axis)
-s_d = ScalarAggregate(d, x_axis=x_axis, y_axis=y_axis)
+s_d = ScalarAggregate(d, x_axis=x_axis2, y_axis=y_axis2)
 
 
 def assert_dynd_eq(a, b, check_dtype=True):


### PR DESCRIPTION
Need to define `__ne__`, otherwise python's default is just to compare with `is`, which can lead to both `a == b` and `a != b` being True.