### PR TITLE
Add conda recipe

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -x
+
+BLD_DIR=`pwd`
+
+SRC_DIR=$RECIPE_DIR/..
+pushd $SRC_DIR
+
+$PYTHON setup.py --quiet install --single-version-externally-managed --record=record.txt
+
+popd
+

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: datashader
+  version: 0.1.0
+
+extra:
+  channels:
+    - blaze
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - dask >=0.7.6
+    - datashape >=0.5.1
+    - numba >=0.23.1
+    - odo >=0.4.2
+    - numpy >=1.7
+    - pandas >=0.15.0
+    - pillow >=3.1.1
+    - xarray >=0.7.0
+    - toolz >=0.7.4
+
+test:
+  requires:
+    - pytest >=2.8.5
+  imports:
+    - datashader
+
+about:
+  home: https://github.com/bokeh/datashader
+  license: New BSD

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -1,0 +1,1 @@
+import datashader; datashader.test()

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-__version__ = '0.0.1'
+__version__ = '0.1.0'
 
 from .core import Canvas
 from .reductions import (count, sum, min, max, mean, std, var, count_cat,
@@ -14,3 +14,11 @@ try:
     from .dask import *
 except ImportError:
     pass
+
+def test():
+    try:
+        import os, pytest
+        pytest.main(os.path.dirname(__file__))
+    except ImportError:
+        import sys
+        sys.stderr.write("You need to install py.test to run tests -- conda install py.test")

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 from setuptools import setup
-import datashader
 
 with open('requirements.txt') as f:
     install_requires = f.read().strip().split('\n')
 
 setup(name='datashader',
-      version=datashader.__version__,
+      version='0.1.0',
       description='Data visualization toolchain based on aggregating into a grid',
       url='http://github.com/bokeh/datashader',
       install_requires=install_requires,
-      packages=['datashader'])
+      packages=['datashader', 'datashader.tests'])


### PR DESCRIPTION
This will automatically run development tests on install, and tests are available as `datashader.test()` as well.