### PR TITLE
Install odo from blaze channel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install dask numba numpy odo pandas pillow pytest toolz xarray
+  - conda install dask numba numpy pandas pillow pytest toolz xarray
   # Need a few fixes to odo and datashape that aren't in the latest release
-  - conda install -c blaze datashape
-  - pip install --upgrade --no-deps git+https://github.com/Blaze/odo
+  - conda install -c blaze datashape odo
 
   - python setup.py develop --no-deps
 


### PR DESCRIPTION
Odo 0.4.2 is now on the blaze channel, install on travis from there.