### PR TITLE
Spreading and compositing operators

### DIFF
--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -1,0 +1,87 @@
+from __future__ import division
+
+import numba as nb
+import numpy as np
+
+
+__all__ = ('composite_op_lookup', 'over', 'add', 'saturate')
+
+
+@nb.jit('(uint32,)', nopython=True, nogil=True)
+def extract_scaled(x):
+    """Extract components as float64 values in [0.0, 1.0]"""
+    r = np.float64((x & 255) / 255)
+    g = np.float64(((x >> 8) & 255) / 255)
+    b = np.float64(((x >> 16) & 255) / 255)
+    a = np.float64(((x >> 24) & 255) / 255)
+    return r, g, b, a
+
+
+@nb.jit('(float64, float64, float64, float64)', nopython=True, nogil=True)
+def combine_scaled(r, g, b, a):
+    """Combine components in [0, 1] to rgba uint32"""
+    r2 = np.uint32(r * 255)
+    g2 = np.uint32(g * 255)
+    b2 = np.uint32(b * 255)
+    a2 = np.uint32(a * 255)
+    return np.uint32((a2 << 24) | (b2 << 16) | (g2 << 8) | r2)
+
+
+extract_scaled.disable_compile()
+combine_scaled.disable_compile()
+
+
+# Lookup table for storing compositing operators by function name
+composite_op_lookup = {}
+
+
+def operator(f):
+    """Define and register a new composite operator"""
+    f = nb.jit('uint32(uint32, uint32)', nopython=True, nogil=True)(f)
+    f.disable_compile()
+    composite_op_lookup[f.__name__] = f
+    return f
+
+
+@operator
+def over(src, dst):
+    sr, sg, sb, sa = extract_scaled(src)
+    dr, dg, db, da = extract_scaled(dst)
+
+    factor = 1 - sa
+    a = sa + da * factor
+    if a == 0:
+        return np.uint32(0)
+    r = (sr * sa + dr * da * factor)/a
+    g = (sg * sa + dg * da * factor)/a
+    b = (sb * sa + db * da * factor)/a
+    return combine_scaled(r, g, b, a)
+
+
+@operator
+def add(src, dst):
+    sr, sg, sb, sa = extract_scaled(src)
+    dr, dg, db, da = extract_scaled(dst)
+
+    a = min(1, sa + da)
+    if a == 0:
+        return np.uint32(0)
+    r = (sr * sa + dr * da)/a
+    g = (sg * sa + dg * da)/a
+    b = (sb * sa + db * da)/a
+    return combine_scaled(r, g, b, a)
+
+
+@operator
+def saturate(src, dst):
+    sr, sg, sb, sa = extract_scaled(src)
+    dr, dg, db, da = extract_scaled(dst)
+
+    a = min(1, sa + da)
+    if a == 0:
+        return np.uint32(0)
+    factor = min(sa, 1 - da)
+    r = (factor * sr + dr * da)/a
+    g = (factor * sg + dg * da)/a
+    b = (factor * sb + db * da)/a
+    return combine_scaled(r, g, b, a)

--- a/datashader/composite.py
+++ b/datashader/composite.py
@@ -4,7 +4,7 @@ import numba as nb
 import numpy as np
 
 
-__all__ = ('composite_op_lookup', 'over', 'add', 'saturate')
+__all__ = ('composite_op_lookup', 'over', 'add', 'saturate', 'source')
 
 
 @nb.jit('(uint32,)', nopython=True, nogil=True, cache=True)
@@ -43,6 +43,14 @@ def operator(f):
     f2._frozen = True
     composite_op_lookup[f.__name__] = f2
     return f2
+
+
+@operator
+def source(src, dst):
+    if src & 0xff000000:
+        return src
+    else:
+        return dst
 
 
 @operator

--- a/datashader/tests/test_composite.py
+++ b/datashader/tests/test_composite.py
@@ -1,0 +1,79 @@
+import numpy as np
+
+from datashader.composite import add, saturate, over
+
+src = np.array([[0x00000000, 0x00ffffff, 0xffffffff],
+                [0x7dff0000, 0x7d00ff00, 0x7d0000ff],
+                [0xffff0000, 0xff000000, 0x3a3b3c3d]], dtype='uint32')
+
+clear = np.uint32(0)
+clear_black = np.uint32(0x00ffffff)
+black = np.uint32(0xffffffff)
+blue = np.uint32(0xffff0000)
+half_blue = np.uint32(0x7dff0000)
+half_purple = np.uint32(0x7d7d007d)
+
+
+def test_over():
+    o = src.copy()
+    o[0, 1] = 0
+    np.testing.assert_equal(over(src, clear), o)
+    np.testing.assert_equal(over(src, clear_black), o)
+    o = np.array([[0xffffffff, 0xffffffff, 0xffffffff],
+                  [0xffff8282, 0xff82ff82, 0xff8282ff],
+                  [0xffff0000, 0xff000000, 0xffd2d2d2]])
+    np.testing.assert_equal(over(src, black), o)
+    o = np.array([[0xffff0000, 0xffff0000, 0xffffffff],
+                  [0xffff0000, 0xff827d00, 0xff82007d],
+                  [0xffff0000, 0xff000000, 0xffd20d0d]])
+    np.testing.assert_equal(over(src, blue), o)
+    o = np.array([[0x7dff0000, 0x7dff0000, 0xffffffff],
+                  [0xbcff0000, 0xbc56a800, 0xbc5600a8],
+                  [0xffff0000, 0xff000000, 0x9ab51616]])
+    np.testing.assert_equal(over(src, half_blue), o)
+    o = np.array([[0x7d7d007d, 0x7d7d007d, 0xffffffff],
+                  [0xbcd3002a, 0xbc2aa82a, 0xbc2a00d3],
+                  [0xffff0000, 0xff000000, 0x9a641664]])
+    np.testing.assert_equal(over(src, half_purple), o)
+
+
+def test_add():
+    o = src.copy()
+    o[0, 1] = 0
+    np.testing.assert_equal(add(src, clear), o)
+    np.testing.assert_equal(add(src, clear_black), o)
+    o = np.array([[0xffffffff, 0xffffffff, 0xfffffffe],
+                  [0xff7cffff, 0xffff7cff, 0xffffff7c],
+                  [0xfffeffff, 0xffffffff, 0xff0d0d0c]])
+    np.testing.assert_equal(add(src, black), o)
+    o = np.array([[0xffff0000, 0xffff0000, 0xfffeffff],
+                  [0xff7c0000, 0xffff7d00, 0xffff007d],
+                  [0xfffe0000, 0xffff0000, 0xff0c0d0d]])
+    np.testing.assert_equal(add(src, blue), o)
+    o = np.array([[0x7dff0000, 0x7dff0000, 0xff7cffff],
+                  [0xfaff0000, 0xfa7f7f00, 0xfa7f007f],
+                  [0xff7c0000, 0xff7d0000, 0xb7c01313]])
+    np.testing.assert_equal(add(src, half_blue), o)
+    o = np.array([[0x7d7d007d, 0x7d7d007d, 0xff3cff3c],
+                  [0xfabe003e, 0xfa3e7f3e, 0xfa3e00be],
+                  [0xff3c003d, 0xff3d003d, 0xb7681368]])
+    np.testing.assert_equal(add(src, half_purple), o)
+
+
+def test_saturate():
+    o = src.copy()
+    o[0, 1] = 0
+    np.testing.assert_equal(saturate(src, clear), o)
+    np.testing.assert_equal(saturate(src, clear_black), o)
+    o = np.full((3, 3), black, dtype='uint32')
+    np.testing.assert_equal(saturate(src, black), o)
+    o = np.full((3, 3), blue, dtype='uint32')
+    np.testing.assert_equal(saturate(src, blue), o)
+    o = np.array([[0x7dff0000, 0x7dff0000, 0xffff8282],
+                  [0xfaff0000, 0xfa7f7f00, 0xfa7f007f],
+                  [0xffff0000, 0xff7d0000, 0xb7c01313]])
+    np.testing.assert_equal(saturate(src, half_blue), o)
+    o = np.array([[0x7d7d007d, 0x7d7d007d, 0xffbf82bf],
+                  [0xfabe003e, 0xfa3e7f3e, 0xfa3e00be],
+                  [0xffbf003d, 0xff3d003d, 0xb7681368]])
+    np.testing.assert_equal(saturate(src, half_purple), o)

--- a/datashader/tests/test_composite.py
+++ b/datashader/tests/test_composite.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from datashader.composite import add, saturate, over
+from datashader.composite import add, saturate, over, source
 
 src = np.array([[0x00000000, 0x00ffffff, 0xffffffff],
                 [0x7dff0000, 0x7d00ff00, 0x7d0000ff],
@@ -12,6 +12,16 @@ black = np.uint32(0xffffffff)
 blue = np.uint32(0xffff0000)
 half_blue = np.uint32(0x7dff0000)
 half_purple = np.uint32(0x7d7d007d)
+
+
+def test_source():
+    o = src.copy()
+    o[0, :2] = clear
+    np.testing.assert_equal(source(src, clear), o)
+    o[0, :2] = clear_black
+    np.testing.assert_equal(source(src, clear_black), o)
+    o[0, :2] = half_blue
+    np.testing.assert_equal(source(src, half_blue), o)
 
 
 def test_over():

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -3,13 +3,16 @@ from __future__ import absolute_import, division, print_function
 from io import BytesIO
 
 import numpy as np
+import numba as nb
 import xarray as xr
 from PIL.Image import fromarray
+from toolz import memoize
 
 from .colors import rgb
+from .composite import composite_op_lookup
 
 
-__all__ = ['Image', 'merge', 'stack', 'interpolate', 'colorize']
+__all__ = ['Image', 'merge', 'stack', 'interpolate', 'colorize', 'spread']
 
 
 class Image(xr.DataArray):
@@ -163,3 +166,144 @@ def colorize(agg, color_key, how='cbrt', min_alpha=20):
     a[white] = 0
     return Image(np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape),
                  dims=agg.dims[:-1], coords=list(agg.coords.values())[:-1])
+
+
+def spread(img, px=1, shape='circle', how='over'):
+    """Spread pixels in an image.
+
+    Spreading expands each pixel a certain number of pixels on all sides
+    according to a given shape, merging pixels using a specified compositing
+    operator. This can be useful to make sparse plots more visible.
+
+    Parameters
+    ----------
+    img : Image
+    px : int, optional
+        Number of pixels to spread on all sides
+    shape : str, optional
+        The shape to spread by. Options are 'circle' [default] or 'square'.
+    how : str, optional
+        The name of the compositing operator to use when combining pixels.
+    """
+    if not isinstance(img, Image):
+        raise TypeError("Expected `Image`, got: `{0}`".format(type(img)))
+    elif not isinstance(px, int) or px < 0:
+        raise ValueError("``px`` must be an integer >= 0")
+    if px == 0:
+        return img
+    mask = _mask_lookup[shape](px)
+    kernel = _build_spread_kernel(how)
+    w = mask.shape[0]
+    extra = w // 2
+    M, N = img.shape
+    buf = np.zeros((M + 2*extra, N + 2*extra), dtype='uint32')
+    kernel(img.data, mask, buf)
+    out = buf[extra:-extra, extra:-extra].copy()
+    return Image(out, dims=img.dims, coords=img.coords)
+
+
+@memoize
+def _build_spread_kernel(how):
+    """Build a spreading kernel for a given composite operator"""
+    op = composite_op_lookup[how]
+
+    @nb.jit(nopython=True, nogil=True)
+    def kernel(arr, mask, out):
+        M, N = arr.shape
+        w = mask.shape[0]
+        for y in range(M):
+            for x in range(N):
+                el = arr[y, x]
+                # Skip if data is transparent
+                if (el >> 24) & 255:
+                    for i in range(w):
+                        for j in range(w):
+                            # Skip if mask is False at this value
+                            if mask[i, j]:
+                                out[i + y, j + x] = op(el, out[i + y, j + x])
+    return kernel
+
+
+def _square_mask(px):
+    """Produce a square mask with sides of length ``2 * px + 1``"""
+    px = int(px)
+    w = 2 * px + 1
+    return np.ones((w, w), dtype='bool')
+
+
+def _circle_mask(r):
+    """Produce a circular mask with a diameter of ``2 * r + 1``"""
+    r = int(r)
+    w = 2 * r + 1
+    mask = np.zeros((w, w), dtype='bool')
+    _fill_circle(mask, r, r, r, True)
+    return mask
+
+
+_mask_lookup = {'square': _square_mask,
+                'circle': _circle_mask}
+
+
+@nb.jit(nopython=True, nogil=True)
+def _fill_circle(arr, x0, y0, r, val):
+    """General circle filling routine.
+
+    Low level, no bounds checking performed. Has potential to segfault if
+    misused.
+
+    Parameters
+    ----------
+    arr : 2d array
+    x0, y0 : int
+        Center coordinates of the circle.
+    r : int
+        Circle radius in pixels. Note that this excludes the center pixel - the
+        resulting circle will be ``2 * r + 1`` pixels in diameter.
+    val : scalar
+        Fill value
+    """
+    x = r
+    y = 0
+    do2 = 1 - x
+
+    # Special cases for r == 0 (fastpath) and r == 1. The normal algorithm will
+    # draw a 3x3 grid for this case, but a "+" looks a bit better in my opinion
+    if r == 0:
+        arr[y0, x0] = 1
+        return
+    elif r == 1:
+        _fill_span(arr, y0, x0 - 1, x0 + 1, val)
+        arr[y0 + 1, x0] = arr[y0 - 1, x0] = val
+        return
+    # Determine width
+    while y <= x:
+        y += 1
+        if do2 <= 0:
+            do2 += 2 * y + 1
+        else:
+            x -= 1
+            do2 += 2 * (y - x) + 1
+            break
+    width = y - 1
+    # Fill in spans
+    _fill_span(arr, y0 + r, x0 - width, x0 + width, val)
+    _fill_span(arr, y0 - r, x0 - width, x0 + width, val)
+    for row in range(-width, width + 1):
+        _fill_span(arr, y0 + row, x0 - r, x0 + r, val)
+    # Fill in remainder
+    while y < r:
+        _fill_span(arr, y0 + y, x0 - x, x0 + x, val)
+        _fill_span(arr, y0 - y, x0 - x, x0 + x, val)
+        y += 1
+        if do2 <= 0:
+            do2 += 2 * y + 1
+        else:
+            x -= 1
+            do2 += 2 * (y - x) + 1
+
+
+@nb.jit(nopython=True, nogil=True)
+def _fill_span(arr, y, l, r, val):
+    """Fill a horizontal span with ``val``"""
+    for i in range(l, r + 1):
+        arr[y, i] = val

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -45,7 +45,7 @@ Transfer Functions
    interpolate
    colorize
    stack
-   merge
+   spread
 
 Definitions
 -----------


### PR DESCRIPTION
- Adds compositing operators from Porter/Duff paper, used for merging multiple pixels into a single value
- Adds spreading function for spreading pixels in a shape. This is useful for making sparse images more visible.

Todo:

- [x] Tests
- [x] Fix merge/stack to use compositing operators
- [x] Docs