### PR TITLE
[WIP] Add line glyph

### DIFF
--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 __version__ = '0.1.0'
 
 from .core import Canvas
-from .reductions import (count, sum, min, max, mean, std, var, count_cat,
+from .reductions import (count, any, sum, min, max, mean, std, var, count_cat,
                          summary)
 from .glyphs import Point
 from .pipeline import Pipeline

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -163,12 +163,12 @@ class Canvas(object):
         x, y : str
             Column names for the x and y coordinates of each vertex.
         agg : Reduction, optional
-            Reduction to compute. Default is ``count()``.
+            Reduction to compute. Default is ``any()``.
         """
         from .glyphs import Line
-        from .reductions import count
+        from .reductions import any
         if agg is None:
-            agg = count()
+            agg = any()
         return bypixel(source, self, Line(x, y), agg)
 
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -129,6 +129,8 @@ class Canvas(object):
         ----------
         source : pandas.DataFrame, dask.DataFrame
             The input datasource.
+        x, y : str
+            Column names for the x and y coordinates of each point.
         x : str
             Column name for the point x coordinates.
         y : str
@@ -158,10 +160,8 @@ class Canvas(object):
         ----------
         source : pandas.DataFrame, dask.DataFrame
             The input datasource.
-        x : str
-            Column name for the point x coordinates.
-        y : str
-            Column name for the point y coordinates.
+        x, y : str
+            Column names for the x and y coordinates of each vertex.
         agg : Reduction, optional
             Reduction to compute. Default is ``count()``.
         """

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -142,6 +142,35 @@ class Canvas(object):
             agg = count()
         return bypixel(source, self, Point(x, y), agg)
 
+    def line(self, source, x, y, agg=None):
+        """Compute a reduction by pixel, mapping data to pixels as a line.
+
+        For aggregates that take in extra fields, the interpolated bins will
+        receive the fields from the previous point. In pseudocode:
+
+        >>> for i in range(len(rows) - 1):    # doctest: +SKIP
+        ...     row0 = rows[i]
+        ...     row1 = rows[i + 1]
+        ...     for xi, yi in interpolate(row0.x, row0.y, row1.x, row1.y):
+        ...         add_to_aggregate(xi, yi, row0)
+
+        Parameters
+        ----------
+        source : pandas.DataFrame, dask.DataFrame
+            The input datasource.
+        x : str
+            Column name for the point x coordinates.
+        y : str
+            Column name for the point y coordinates.
+        agg : Reduction, optional
+            Reduction to compute. Default is ``count()``.
+        """
+        from .glyphs import Line
+        from .reductions import count
+        if agg is None:
+            agg = count()
+        return bypixel(source, self, Line(x, y), agg)
+
 
 def bypixel(source, canvas, glyph, agg):
     """Compute an aggregate grouped by pixel sized bins.

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -3,22 +3,29 @@ from __future__ import absolute_import, division
 import dask.dataframe as dd
 from dask.base import tokenize, compute
 from dask.context import _globals
+import pandas as pd
 
 from .core import bypixel
 from .compatibility import apply
 from .compiler import compile_components
+from .glyphs import Glyph, Line
+from .utils import Dispatcher
 
 __all__ = ()
 
 
 @bypixel.pipeline.register(dd.DataFrame)
 def dask_pipeline(df, schema, canvas, glyph, summary):
-    create, info, append, combine, finalize = compile_components(summary,
-                                                                 schema)
-    x_mapper = canvas.x_axis.mapper
-    y_mapper = canvas.y_axis.mapper
-    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
+    dsk, name = glyph_dispatch(glyph, df, schema, canvas, summary)
 
+    get = _globals['get'] or df._default_get
+    dsk.update(df.dask)
+    dsk = df._optimize(dsk, name)
+
+    return get(dsk, name)
+
+
+def shape_bounds_st_and_axis(df, canvas, glyph):
     x_range = canvas.x_range or glyph._compute_x_bounds(df)
     y_range = canvas.y_range or glyph._compute_y_bounds(df)
     x_min, x_max, y_min, y_max = bounds = compute(*(x_range + y_range))
@@ -33,6 +40,24 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
 
     x_axis = canvas.x_axis.compute_index(x_st, width)
     y_axis = canvas.y_axis.compute_index(y_st, height)
+    axis = [y_axis, x_axis]
+
+    return shape, bounds, st, axis
+
+
+glyph_dispatch = Dispatcher()
+
+
+@glyph_dispatch.register(Glyph)
+def default(glyph, df, schema, canvas, summary):
+    shape, bounds, st, axis = shape_bounds_st_and_axis(df, canvas, glyph)
+
+    # Compile functions
+    create, info, append, combine, finalize = compile_components(summary,
+                                                                 schema)
+    x_mapper = canvas.x_axis.mapper
+    y_mapper = canvas.y_axis.mapper
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
     def chunk(df):
         aggs = create(shape)
@@ -44,10 +69,36 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
     keys2 = [(name, i) for i in range(len(keys))]
     dsk = dict((k2, (chunk, k)) for (k2, k) in zip(keys2, keys))
     dsk[name] = (apply, finalize, [(combine, keys2)],
-                 dict(coords=[y_axis, x_axis], dims=['y_axis', 'x_axis']))
-    dsk.update(df.dask)
-    dsk = df._optimize(dsk, name)
+                 dict(coords=axis, dims=['y_axis', 'x_axis']))
+    return dsk, name
 
-    get = _globals['get'] or df._default_get
 
-    return get(dsk, name)
+@glyph_dispatch.register(Line)
+def line(glyph, df, schema, canvas, summary):
+    shape, bounds, st, axis = shape_bounds_st_and_axis(df, canvas, glyph)
+
+    # Compile functions
+    create, info, append, combine, finalize = compile_components(summary,
+                                                                 schema)
+    x_mapper = canvas.x_axis.mapper
+    y_mapper = canvas.y_axis.mapper
+    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
+
+    def chunk(df, df2=None):
+        plot_start = True
+        if df2 is not None:
+            df = pd.concat([df.iloc[-1:], df2])
+            plot_start = False
+        aggs = create(shape)
+        extend(aggs, df, st, bounds, plot_start=plot_start)
+        return aggs
+
+    name = tokenize(df._name, canvas, glyph, summary)
+    old_name = df._name
+    dsk = {(name, 0): (chunk, (old_name, 0))}
+    for i in range(1, df.npartitions):
+        dsk[(name, i)] = (chunk, (old_name, i - 1), (old_name, i))
+    keys2 = [(name, i) for i in range(df.npartitions)]
+    dsk[name] = (apply, finalize, [(combine, keys2)],
+                 dict(coords=axis, dims=['y_axis', 'x_axis']))
+    return dsk, name

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -20,7 +20,7 @@ class Point(Glyph):
     Parameters
     ----------
     x, y : str
-        Column names for the x and y coordinates of center of each point.
+        Column names for the x and y coordinates of each point.
     """
     def __init__(self, x, y):
         self.x = x
@@ -70,12 +70,12 @@ class Point(Glyph):
 
 
 class Line(Glyph):
-    """A point, with points defined by ``x`` and ``y``.
+    """A line, with vertices defined by ``x`` and ``y``.
 
     Parameters
     ----------
     x, y : str
-        Column names for the x and y coordinates of center of each point.
+        Column names for the x and y coordinates of each vertex.
     """
     def __init__(self, x, y):
         self.x = x

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 
 from toolz import memoize
+import numpy as np
 
 from .core import Expr
 from .utils import ngjit, isreal
@@ -66,3 +67,182 @@ class Point(Glyph):
 
     def _compute_y_bounds(self, df):
         return df[self.y].min(), df[self.y].max()
+
+
+class Line(Glyph):
+    """A point, with points defined by ``x`` and ``y``.
+
+    Parameters
+    ----------
+    x, y : str
+        Column names for the x and y coordinates of center of each point.
+    """
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    @property
+    def inputs(self):
+        return (self.x, self.y)
+
+    def validate(self, in_dshape):
+        if not isreal(in_dshape.measure[self.x]):
+            raise ValueError('x must be real')
+        elif not isreal(in_dshape.measure[self.y]):
+            raise ValueError('y must be real')
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        _extend = _build_line_kernel(append, x_mapper, y_mapper)
+        x_name = self.x
+        y_name = self.y
+
+        def extend(aggs, df, vt, bounds):
+            xs = df[x_name].values
+            ys = df[y_name].values
+            cols = aggs + info(df)
+            _extend(vt, bounds, xs, ys, *cols)
+
+        return extend
+
+    def _compute_x_bounds(self, df):
+        return df[self.x].min(), df[self.x].max()
+
+    def _compute_y_bounds(self, df):
+        return df[self.y].min(), df[self.y].max()
+
+
+# Outcode constants
+INSIDE = 0b0000
+LEFT = 0b0001
+RIGHT = 0b0010
+BOTTOM = 0b0100
+TOP = 0b1000
+
+
+@ngjit
+def _compute_outcode(x, y, xmin, xmax, ymin, ymax):
+    code = INSIDE
+
+    if x < xmin:
+        code |= LEFT
+    elif x > xmax:
+        code |= RIGHT
+    if y < ymin:
+        code |= BOTTOM
+    elif y > ymax:
+        code |= TOP
+    return code
+
+
+def _build_line_kernel(append, x_mapper, y_mapper):
+    """Specialize a line plotting kernel for a given append/axis combination"""
+    @ngjit
+    def draw_line(vt, bounds, x0, y0, x1, y1, lastx, lasty, i, *aggs_and_cols):
+        """Draw a line using bresenham's algorithm"""
+        sx, tx, sy, ty = vt
+        # Project to pixel space
+        x0i = int(x_mapper(x0) * sx + tx)
+        y0i = int(y_mapper(y0) * sy + ty)
+        x1i = int(x_mapper(x1) * sx + tx)
+        y1i = int(y_mapper(y1) * sy + ty)
+
+        dx = x1i - x0i
+        ix = (dx > 0) - (dx < 0)
+        dx = abs(dx) * 2
+
+        dy = y1i - y0i
+        iy = (dy > 0) - (dy < 0)
+        dy = abs(dy) * 2
+
+        if lastx != x0i or lasty != y0i:
+            append(i, x0i, y0i, *aggs_and_cols)
+        elif lastx == x1i and lasty == y1i:
+            return (lastx, lasty)
+
+        if dx >= dy:
+            error = 2*dy - dx
+            while x0i != x1i:
+                if error >= 0 and (error or ix > 0):
+                    error -= 2 * dx
+                    y0i += iy
+                error += 2 * dy
+                x0i += ix
+                append(i, x0i, y0i, *aggs_and_cols)
+        else:
+            error = 2*dx - dy
+            while y0i != y1i:
+                if error >= 0 and (error or iy > 0):
+                    error -= 2 * dy
+                    x0i += ix
+                error += 2 * dx
+                y0i += iy
+                append(i, x0i, y0i, *aggs_and_cols)
+        return (x0i, y0i)
+
+    @ngjit
+    def extend_lines(vt, bounds, xs, ys, *aggs_and_cols):
+        """Aggregate along a line formed by ``xs`` and ``ys``"""
+        sx, tx, sy, ty = vt
+        xmin, xmax, ymin, ymax = bounds
+        # These track the last pixel coordinate appended to, allowing us to
+        # debounce on duplicate pixels.
+        lastx = lasty = -1
+        nrows = xs.shape[0]
+        i = 0
+        while i < nrows - 1:
+            x0 = xs[i]
+            y0 = ys[i]
+            x1 = xs[i + 1]
+            y1 = ys[i + 1]
+            # If any of the coordinates are NaN, there's a discontinuity. Skip
+            # the entire segment.
+            if np.isnan(x0) or np.isnan(y0) or np.isnan(x1) or np.isnan(y1):
+                i += 2
+                lastx = lasty = -1
+                continue
+
+            # Use Cohen-Sutherland to clip the segment to a bounding box
+            # This is pretty much taken verbatim from Wikipedia:
+            # https://en.wikipedia.org/wiki/Cohen%E2%80%93Sutherland_algorithm
+            outcode0 = _compute_outcode(x0, y0, xmin, xmax, ymin, ymax)
+            outcode1 = _compute_outcode(x1, y1, xmin, xmax, ymin, ymax)
+
+            accept = False
+
+            while True:
+                if not (outcode0 | outcode1):
+                    accept = True
+                    break
+                elif outcode0 & outcode1:
+                    break
+                else:
+                    outcode_out = outcode0 if outcode0 else outcode1
+                    if outcode_out & TOP:
+                        x = x0 + (x1 - x0) * (ymax - y0) / (y1 - y0)
+                        y = ymax
+                    elif outcode_out & BOTTOM:
+                        x = x0 + (x1 - x0) * (ymin - y0) / (y1 - y0)
+                        y = ymin
+                    elif outcode_out & RIGHT:
+                        y = y0 + (y1 - y0) * (xmax - x0) / (x1 - x0)
+                        x = xmax
+                    elif outcode_out & LEFT:
+                        y = y0 + (y1 - y0) * (xmin - x0) / (x1 - x0)
+                        x = xmin
+
+                    if outcode_out == outcode0:
+                        x0, y0 = x, y
+                        outcode0 = _compute_outcode(x0, y0, xmin, xmax,
+                                                    ymin, ymax)
+                    else:
+                        x1, y1 = x, y
+                        outcode1 = _compute_outcode(x1, y1, xmin, xmax,
+                                                    ymin, ymax)
+
+            if accept:
+                lastx, lasty = draw_line(vt, bounds, x0, y0, x1, y1, lastx,
+                                         lasty, i, *aggs_and_cols)
+            i += 1
+
+    return extend_lines

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -121,7 +121,7 @@ class count(OptionalFieldReduction):
 
 
 class any(OptionalFieldReduction):
-    """Whether any elements in column map to each bin.
+    """Whether any elements in ``column`` map to each bin.
 
     Parameters
     ----------

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -17,6 +17,7 @@ df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                    'i64': np.arange(20, dtype='i8'),
                    'f32': np.arange(20, dtype='f4'),
                    'f64': np.arange(20, dtype='f8'),
+                   'empty_bin': np.array([0.] * 15 + [np.nan] * 5),
                    'cat': ['a']*5 + ['b']*5 + ['c']*5 + ['d']*5})
 df.cat = df.cat.astype('category')
 df.f32[2] = np.nan
@@ -50,6 +51,17 @@ def test_count():
                        coords=coords, dims=dims)
     assert_eq(c.points(ddf, 'x', 'y', ds.count('f32')), out)
     assert_eq(c.points(ddf, 'x', 'y', ds.count('f64')), out)
+
+
+def test_any():
+    out = xr.DataArray(np.array([[True, True], [True, True]]),
+                       coords=coords, dims=dims)
+    assert_eq(c.points(df, 'x', 'y', ds.any('i64')), out)
+    assert_eq(c.points(df, 'x', 'y', ds.any('f64')), out)
+    assert_eq(c.points(df, 'x', 'y', ds.any()), out)
+    out = xr.DataArray(np.array([[True, True], [True, False]]),
+                       coords=coords, dims=dims)
+    assert_eq(c.points(df, 'x', 'y', ds.any('empty_bin')), out)
 
 
 def test_sum():

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -162,3 +162,22 @@ def test_log_axis():
     out = xr.DataArray(sol, coords=[np.array([1., 10.]), np.array([1., 10.])],
                        dims=dims)
     assert_eq(c_logxy.points(ddf, 'log_x', 'log_y', ds.count('i32')), out)
+
+
+def test_line():
+    df = pd.DataFrame({'x': [4, 0, -4, -3, -2, -1.9, 0, 10, 10, 0, 4],
+                       'y': [0, -4, 0, 1, 2, 2.1, 4, 20, 30, 4, 0]})
+    ddf = dd.from_pandas(df, npartitions=3)
+    cvs = ds.Canvas(plot_width=7, plot_height=7,
+                    x_range=(-3, 3), y_range=(-3, 3))
+    agg = cvs.line(ddf, 'x', 'y', ds.count())
+    sol = np.array([[0, 0, 1, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 1, 0],
+                    [1, 0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0, 1],
+                    [0, 2, 0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
+    out = xr.DataArray(sol, coords=[np.arange(-3, 4), np.arange(-3, 4)],
+                       dims=['y_axis', 'x_axis'])
+    assert_eq(agg, out)

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -1,8 +1,10 @@
 from datashape import dshape
 import pandas as pd
+import numpy as np
 import pytest
 
-from datashader.glyphs import Point
+from datashader.glyphs import Point, _build_draw_line, _build_extend_line
+from datashader.utils import ngjit
 
 
 def test_point_bounds_check():
@@ -17,3 +19,149 @@ def test_point_validate():
     p.validate(dshape("{x: int32, y: float32}"))
     with pytest.raises(ValueError):
         p.validate(dshape("{x: string, y: float32}"))
+
+
+@ngjit
+def append(i, x, y, agg):
+    agg[y, x] += 1
+
+
+def new_agg():
+    return np.zeros((5, 5), dtype='i4')
+
+
+mapper = ngjit(lambda x: x)
+draw_line = _build_draw_line(append, mapper, mapper)
+extend_line = _build_extend_line(draw_line)
+
+bounds = (-3, 1, -3, 1)
+vt = (1., 3., 1., 3.)
+
+
+def test_draw_line():
+    x0, y0 = (-3, -3)
+    x1, y1 = (0, 0)
+    out = np.array([[1, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 0],
+                    [0, 0, 0, 0, 0]])
+    agg = new_agg()
+    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
+    np.testing.assert_equal(agg, out)
+    agg = new_agg()
+    draw_line(vt, bounds, x1, y1, x0, y0, 0, True, False, agg)
+    np.testing.assert_equal(agg, out)
+    # plot_start = False
+    agg = new_agg()
+    draw_line(vt, bounds, x0, y0, x1, y1, 0, False, False, agg)
+    out[0, 0] = 0
+    np.testing.assert_equal(agg, out)
+    agg = new_agg()
+    draw_line(vt, bounds, x1, y1, x0, y0, 0, False, False, agg)
+    out[0, 0] = 1
+    out[3, 3] = 0
+    np.testing.assert_equal(agg, out)
+    # Flip coords
+    x0, y0 = (-3, 1)
+    x1, y1 = (0, -2)
+    out = np.array([[0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0],
+                    [1, 0, 0, 0, 0]])
+    agg = new_agg()
+    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
+    np.testing.assert_equal(agg, out)
+    agg = new_agg()
+    draw_line(vt, bounds, x1, y1, x0, y0, 0, True, False, agg)
+    np.testing.assert_equal(agg, out)
+    # plot_start = False
+    agg = new_agg()
+    draw_line(vt, bounds, x0, y0, x1, y1, 0, False, False, agg)
+    out[4, 0] = 0
+    np.testing.assert_equal(agg, out)
+    agg = new_agg()
+    draw_line(vt, bounds, x1, y1, x0, y0, 0, False, False, agg)
+    out[4, 0] = 1
+    out[1, 3] = 0
+
+
+def test_draw_line_same_point():
+    x0, y0 = (0, 0)
+    x1, y1 = (0.1, 0.1)
+    agg = new_agg()
+    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
+    assert agg.sum() == 2
+    assert agg[3, 3] == 2
+    agg = new_agg()
+    draw_line(vt, bounds, x0, y0, x1, y1, 0, False, False, agg)
+    assert agg.sum() == 1
+    assert agg[3, 3] == 1
+    agg = new_agg()
+    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, True, agg)
+    assert agg.sum() == 1
+    assert agg[3, 3] == 1
+
+
+def test_draw_line_vertical_horizontal():
+    # Vertical
+    x0, y0 = (0, 0)
+    x1, y1 = (0, -3)
+    agg = new_agg()
+    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
+    out = new_agg()
+    out[:4, 3] = 1
+    np.testing.assert_equal(agg, out)
+    # Horizontal
+    agg = new_agg()
+    draw_line(vt, bounds, y0, x0, y1, x1, 0, True, False, agg)
+    out = new_agg()
+    out[3, :4] = 1
+    np.testing.assert_equal(agg, out)
+
+
+def test_extend_lines():
+    xs = np.array([0, -2, -2, 0, 0])
+    ys = np.array([-1,  -1,  1.1, 1.1, -1])
+    out = np.array([[0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 1, 0, 1, 0],
+                    [0, 1, 0, 1, 0]])
+    agg = new_agg()
+    extend_line(vt, bounds, xs, ys, False, agg)
+    np.testing.assert_equal(agg, out)
+    # plot_start = True
+    out[2, 3] += 1
+    agg = new_agg()
+    extend_line(vt, bounds, xs, ys, True, agg)
+    np.testing.assert_equal(agg, out)
+
+    xs = np.array([2, 1, 0, -1, -4, -1, -100, -1, 2])
+    ys = np.array([-1, -2, -3, -4, -1, 2, 100, 2, -1])
+    out = np.array([[0, 1, 0, 1, 0],
+                    [1, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 1],
+                    [0, 1, 0, 1, 0]])
+    agg = new_agg()
+    extend_line(vt, bounds, xs, ys, True, agg)
+    np.testing.assert_equal(agg, out)
+
+
+def test_extend_lines_all_out_of_bounds():
+    xs = np.array([-100, -200, -100])
+    ys = np.array([0, 0, 1])
+    agg = new_agg()
+    extend_line(vt, bounds, xs, ys, True, agg)
+    assert agg.sum() == 0
+
+
+def test_extend_lines_nan():
+    xs = np.array([-3, -2, np.nan, 0, 1])
+    ys = np.array([-3, -2, np.nan, 0, 1])
+    agg = new_agg()
+    extend_line(vt, bounds, xs, ys, True, agg)
+    out = np.diag([1, 1, 0, 1, 1])
+    np.testing.assert_equal(agg, out)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -13,6 +13,7 @@ df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                    'i64': np.arange(20, dtype='i8'),
                    'f32': np.arange(20, dtype='f4'),
                    'f64': np.arange(20, dtype='f8'),
+                   'empty_bin': np.array([0.] * 15 + [np.nan] * 5),
                    'cat': ['a']*5 + ['b']*5 + ['c']*5 + ['d']*5})
 df.cat = df.cat.astype('category')
 df.f32[2] = np.nan
@@ -44,6 +45,17 @@ def test_count():
                        coords=coords, dims=dims)
     assert_eq(c.points(df, 'x', 'y', ds.count('f32')), out)
     assert_eq(c.points(df, 'x', 'y', ds.count('f64')), out)
+
+
+def test_any():
+    out = xr.DataArray(np.array([[True, True], [True, True]]),
+                       coords=coords, dims=dims)
+    assert_eq(c.points(df, 'x', 'y', ds.any('i64')), out)
+    assert_eq(c.points(df, 'x', 'y', ds.any('f64')), out)
+    assert_eq(c.points(df, 'x', 'y', ds.any()), out)
+    out = xr.DataArray(np.array([[True, True], [True, False]]),
+                       coords=coords, dims=dims)
+    assert_eq(c.points(df, 'x', 'y', ds.any('empty_bin')), out)
 
 
 def test_sum():

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -156,3 +156,21 @@ def test_log_axis():
     out = xr.DataArray(sol, coords=[np.array([1., 10.]), np.array([1., 10.])],
                        dims=dims)
     assert_eq(c_logxy.points(df, 'log_x', 'log_y', ds.count('i32')), out)
+
+
+def test_line():
+    df = pd.DataFrame({'x': [4, 0, -4, -3, -2, -1.9, 0, 10, 10, 0, 4],
+                       'y': [0, -4, 0, 1, 2, 2.1, 4, 20, 30, 4, 0]})
+    cvs = ds.Canvas(plot_width=7, plot_height=7,
+                    x_range=(-3, 3), y_range=(-3, 3))
+    agg = cvs.line(df, 'x', 'y', ds.count())
+    sol = np.array([[0, 0, 1, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 1, 0],
+                    [1, 0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0, 1],
+                    [0, 2, 0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
+    out = xr.DataArray(sol, coords=[np.arange(-3, 4), np.arange(-3, 4)],
+                       dims=['y_axis', 'x_axis'])
+    assert_eq(agg, out)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,6 +17,7 @@ Glyphs
 .. autosummary::
 
    Point
+   Line
 
 Reductions
 ----------
@@ -25,6 +26,7 @@ Reductions
 .. autosummary::
 
    count
+   any
    sum
    min
    max
@@ -54,10 +56,11 @@ Definitions
 
 .. currentmodule:: datashader.glyphs
 .. autoclass:: Point
+.. autoclass:: Line
 
 .. currentmodule:: datashader.reductions
 .. autoclass:: count
-   :no-inherited-members:
+.. autoclass:: any
 .. autoclass:: sum
 .. autoclass:: min
 .. autoclass:: max


### PR DESCRIPTION
This adds a basic implementation of a line glyph. Lines are represented as a `(x, y)` column pair, similar to points. Consecutive rows are joined by line segments between points. Determining proper aggregate behavior is a bit tricky. For now, the following behavior is used:
- If multiple *consecutive* rows map to the same pixel, only the first row is appended to the aggregate.
- Bins that are incremented by interpolating between two points receive the first point's fields (effectively a zero-order-hold approximation of the underlying data)
- Rows that have `nan` for a coordinate are treated as a discontinuity and skipped.

Algorithmic details
- Cohen-Sutherland is used to clip line segments to within the bounding box
- Bresenhams is used to perform the line interpolation.

Both have been mildly optimized, and perform well enough on my laptop (although will never reach the speed of points, as we're doing more work).

Todo:

- [x] Tests
- [x] Parallelize with dask. Currently, using with dask will result in gaps between dataframe chunks