### PR TITLE
InteractiveImage Improvements

### DIFF
--- a/datashader/callbacks.py
+++ b/datashader/callbacks.py
@@ -1,6 +1,10 @@
-import uuid, json
+import uuid
 
-from bokeh.core.json_encoder import serialize_json
+try:
+    import ujson as json
+except:
+    import json
+
 from bokeh.embed import notebook_div
 from bokeh.document import Document
 from bokeh.models import CustomJS, ColumnDataSource
@@ -64,7 +68,7 @@ class InteractiveImage(object):
 
     _callbacks = {}
 
-    def __init__(self, bokeh_plot, callback, throttle=250, **kwargs):
+    def __init__(self, bokeh_plot, callback, throttle=200, **kwargs):
         """
         The callback function should have the signature:
 
@@ -158,11 +162,13 @@ class InteractiveImage(object):
         """
         Generate an update event json message.
         """
-        return serialize_json({'events': [{'attr': u'data',
-                                           'kind': 'ModelChanged',
-                                           'model': self.ds.ref,
-                                           'new': self.ds.data}],
-                               'references': []})
+        data = dict(self.ds.data)
+        data['image'] = [data['image'][0].tolist()]
+        return json.dumps({'events': [{'attr': u'data',
+                                       'kind': 'ModelChanged',
+                                       'model': self.ds.ref,
+                                       'new': data}],
+                           'references': []})
 
 
     def update_image(self, ranges):

--- a/datashader/callbacks.py
+++ b/datashader/callbacks.py
@@ -15,7 +15,8 @@ from bokeh.util.notebook import get_comms
 
 class InteractiveImage(object):
     """
-    Bokeh-based interactive image object that updates on pan/zoom events.
+    Bokeh-based interactive image object that updates on pan/zoom
+    events.
 
     Given a Bokeh plot and a callback function, calls the function
     whenever the pan or zoom changes the plot's extent, regenerating
@@ -23,6 +24,24 @@ class InteractiveImage(object):
     using the existing notebook kernel Python process (not a separate
     Bokeh server).  Does not yet support usage outside the notebook,
     but could be extened to use Bokeh server in that case.
+
+    Parameters
+    ----------
+    bokeh_plot : plot or figure
+        Bokeh plot the image will be drawn on
+    callback : function
+        Python callback function with the signature::
+
+           fn(x_range=(xmin, xmax), y_range=(ymin, ymax),
+              w, h, **kwargs)
+
+        and returning a PIL image object.
+    throttle : int
+        The throttle parameter specifies how frequently events
+        are generated in milliseconds.
+    **kwargs
+        Any kwargs provided here will be passed to the callback
+        function.
     """
 
     jscode="""
@@ -69,19 +88,6 @@ class InteractiveImage(object):
     _callbacks = {}
 
     def __init__(self, bokeh_plot, callback, throttle=200, **kwargs):
-        """
-        The callback function should have the signature:
-
-        fn(x_range=(xmin, xmax), y_range=(ymin, ymax), w, h, **kwargs)
-
-        and return a PIL image object.  Any kwargs provided here will
-        be passed to the callback each time.
-
-        The throttle parameter allows control over how many times the
-        callback will get executed when there are frequent closely
-        spaced events.
-        """
-
         self.p = bokeh_plot
         self.callback = callback
         self.kwargs = kwargs
@@ -148,6 +154,12 @@ class InteractiveImage(object):
         Update the image datasource based on the new ranges,
         serialize the data to JSON and send to notebook via
         a new or existing notebook comms handle.
+
+        Parameters
+        ----------
+        ranges : dict(xmin=float, xmax=float, ymin=float, ymax=float,
+                      h=int, w=int)
+            Dictionary with of x/y-ranges, width and height.
         """
         if not self.comms_handle:
             self.comms_handle = _CommsHandle(get_comms(self.ref), self.doc,


### PR DESCRIPTION
This PR refactors ``InteractiveImage`` initialization into separate methods and changes how the events sent back to BokehJS are generated resulting in a considerable speedup. Rather than having to debounce events until you stop interacting with the plot it is now responsive enough on the NYC example that a simple throttle set to about ~250 ms let's you pan and zoom fairly fluidly. For larger datasets it may well be too slow again so maybe letting the user toggle between debouncing and simple throttling would be nice.

The performance boost comes from generating a model update event directly rather than converting the entire document to json and then computing a patch for only the changed bits (which should only ever have been the datasource anyway). I do think this is the right approach to show off datashader in the notebook, but it's not a general solution to update plots.

I also promised some unit tests at some point, so I'll add some to this PR in the next few days.