### PR TITLE
Improved InteractiveImage throttling behavior

### DIFF
--- a/datashader/callbacks.py
+++ b/datashader/callbacks.py
@@ -78,7 +78,8 @@ class InteractiveImage(object):
         if (throttled_cb) {{
             throttled_cb()
         }} else {{
-            Bokeh._throttle['{ref}'] = _.throttle(update_plot, {throttle});
+            Bokeh._throttle['{ref}'] = _.throttle(update_plot, {throttle},
+                                                  {{leading: false}});
             Bokeh._throttle['{ref}']()
         }}
     """


### PR DESCRIPTION
Disables the leading edge event when interacting with the an InteractiveImage, so the plot isn't unnecessarily updated when the user has just started panning or zooming.