### PR TITLE
Dashboard fixes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,8 +8,8 @@ good network connection. The dataset is roughly 1.5 GB on disk.
 python download_sample_data.py
 ```
 
-The examples also require bokeh to be installed. Bokeh is available through
-either conda or pip.
+Datashader is an independent library, but most of the examples require
+bokeh to be installed. Bokeh is available through either conda or pip:
 
 ```
 conda install bokeh
@@ -20,16 +20,6 @@ pip install bokeh
 ```
 
 ## Examples
-
-### Dashboard
-
-An example interactive dashboard using [bokeh
-server](http://bokeh.pydata.org/en/latest/docs/user_guide/server.html)
-integrated with a datashading pipeline. To start, run:
-
-```
-python dashboard/dashboard.py --config dashboard/nyc_taxi.yml
-```
 
 ### Notebooks
 
@@ -74,3 +64,52 @@ map](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). This
 dataset isn't provided by the download script, and is only included to
 demonstrate working with a large dataset. The run notebook can be viewed using
 the `anaconda.org` link provided above.
+
+
+
+### Dashboard
+
+An example interactive dashboard using 
+[bokeh server](http://bokeh.pydata.org/en/latest/docs/user_guide/server.html)
+integrated with a datashading pipeline.  Requires webargs:
+
+```
+pip install webargs
+```
+
+To start, run:
+
+```
+python dashboard/dashboard.py -c dashboard/nyc_taxi.yml
+```
+
+The 'nyc_taxi.yml' configuration file set up the dashboard to use the
+NYC Taxi dataset downloaded above.  If you have less than 16GB of RAM
+on your machine, you will want to add the "-o" option to tell it to work
+out of core instead of loading all data into memory, though doing so will
+make interactive use substantially slower than if sufficient memory were
+available.
+
+You can write similar configuration files for working with other
+datasets of your own, while adding features to dashboard.py itself if
+needed.  As an example, a configuration file for the [2010 US Census
+racial data](http://www.coopercenter.org/demographics/Racial-Dot-Map)
+is also provided.  To use the census data, you'll need to install dask
+and castra:
+
+```
+conda install dask
+conda install -c quanyuan castra
+```
+
+You'll also need to download the 1.3GB data file
+[census.castra.zip]()
+and unzip it into `examples/data/` (5GB unzipped), then run the
+dashboard:
+
+```
+python dashboard/dashboard.py -c dashboard/census.yml
+```
+
+If you have other dashboards running, you'll need to add "-p 5001" (etc.) to select
+a unique port number for the web page to use for communicating with the Bokeh server.

--- a/examples/dashboard/census.yml
+++ b/examples/dashboard/census.yml
@@ -1,0 +1,30 @@
+---
+
+file: ../data/census.castra
+
+initial_extent:
+  is_geo: true
+  xmin: -13914936
+  ymin: 2632019
+  xmax: -7235767
+  ymax: 6446276
+
+axes: 
+  - name: US Census Synthetic people
+    xaxis: meterswest
+    yaxis: metersnorth
+
+summary_fields:
+  - name: Counts
+    field: None
+
+  - name: Race
+    field: race
+    cat_colors: race_colors
+
+race_colors:
+  w: blue
+  b: green
+  a: red
+  h: orange
+  o: saddlebrown

--- a/examples/dashboard/census.yml
+++ b/examples/dashboard/census.yml
@@ -15,16 +15,15 @@ axes:
     yaxis: metersnorth
 
 summary_fields:
-  - name: Counts
-    field: None
 
   - name: Race
     field: race
-    cat_colors: race_colors
+    cat_colors:
+      w: blue
+      b: green
+      a: red
+      h: orange
+      o: saddlebrown
 
-race_colors:
-  w: blue
-  b: green
-  a: red
-  h: orange
-  o: saddlebrown
+  - name: Counts
+    field: None

--- a/examples/dashboard/census.yml
+++ b/examples/dashboard/census.yml
@@ -24,6 +24,12 @@ summary_fields:
       a: red
       h: orange
       o: saddlebrown
+    cat_names:
+      w: White
+      b: Black
+      a: Asian
+      h: Hispanic
+      o: Other
 
   - name: Counts
     field: None

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -22,7 +22,10 @@ from bokeh.plotting import Figure
 from bokeh.models import (Range1d, ImageSource, WMTSTileSource, TileRenderer,
                           DynamicImageRenderer, HBox, VBox)
 
-from bokeh.models import Select, Slider, CheckboxGroup, CustomJS, ColumnDataSource, Square, HoverTool
+from bokeh.models import (Select, Slider, CheckboxGroup,
+                          CustomJS, ColumnDataSource,
+                          Square, HoverTool)
+
 from bokeh.models import Plot, Text, Circle
 from bokeh.palettes import GnBu9, OrRd9, PuRd9, YlGnBu9, Greys9
 

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -29,9 +29,6 @@ from tornado.web import RequestHandler
 from webargs import fields
 from webargs.tornadoparser import use_args
 
-from pdb import set_trace
-
-
 # http request arguments for datashing HTTP request
 ds_args = {
     'width': fields.Int(missing=800),

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -5,7 +5,6 @@ from os import path
 import yaml
 import webbrowser
 import uuid
-import pdb
 
 from collections import OrderedDict
 

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -146,8 +146,8 @@ class AppState(object):
         self.field = list(self.fields.values())[0]
 
     def load_datasets(self):
-        print('Loading Data...')
         data_path = self.config['file']
+        print('Loading Data from {}...'.format(data_path))
 
         if not path.isabs(data_path):
             config_dir = path.split(self.config_path)[0]

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -142,26 +142,26 @@ class AppState(object):
         # parse summary field
         self.fields = OrderedDict()
         for f in self.config['summary_fields']:
-            self.fields[f['name']] = f['field']
+            self.fields[f['name']] = None if f['field'] == 'None' else f['field']
         self.field = list(self.fields.values())[0]
 
     def load_datasets(self):
         print('Loading Data...')
-        taxi_path = self.config['file']
+        data_path = self.config['file']
 
-        if not path.isabs(taxi_path):
+        if not path.isabs(data_path):
             config_dir = path.split(self.config_path)[0]
-            taxi_path = path.join(config_dir, taxi_path)
+            data_path = path.join(config_dir, data_path)
 
-        if not path.exists(taxi_path):
-            raise IOError('Unable to find input dataset: "{}"'.format(taxi_path))
+        if not path.exists(data_path):
+            raise IOError('Unable to find input dataset: "{}"'.format(data_path))
 
         axes_fields = []
         for f in self.axes.values():
             axes_fields += [f[1], f[2]]
 
-        load_fields = list(self.fields.values()) + axes_fields
-        self.df = pd.read_csv(taxi_path, usecols=load_fields)
+        load_fields = [f for f in self.fields.values() if f is not None] + axes_fields
+        self.df = pd.read_csv(data_path, usecols=load_fields)
 
 class AppView(object):
 

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -140,8 +140,21 @@ class GetDataset(RequestHandler):
 
             else:
                 min_val = np.nanmin(agg.values)
+
+                if min_val == 0:
+                    min_val = agg.data[agg.data > 0].min()
+                    
                 max_val = np.nanmax(agg.values)
-                vals = np.linspace(min_val, max_val, 180)[None, :]
+                
+
+                if self.model.transfer_function == 'linear':
+                    vals = np.linspace(min_val, max_val, 180)[None, :]
+                else:
+                    vals = (np.logspace(0, 
+                                        np.log1p(max_val-min_val),
+                                        base=np.e, num=180,
+                                        dtype=min_val.dtype) + min_val)[None,:]
+
                 vals_arr = DataArray(vals)
                 img = tf.interpolate(vals_arr, cmap=self.model.color_ramp,
                                      how=self.model.transfer_function)

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -73,7 +73,7 @@ class GetDataset(RequestHandler):
                              self.model.active_axes[2],
                              self.model.aggregate_function(self.model.field))
 
-            pix = tf.interpolate(agg, (255, 204, 204), 'red',
+            pix = tf.interpolate(agg, cmap=[(255, 204, 204), 'red'],
                                  how=self.model.transfer_function)
         # handle no field
         else:
@@ -81,7 +81,7 @@ class GetDataset(RequestHandler):
                              self.model.active_axes[1],
                              self.model.active_axes[2])
 
-            pix = tf.interpolate(agg, (255, 204, 204), 'red',
+            pix = tf.interpolate(agg, cmap=[(255, 204, 204), 'red'],
                                  how=self.model.transfer_function)
 
         def hover_callback():

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -343,7 +343,7 @@ class AppView(object):
                                         end=100, step=1)
         basemap_opacity_slider.on_change('value', self.on_basemap_opacity_slider_change)
 
-        hover_size_slider = Slider(title="Hover Size (px)", value=8, start=1,
+        hover_size_slider = Slider(title="Hover Size (px)", value=8, start=4,
                                         end=30, step=1)
         hover_size_slider.on_change('value', self.on_hover_size_change)
         controls.append(hover_size_slider)

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -161,8 +161,16 @@ class AppState(object):
             axes_fields += [f[1], f[2]]
 
         load_fields = [f for f in self.fields.values() if f is not None] + axes_fields
-        self.df = pd.read_csv(data_path, usecols=load_fields)
 
+        if data_path.endswith(".csv") :
+            self.df = pd.read_csv(data_path, usecols=load_fields)
+        elif data_path.endswith(".castra"):
+            import dask.dataframe as dd
+            self.df = dd.from_castra(data_path)
+        else:
+            raise IOError("Unknown data file type; .csv and .castra currently supported")
+
+        
 class AppView(object):
 
     def __init__(self, app_model):
@@ -278,7 +286,7 @@ class AppView(object):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--config', help='yaml config file (e.g. nyc_taxi.yml)', required=True)
+    parser.add_argument('-c', '--config', help='yaml config file (e.g. nyc_taxi.yml)', required=True)
     args = vars(parser.parse_args())
 
     APP_PORT = 5000

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -191,8 +191,8 @@ class AppState(object):
     def __init__(self, config_file, outofcore, app_port):
 
         self.load_config_file(config_file)
-        self.plot_height = 560
-        self.plot_width = 810
+        self.plot_height = 600
+        self.plot_width = 1124
 
         self.aggregate_functions = OrderedDict()
         self.aggregate_functions['Count'] = ds.count
@@ -486,7 +486,7 @@ class AppView(object):
         self.map_area = VBox(width=self.fig.plot_width, children=[self.map_controls,
                                                                   self.fig,
                                                                   self.model.legend_vbox])
-        self.layout = HBox(width=1024, children=[self.controls, self.map_area])
+        self.layout = HBox(width=1366, children=[self.controls, self.map_area])
 
     def update_image(self):
         self.model.shader_url_vars['cachebust'] = str(uuid.uuid4())

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -331,12 +331,15 @@ class AppState(object):
             raise IOError("Unknown data file type; .csv and .castra currently supported")
 
     def create_legend(self, img, x, y, dw, dh, x_start, x_end, y_range):
+
+        x_axis_type = 'linear' if self.transfer_function == 'linear' else 'log'
         legend_fig = Figure(x_range=(x_start, x_end),
                             plot_height=max(dh, 50),
                             plot_width=self.plot_width,
                             lod_threshold=None,
                             toolbar_location=None,
-                            y_range=y_range)
+                            y_range=y_range,
+                            x_axis_type=x_axis_type)
 
         legend_fig.min_border_top = 0
         legend_fig.min_border_bottom = 10

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -25,7 +25,7 @@ from bokeh.models import (Range1d, ImageSource, WMTSTileSource, TileRenderer,
 
 from bokeh.models import Select, Slider, CheckboxGroup, CustomJS, ColumnDataSource, Square, HoverTool
 from bokeh.models import Plot, Text, Circle
-from bokeh.palettes import BrBG9, PiYG9
+from bokeh.palettes import GnBu9, OrRd9, PuRd9, YlGnBu9, Greys9
 
 from tornado.ioloop import IOLoop
 from tornado.web import RequestHandler
@@ -242,8 +242,11 @@ class AppState(object):
 
         # color ramps
         self.color_ramps = OrderedDict()
-        self.color_ramps['BrBG'] = BrBG9
-        self.color_ramps['PiYG'] = PiYG9
+        self.color_ramps['Orange-Red'] = list(reversed(OrRd9))[2:]
+        self.color_ramps['Green-Blue'] = list(reversed(GnBu9))[2:]
+        self.color_ramps['Purple-Red'] = list(reversed(PuRd9))[2:]
+        self.color_ramps['Yellow-Green-Blue'] = list(reversed(YlGnBu9))[2:]
+        self.color_ramps['Grays'] = list(reversed(Greys9))[2:]
         self.color_ramp = list(self.color_ramps.values())[0]
 
     def load_config_file(self, config_path):

--- a/examples/dashboard/nyc_taxi.yml
+++ b/examples/dashboard/nyc_taxi.yml
@@ -19,6 +19,9 @@ axes:
     yaxis: dropoff_y
 
 summary_fields:
+  - name: Trip Count
+    field: None
+
   - name: Passenger Count
     field: passenger_count
 


### PR DESCRIPTION
This PR adds:

 - Support for Castra-format files (via dask imported dynamically, thus not adding a required dependency)
 - Support for plotting pure counts (rows in the data, e.g. taxi trips, not associated with any particular field)
 - Support for plotting counts for the census data

It's also close to adding support for colorization by census race categories, but I'm not sure how to add that in a general way.  Below are some trivial diffs that are sufficient to get racial color categories shown, in a hardcoded way that removes support for non-categorical data.  With this PR and those diffs applied, there will initially be an error on startup because the default Field is counts in census.yml, but if the Field is then changed to Race to match the new Count Categories aggregate declared below, it should work.

So, @brendancol, can you take it from here?  Can you make dashboard.py support categorical information where appropriate?  I've added the race colors to the census.yml file already, but it would take me a while to figure out how to look that information up when needed, based on the "cat_colors" pointer I added to census.yml (but which could be changed if needed).   There will also of course need to be some logic to switch between tf.interpolate and tf.colorize.  

If we want to avoid errors for nonsensical combinations, just as for the earliest client.py file from ages ago, we'll presumably need to start declaring datatypes for these objects so that the buttons generally work rather than generally fail...

```python
0045-jbednar:~/datashader/examples> git diff
diff --git a/examples/dashboard/dashboard.py b/examples/dashboard/dashboard.py
index 5d304de..0c32239 100644
--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -55,8 +55,8 @@ class GetDataset(RequestHandler):
                          self.model.active_axes[1],
                          self.model.active_axes[2],
                          self.model.aggregate_function(self.model.field))
-        pix = tf.interpolate(agg, (255, 204, 204), 'red',
-                             how=self.model.transfer_function)
+        color_field = 'race_colors'
+        pix = tf.colorize(agg, self.model.config[color_field])

         # serialize to image
         img_io = pix.to_bytesio()
@@ -72,6 +72,7 @@ class AppState(object):
         self.load_config_file(config_file)

         self.aggregate_functions = OrderedDict()
+        self.aggregate_functions['Count Categories'] = ds.count_cat
         self.aggregate_functions['Count'] = ds.count
         self.aggregate_functions['Mean'] = ds.mean
         self.aggregate_functions['Sum'] = ds.sum
```