### PR TITLE
Added cmap option to interpolate.

### DIFF
--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -85,9 +85,9 @@ def interpolate(agg, low="lightblue", high="darkblue", how='cbrt', cmap=None):
         'log', and 'linear'. Callables take a 2-dimensional array of
         magnitudes at each pixel, and should return a numeric array of the same
         shape.
-    cmap : str or None, optional
-        If specified, overrides the provided low, high values with the name
-        of a colormap to import from matplotlib.
+    cmap : str, optional
+        If specified, interpolate along the named colormap, as provided by
+        matplotlib.  Overrides low,high.
     """
     if not isinstance(agg, xr.DataArray):
         raise TypeError("agg must be instance of DataArray")

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -109,10 +109,8 @@ def interpolate(agg, low="lightblue", high="darkblue", how='cbrt', cmap=None):
         a = np.where(np.isnan(data), 0, 255).astype(np.uint8)
         img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
     else:
-        from matplotlib import cm
-        if cmap not in dir(cm):
-            raise RuntimeException("Can't find Matplotlib colormap named '%s'" % cmap)
-        mapper = cm.__dict__[cmap]
+        from matplotlib.cm import get_cmap
+        mapper = get_cmap(cmap)
         tmp = mapper(data, bytes=True)
         tmp[:,:,3] = np.where(np.isnan(data), 0, 255).astype(np.uint8)
         img = tmp.view(np.uint32).reshape(data.shape)

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -70,7 +70,7 @@ def _normalize_interpolate_how(how):
     raise ValueError("Unknown interpolation method: {0}".format(how))
 
 
-def interpolate(agg, low="lightblue", high="darkblue", how='cbrt'):
+def interpolate(agg, low="lightblue", high="darkblue", how='cbrt', cmap=None):    
     """Convert a 2D DataArray to an image.
 
     Parameters
@@ -85,6 +85,9 @@ def interpolate(agg, low="lightblue", high="darkblue", how='cbrt'):
         'log', and 'linear'. Callables take a 2-dimensional array of
         magnitudes at each pixel, and should return a numeric array of the same
         shape.
+    cmap : str or None, optional
+        If specified, overrides the provided low, high values with the name
+        of a colormap to import from matplotlib.
     """
     if not isinstance(agg, xr.DataArray):
         raise TypeError("agg must be instance of DataArray")
@@ -97,12 +100,22 @@ def interpolate(agg, low="lightblue", high="darkblue", how='cbrt'):
     how = _normalize_interpolate_how(how)
     data = how(agg - offset)
     span = [np.nanmin(data), np.nanmax(data)]
-    rspan, gspan, bspan = zip(rgb(low), rgb(high))
-    r = np.interp(data, span, rspan, left=255).astype(np.uint8)
-    g = np.interp(data, span, gspan, left=255).astype(np.uint8)
-    b = np.interp(data, span, bspan, left=255).astype(np.uint8)
-    a = np.where(np.isnan(data), 0, 255).astype(np.uint8)
-    img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
+
+    if cmap is None:
+        rspan, gspan, bspan = zip(rgb(low), rgb(high))
+        r = np.interp(data, span, rspan, left=255).astype(np.uint8)
+        g = np.interp(data, span, gspan, left=255).astype(np.uint8)
+        b = np.interp(data, span, bspan, left=255).astype(np.uint8)
+        a = np.where(np.isnan(data), 0, 255).astype(np.uint8)
+        img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
+    else:
+        from matplotlib import cm
+        if cmap not in dir(cm):
+            raise RuntimeException("Can't find Matplotlib colormap named '%s'" % cmap)
+        mapper = cm.__dict__[cmap]
+        tmp = mapper(data, bytes=True)
+        tmp[:,:,3] = np.where(np.isnan(data), 0, 255).astype(np.uint8)
+        img = tmp.view(np.uint32).reshape(data.shape)
     return Image(img, coords=agg.coords, dims=agg.dims)
 
 


### PR DESCRIPTION
Fixes #81

Code from Peter to allow usage of matplotlib  colormaps, via a new `cmap` option to `interpolate`.  Sample usage:

```python
import pandas as pd
import numpy as np
import xarray as xr
import datashader as ds
import datashader.transfer_functions as tf

n = 100000
data= {}
data['x'] = np.random.normal(0, 0.3, size=n)
data['y'] = np.random.normal(0, 0.3, size=n)
df = pd.DataFrame(data)

cvs = ds.Canvas(plot_width=300,plot_height=300)
agg = cvs.points(df, 'x', 'y')

tf.interpolate(agg, cmap="viridis", how="linear")
```

![image](https://cloud.githubusercontent.com/assets/1695496/13646270/3facd784-e5f4-11e5-9f72-1ab85a02af13.png)

![image](https://cloud.githubusercontent.com/assets/1695496/13646281/5192f668-e5f4-11e5-8404-e91223de09dd.png)
