### PR TITLE
Add cmap to interpolate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install dask numba numpy pandas pillow pytest toolz xarray
+  - conda install dask numba numpy pandas pillow pytest toolz xarray matplotlib
   # Need a few fixes to odo and datashape that aren't in the latest release
   - conda install -c blaze datashape odo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - conda install dask numba numpy pandas pillow pytest toolz xarray matplotlib
-  # Need a few fixes to odo and datashape that aren't in the latest release
-  - conda install -c blaze datashape odo
+  - conda install dask numba numpy pandas pillow pytest toolz xarray datashape odo
+  # Optional dependencies, for testing only
+  - conda install matplotlib
 
   - python setup.py develop --no-deps
 

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -52,6 +52,29 @@ def test_interpolate(attr):
     assert img.equals(sol)
 
 
+def test_interpolate_cmap():
+    cmap = ['red', (0, 255, 0), '#0000FF']
+    img = tf.interpolate(agg.a, how='log', cmap=cmap)
+    sol = np.array([[0, 4278190335, 4278236489],
+                    [4280344064, 0, 4289091584],
+                    [4292225024, 4294901760, 0]])
+    sol = xr.DataArray(sol, coords=coords, dims=dims)
+    assert img.equals(sol)
+
+    with pytest.raises(TypeError):
+        tf.interpolate(agg.a, cmap='foo')
+
+
+def test_interpolate_mpl_cmap():
+    cm = pytest.importorskip('matplotlib.cm')
+    img = tf.interpolate(agg.a, how='log', cmap=cm.viridis)
+    sol = np.array([[5505348, 4283695428, 4287524142],
+                    [4287143710, 5505348, 4282832267],
+                    [4280213706, 4280608765, 5505348]])
+    sol = xr.DataArray(sol, coords=coords, dims=dims)
+    assert img.equals(sol)
+
+
 def test_colorize():
     coords = [np.array([0, 1]), np.array([2, 5])]
     cat_agg = xr.DataArray(np.array([[(0, 12, 0), (3, 0, 3)],

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -64,6 +64,9 @@ def test_interpolate_cmap():
     with pytest.raises(TypeError):
         tf.interpolate(agg.a, cmap='foo')
 
+    with pytest.raises(ValueError):
+        tf.interpolate(agg.a, low='red', cmap=cmap)
+
 
 def test_interpolate_mpl_cmap():
     cm = pytest.importorskip('matplotlib.cm')

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -26,25 +26,26 @@ agg = xr.Dataset(dict(a=s_a, b=s_b, c=s_c))
 @pytest.mark.parametrize(['attr'], ['a', 'b', 'c'])
 def test_interpolate(attr):
     x = getattr(agg, attr)
-    img = tf.interpolate(x, 'pink', 'red', how='log')
+    cmap = ['pink', 'red']
+    img = tf.interpolate(x, cmap=cmap, how='log')
     sol = np.array([[0, 4291543295, 4286741503],
                     [4283978751, 0, 4280492543],
                     [4279242751, 4278190335, 0]], dtype='u4')
     sol = xr.DataArray(sol, coords=coords, dims=dims)
     assert img.equals(sol)
-    img = tf.interpolate(x, 'pink', 'red', how='cbrt')
+    img = tf.interpolate(x, cmap=cmap, how='cbrt')
     sol = np.array([[0, 4291543295, 4284176127],
                     [4282268415, 0, 4279834879],
                     [4278914047, 4278190335, 0]], dtype='u4')
     sol = xr.DataArray(sol, coords=coords, dims=dims)
     assert img.equals(sol)
-    img = tf.interpolate(x, 'pink', 'red', how='linear')
+    img = tf.interpolate(x, cmap=cmap, how='linear')
     sol = np.array([[0, 4291543295, 4289306879],
                     [4287070463, 0, 4282597631],
                     [4280361215, 4278190335, 0]])
     sol = xr.DataArray(sol, coords=coords, dims=dims)
     assert img.equals(sol)
-    img = tf.interpolate(x, 'pink', 'red', how=lambda x: x ** 2)
+    img = tf.interpolate(x, cmap=cmap, how=lambda x: x ** 2)
     sol = np.array([[0, 4291543295, 4291148543],
                     [4290030335, 0, 4285557503],
                     [4282268415, 4278190335, 0]], dtype='u4')

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from io import BytesIO
+import warnings
 
 import numpy as np
 import toolz as tz
@@ -15,6 +16,8 @@ from .utils import ngjit
 
 __all__ = ['Image', 'stack', 'interpolate', 'colorize', 'set_background',
            'spread']
+
+warnings.simplefilter('always', DeprecationWarning)
 
 
 class Image(xr.DataArray):
@@ -70,7 +73,7 @@ def _normalize_interpolate_how(how):
     raise ValueError("Unknown interpolation method: {0}".format(how))
 
 
-def interpolate(agg, low=None, high=None, how='cbrt', cmap=None):
+def interpolate(agg, low=None, high=None, cmap=None, how='cbrt'):
     """Convert a 2D DataArray to an image.
 
     Data is converted to an image either by interpolating between a `low` and
@@ -80,17 +83,18 @@ def interpolate(agg, low=None, high=None, how='cbrt', cmap=None):
     ----------
     agg : DataArray
     low, high : color name or tuple, optional
-        The color for the low and high ends of the scale. Can be specified
-        either by name, hexcode, or as a tuple of ``(red, green, blue)``
-        values. Defaults are "lightblue" and "darkblue", respectively.
+        Deprecated. The color for the low and high ends of the scale. Can be
+        specified either by name, hexcode, or as a tuple of ``(red, green,
+        blue)`` values.
+    cmap : list of colors or matplotlib.colors.Colormap, optional
+        The colormap to use. Can be either a list of colors (in any of the
+        formats described above), or a matplotlib colormap object.
+        Default is `["lightblue", "darkblue"]`
     how : str or callable, optional
         The interpolation method to use. Valid strings are 'cbrt' [default],
         'log', and 'linear'. Callables take a 2-dimensional array of
         magnitudes at each pixel, and should return a numeric array of the same
         shape.
-    cmap : list of colors or matplotlib.colors.Colormap, optional
-        The colormap to use. Can be either a list of colors (in any of the
-        formats described above), or a matplotlib colormap object.
     """
     if not isinstance(agg, xr.DataArray):
         raise TypeError("agg must be instance of DataArray")
@@ -101,7 +105,12 @@ def interpolate(agg, low=None, high=None, how='cbrt', cmap=None):
             raise ValueError("Can't provide both `cmap` and `low` or `high`")
     else:
         # Defaults
-        cmap = [low or 'lightblue', high or 'darkblue']
+        cmap = ['lightblue', 'darkblue']
+        if low or high:
+            w = DeprecationWarning("Using `low` and `high` is deprecated. "
+                                   "Instead use `cmap=[low, high]`")
+            warnings.warn(w)
+            cmap = [low or cmap[0], high or cmap[1]]
     offset = agg.min()
     if offset == 0:
         agg = agg.where(agg > 0)
@@ -117,8 +126,8 @@ def interpolate(agg, low=None, high=None, how='cbrt', cmap=None):
         b = np.interp(data, span, bspan, left=255).astype(np.uint8)
         a = np.where(np.isnan(data), 0, 255).astype(np.uint8)
         img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
-    elif (getattr(type(cmap), '__module__', '').startswith('matplotlib') and
-          callable(cmap)):
+    elif callable(cmap):
+        # Assume callable is matplotlib colormap
         img = cmap((data - span[0])/(span[1] - span[0]), bytes=True)
         img[:, :, 3] = np.where(np.isnan(data), 0, 255).astype(np.uint8)
         img = img.view(np.uint32).reshape(data.shape)

--- a/examples/README.md
+++ b/examples/README.md
@@ -74,3 +74,11 @@ map](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). This
 dataset isn't provided by the download script, and is only included to
 demonstrate working with a large dataset. The run notebook can be viewed using
 the `anaconda.org` link provided above.
+
+**[tseries](https://anaconda.org/jbednar/tseries/notebook)**
+
+Plotting several time series on the same plot.
+
+**[trajectory](https://anaconda.org/jbednar/trajectory/notebook)**
+
+Plotting a 2D trajectory.

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -55,7 +55,7 @@ class GetDataset(RequestHandler):
                          self.model.active_axes[1],
                          self.model.active_axes[2],
                          self.model.aggregate_function(self.model.field))
-        pix = tf.interpolate(agg, (255, 204, 204), 'red',
+        pix = tf.interpolate(agg, cmap=[(255, 204, 204), 'red'],
                              how=self.model.transfer_function)
 
         # serialize to image

--- a/examples/nyc_taxi.ipynb
+++ b/examples/nyc_taxi.ipynb
@@ -194,7 +194,7 @@
     "%%time\n",
     "cvs = ds.Canvas(plot_width=800, plot_height=500, x_range=x_range, y_range=y_range)\n",
     "agg = cvs.points(df, 'dropoff_x', 'dropoff_y',  ds.count('passenger_count'))\n",
-    "img = tf.interpolate(agg, low=\"white\", high='darkblue', how='linear')"
+    "img = tf.interpolate(agg, cmap=[\"white\", 'darkblue'], how='linear')"
    ]
   },
   {
@@ -279,7 +279,7 @@
    "outputs": [],
    "source": [
     "histogram(np.log1p(agg.values))\n",
-    "tf.interpolate(agg, low=\"white\", high='darkblue', how='log')"
+    "tf.interpolate(agg, cmap=[\"white\", 'darkblue'], how='log')"
    ]
   },
   {
@@ -304,7 +304,7 @@
     "    equalized_agg.values=equalize_hist(agg.values)\n",
     "    histogram(equalized_agg.values)\n",
     "\n",
-    "    tf.interpolate(equalized_agg, low=\"white\", high='darkblue', how='linear')\n",
+    "    tf.interpolate(equalized_agg, cmap=[\"white\", 'darkblue'], how='linear')\n",
     "except ImportError:\n",
     "    print(\"This example requires scikit-image, e.g. via 'conda install scikit-image'\")"
    ]
@@ -378,7 +378,7 @@
     "    \n",
     "pipeline = ds.Pipeline(df, ds.Point(\"dropoff_x\", \"dropoff_y\"), agg=ds.count(\"passenger_count\"),\n",
     "                       transform_fn=lambda x: x.where(x>np.percentile(x,90)),\n",
-    "                       color_fn=partial(tf.interpolate,low=\"darkred\",high=\"yellow\", how='linear'))\n",
+    "                       color_fn=partial(tf.interpolate, cmap=['darkred', 'yellow'], how='linear'))\n",
     "InteractiveImage(p, pipeline)"
    ]
   },
@@ -404,8 +404,8 @@
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
     "    picks = cvs.points(df, 'pickup_x',  'pickup_y',  ds.count('passenger_count'))\n",
     "    drops = cvs.points(df, 'dropoff_x', 'dropoff_y', ds.count('passenger_count'))\n",
-    "    more_drops = tf.interpolate(drops.where(drops > picks), \"lightblue\", 'blue', how=how)\n",
-    "    more_picks = tf.interpolate(picks.where(picks > drops), \"lightpink\", 'red',  how=how)\n",
+    "    more_drops = tf.interpolate(drops.where(drops > picks), cmap=[\"lightblue\", 'blue'], how=how)\n",
+    "    more_picks = tf.interpolate(picks.where(picks > drops), cmap=[\"lightpink\", 'red'],  how=how)\n",
     "    return tf.stack(more_picks,more_drops)\n",
     "\n",
     "p = base_plot()\n",

--- a/examples/osm.ipynb
+++ b/examples/osm.ipynb
@@ -99,7 +99,7 @@
    },
    "outputs": [],
    "source": [
-    "tf.interpolate(agg,low=\"lightcyan\",high=\"darkblue\",how=\"log\")"
+    "tf.interpolate(agg, cmap=[\"lightcyan\", \"darkblue\"], how=\"log\")"
    ]
   },
   {
@@ -117,7 +117,7 @@
    },
    "outputs": [],
    "source": [
-    "tf.interpolate(agg.where(agg > 20),low=\"lightcyan\",high=\"darkblue\",how=\"log\")"
+    "tf.interpolate(agg.where(agg > 20), cmap=[\"lightcyan\", \"darkblue\"], how=\"log\")"
    ]
   },
   {
@@ -200,7 +200,7 @@
     "def create_image(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(x_range=x_range, y_range=y_range)\n",
     "    agg = cvs.points(df, 'x', 'y', ds.count())\n",
-    "    return tf.interpolate(agg.where(agg > 20),low=\"lightcyan\",high=\"darkblue\",how=\"log\")\n",
+    "    return tf.interpolate(agg.where(agg > 20), cmap=[\"lightcyan\", \"darkblue\"], how=\"log\")\n",
     "\n",
     "p = figure(tools='pan,wheel_zoom,box_zoom,reset', plot_width=800, plot_height=800, \n",
     "           x_range=(-bound, bound), y_range=(-bound, bound))\n",

--- a/examples/tseries.ipynb
+++ b/examples/tseries.ipynb
@@ -97,8 +97,8 @@
    "source": [
     "%%time\n",
     "cvs = ds.Canvas(x_range=x_range, y_range=y_range, plot_height=300)\n",
-    "aggs= OrderedDict((c,cvs.line(df, 'Time', c)) for c in cols)\n",
-    "img = tf.interpolate(aggs['a'],high=\"red\")"
+    "aggs= OrderedDict((c, cvs.line(df, 'Time', c)) for c in cols)\n",
+    "img = tf.interpolate(aggs['a'], cmap=[\"lighblue\", \"red\"])"
    ]
   },
   {
@@ -132,8 +132,9 @@
    },
    "outputs": [],
    "source": [
-    "colors = [\"yellow\",\"green\",\"orange\",\"purple\",\"red\",\"pink\",\"brown\",\"grey\",\"black\",\"blue\"]\n",
-    "imgs = [tf.interpolate(aggs[c],high=colors[i]) for i,c in enumerate(cols)]\n",
+    "colors = [\"yellow\", \"green\", \"orange\", \"purple\", \"red\",\n",
+    "          \"pink\", \"brown\", \"grey\", \"black\", \"blue\"]\n",
+    "imgs = [tf.interpolate(aggs[n], cmap=[c]) for n, c in zip(cols, colors)]\n",
     "tf.stack(*imgs)"
    ]
   },
@@ -190,7 +191,7 @@
    },
    "outputs": [],
    "source": [
-    "total = tf.interpolate(merged.sum(dim='cols'), low=\"lightblue\", high=\"darkblue\", how='linear')\n",
+    "total = tf.interpolate(merged.sum(dim='cols'), cmap=[\"lightblue\", \"darkblue\"], how='linear')\n",
     "total"
    ]
   },
@@ -215,8 +216,8 @@
    },
    "outputs": [],
    "source": [
-    "img = tf.interpolate(aggs['a'],high=\"red\")\n",
-    "tf.stack(total,img)"
+    "img = tf.interpolate(aggs['a'], cmap=[\"lightblue\", \"red\"])\n",
+    "tf.stack(total, img)"
    ]
   },
   {
@@ -235,8 +236,8 @@
    },
    "outputs": [],
    "source": [
-    "img = tf.interpolate(aggs['z'],high=\"red\")\n",
-    "tf.stack(total,img)"
+    "img = tf.interpolate(aggs['z'], high=[\"lightblue\", \"red\"])\n",
+    "tf.stack(total, img)"
    ]
   },
   {


### PR DESCRIPTION
Can now interpolate with a colormap. Colormaps can be either lists of colors, or a matplotlib colormap. Due to how bokeh stores palettes, this means that colormaps can be taken from either bokeh or matplotlib. Note that this *doesn't* add either as a dependency, just means that we understand how to use the colormappers.

Example notebook: https://gist.github.com/jcrist/a9dfc6e8f8bce3b4ae30

Fixes #81, fixes #93, subsumes #109.