### PR TITLE
Add dynspread transfer function

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,10 +42,13 @@ Transfer Functions
 .. currentmodule:: datashader.transfer_functions
 .. autosummary::
 
+   Image
    interpolate
    colorize
    stack
    spread
+   dynspread
+   set_background
 
 Definitions
 -----------


### PR DESCRIPTION
`dynspread` dynamically spreads pixels in an image based on a density heuristic. This is useful for maintaining visibility of points when zooming in.

The heuristic is defined as the normalized mean number of non-empty adjacent pixels for each non-empty pixel. This gives a simple to compute tuning parameter in `[0, 1]`.