### PR TITLE
InteractiveImage only attempts callback if IPython kernel available

### DIFF
--- a/datashader/callbacks.py
+++ b/datashader/callbacks.py
@@ -66,8 +66,10 @@ class InteractiveImage(object):
             var cmd = "{cmd}(" + range_str + ")"
 
             // Execute the command on the Python kernel
-            var kernel = IPython.notebook.kernel;
-            kernel.execute(cmd, callbacks, {{silent : false}});
+            if (IPython.notebook.kernel !== undefined) {{
+                var kernel = IPython.notebook.kernel;
+                kernel.execute(cmd, callbacks, {{silent : false}});
+            }}
         }}
 
         if (!Bokeh._throttle) {{


### PR DESCRIPTION
This avoids issues when the plot is reused outside a notebook context, which resulted in vertical zoom events getting dropped.