### PR TITLE
Notebook updates

### DIFF
--- a/datashader/pipeline.py
+++ b/datashader/pipeline.py
@@ -32,14 +32,18 @@ class Pipeline(object):
     color_fn : callable, optional
         A callable that takes the output of ``tranform_fn``, and returns an
         ``Image`` object. Default is ``interpolate``.
+    spread_fn : callable, optional
+        A callable that takes the output of ``color_fn``, and returns another
+        ``Image`` object. Default is ``dynspread``.
     """
     def __init__(self, df, glyph, agg=reductions.count(),
-                 transform_fn=identity, color_fn=tf.interpolate):
+                 transform_fn=identity, color_fn=tf.interpolate,  spread_fn=tf.dynspread):
         self.df = df
         self.glyph = glyph
         self.agg = agg
         self.transform_fn = transform_fn
         self.color_fn = color_fn
+        self.spread_fn = spread_fn
 
     def __call__(self, x_range=None, y_range=None, width=600, height=600):
         """Compute an image from the specified pipeline.
@@ -55,4 +59,5 @@ class Pipeline(object):
         canvas = core.Canvas(plot_width=width, plot_height=height,
                              x_range=x_range, y_range=y_range)
         bins = core.bypixel(self.df, canvas, self.glyph, self.agg)
-        return self.color_fn(self.transform_fn(bins))
+        img = self.color_fn(self.transform_fn(bins))
+        return self.spread_fn(img)

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -176,9 +176,9 @@ def test_masks():
     np.testing.assert_equal(tf._square_mask(0), np.ones((1, 1), dtype='bool'))
     # Circle
     np.testing.assert_equal(tf._circle_mask(0), np.ones((1, 1), dtype='bool'))
-    out = np.array([[0, 1, 0],
+    out = np.array([[1, 1, 1],
                     [1, 1, 1],
-                    [0, 1, 0]], dtype='bool')
+                    [1, 1, 1]], dtype='bool')
     np.testing.assert_equal(tf._circle_mask(1), out)
     out = np.array([[0, 0, 1, 1, 1, 0, 0],
                     [0, 1, 1, 1, 1, 1, 0],
@@ -203,11 +203,11 @@ def test_spread():
     img = tf.Image(data, coords=coords, dims=dims)
 
     s = tf.spread(img)
-    o = np.array([[0xdc00007d, 0xdc009036, 0x7d00007d, 0x00000000, 0x00000000],
-                  [0xdc009036, 0xdc009036, 0x7d00ff00, 0x00000000, 0x00000000],
-                  [0x7d00007d, 0x7d00ff00, 0x00000000, 0x7dff0000, 0x00000000],
+    o = np.array([[0xed00863b, 0xed00863b, 0xbc00a82a, 0x00000000, 0x00000000],
+                  [0xed00863b, 0xed00863b, 0xbc00a82a, 0x00000000, 0x00000000],
+                  [0xbc00a82a, 0xbc00a82a, 0xbca85600, 0x7dff0000, 0x7dff0000],
                   [0x00000000, 0x00000000, 0x7dff0000, 0x7dff0000, 0x7dff0000],
-                  [0x00000000, 0x00000000, 0x00000000, 0x7dff0000, 0x00000000]])
+                  [0x00000000, 0x00000000, 0x7dff0000, 0x7dff0000, 0x7dff0000]])
     np.testing.assert_equal(s.data, o)
     assert (s.x_axis == img.x_axis).all()
     assert (s.y_axis == img.y_axis).all()
@@ -230,11 +230,11 @@ def test_spread():
     np.testing.assert_equal(s.data, o)
 
     s = tf.spread(img, how='add')
-    o = np.array([[0xff0000b7, 0xff007d7a, 0x7d00007d, 0x00000000, 0x00000000],
-                  [0xff007d7a, 0xff007d7a, 0x7d00ff00, 0x00000000, 0x00000000],
-                  [0x7d00007d, 0x7d00ff00, 0x00000000, 0x7dff0000, 0x00000000],
+    o = np.array([[0xff007db7, 0xff007db7, 0xfa007f3e, 0x00000000, 0x00000000],
+                  [0xff007db7, 0xff007db7, 0xfa007f3e, 0x00000000, 0x00000000],
+                  [0xfa007f3e, 0xfa007f3e, 0xfa7f7f00, 0x7dff0000, 0x7dff0000],
                   [0x00000000, 0x00000000, 0x7dff0000, 0x7dff0000, 0x7dff0000],
-                  [0x00000000, 0x00000000, 0x00000000, 0x7dff0000, 0x00000000]])
+                  [0x00000000, 0x00000000, 0x7dff0000, 0x7dff0000, 0x7dff0000L]])
     np.testing.assert_equal(s.data, o)
 
     mask = np.array([[1, 0, 1],

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -234,7 +234,7 @@ def test_spread():
                   [0xff007db7, 0xff007db7, 0xfa007f3e, 0x00000000, 0x00000000],
                   [0xfa007f3e, 0xfa007f3e, 0xfa7f7f00, 0x7dff0000, 0x7dff0000],
                   [0x00000000, 0x00000000, 0x7dff0000, 0x7dff0000, 0x7dff0000],
-                  [0x00000000, 0x00000000, 0x7dff0000, 0x7dff0000, 0x7dff0000L]])
+                  [0x00000000, 0x00000000, 0x7dff0000, 0x7dff0000, 0x7dff0000]])
     np.testing.assert_equal(s.data, o)
 
     mask = np.array([[1, 0, 1],

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -114,7 +114,7 @@ def _normalize_interpolate_how(how):
     raise ValueError("Unknown interpolation method: {0}".format(how))
 
 
-def interpolate(agg, low=None, high=None, cmap=None, how='cbrt'):
+def interpolate(agg, low=None, high=None, cmap=None, how='eq_hist'):
     """Convert a 2D DataArray to an image.
 
     Data is converted to an image either by interpolating between a `low` and
@@ -182,7 +182,7 @@ def interpolate(agg, low=None, high=None, cmap=None, how='cbrt'):
     return Image(img, coords=agg.coords, dims=agg.dims)
 
 
-def colorize(agg, color_key, how='cbrt', min_alpha=20):
+def colorize(agg, color_key, how='eq_hist', min_alpha=20):
     """Color a CategoricalAggregate by field.
 
     Parameters

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -11,7 +11,7 @@ from PIL.Image import fromarray
 
 
 from .colors import rgb
-from .composite import composite_op_lookup, source
+from .composite import composite_op_lookup, over
 from .utils import ngjit
 
 
@@ -247,7 +247,7 @@ def set_background(img, color=None):
     if color is None:
         return img
     background = np.uint8(rgb(color) + (255,)).view('uint32')[0]
-    data = source(img.data, background)
+    data = over(img.data, background)
     return Image(data, coords=img.coords, dims=img.dims)
 
 

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -328,8 +328,7 @@ def _square_mask(px):
 def _circle_mask(r):
     """Produce a circular mask with a diameter of ``2 * r + 1``"""
     x = np.arange(-r, r + 1, dtype='i4')
-    bound = r + 0.5 if r > 1 else r
-    return np.where(np.sqrt(x**2 + x[:, None]**2) <= bound, True, False)
+    return np.where(np.sqrt(x**2 + x[:, None]**2) <= r+0.5, True, False)
 
 
 _mask_lookup = {'square': _square_mask,

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -61,7 +61,7 @@ def stack(*imgs, **kwargs):
     return Image(out, coords=imgs[0].coords, dims=imgs[0].dims)
 
 
-def eq_hist(data, mask=None, nbins=256):
+def eq_hist(data, mask=None, nbins=256*256):
     """Return a numpy array after histogram equalization.
 
     For use in `interpolate`.

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, division, print_function
 
 from io import BytesIO
 import warnings
-
+import collections
+        
 import numpy as np
 import numba as nb
 import toolz as tz
@@ -161,7 +162,7 @@ def interpolate(agg, low=None, high=None, cmap=None, how='eq_hist'):
         offset = agg.data[agg.data > 0].min()
     data = how(agg.data - offset, mask.data)
     span = [np.nanmin(data), np.nanmax(data)]
-    if isinstance(cmap,type(reversed(list()))):
+    if isinstance(cmap,collections.Iterator):
         cmap = list(cmap)
     if isinstance(cmap, list):
         rspan, gspan, bspan = np.array(list(zip(*map(rgb, cmap))))

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -161,6 +161,8 @@ def interpolate(agg, low=None, high=None, cmap=None, how='cbrt'):
         offset = agg.data[agg.data > 0].min()
     data = how(agg.data - offset, mask.data)
     span = [np.nanmin(data), np.nanmax(data)]
+    if isinstance(cmap,type(reversed(list()))):
+        cmap = list(cmap)
     if isinstance(cmap, list):
         rspan, gspan, bspan = np.array(list(zip(*map(rgb, cmap))))
         span = np.linspace(span[0], span[1], len(cmap))

--- a/examples/census.ipynb
+++ b/examples/census.ipynb
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output of `.tail()` shows that there are more than 300 million datapoints (one per person), each with a location in Web Mercator format, and that the race for each datapoint has been encoded as a single character (where 'w' is white, 'b' is black, 'a' is Asian, 'h' is Hispanic, and 'o' is other (typically Native American).\n",
+    "The output of `.tail()` shows that there are more than 300 million datapoints (one per person), each with a location in Web Mercator format, and that the race for each datapoint has been encoded as a single character (where 'w' is white, 'b' is black, 'a' is Asian, 'h' is Hispanic, and 'o' is other (typically Native American)).\n",
     "\n",
     "Let's define some geographic ranges to look at later, and also a default plot size.  Feel free to increase `plot_width` to 2000 or more if you have a very large monitor or want to save files to disk, which shouldn't *greatly* affect the processing time or memory requirements.  "
    ]
@@ -236,9 +236,9 @@
    "source": [
     "Suddenly, we can see an amazing amount of structure!  There are clearly meaningful patterns at nearly every location, ranging from the geographic variations in the mountainous West, to the densely spaced urban centers in New England, and the many towns stretched out along roadsides in the midwest (especially those leading to Denver, the hot spot towards the right of the Rocky Mountains).  \n",
     "\n",
-    "Clearly, we can now see much more of what's going on in this dataset, thanks to the logarithmic mapping.  Yet the choice of `'log'` was purely arbitrary, and one could easily imagine that other nonlinear functions would show other interesting patterns.  Instead of blindly searching through the space of all such functions, we can step back and notice that the main effect of the log transform has been to reveal *local* patterns at all population densities -- urban areas show up clearly even if they are just slightly more dense than their immediate, rural neighbors, yet they still show up as denser areas in more populated regions.\n",
+    "Clearly, we can now see much more of what's going on in this dataset, thanks to the logarithmic mapping.  Yet the choice of `'log'` was purely arbitrary, and one could easily imagine that other nonlinear functions would show other interesting patterns.  Instead of blindly searching through the space of all such functions, we can step back and notice that the main effect of the log transform has been to reveal *local* patterns at all population densities -- small towns show up clearly even if they are just slightly more dense than their immediate, rural neighbors, yet large cities with high population density also show up well against the surrounding suburban regions, even if those regions are more dense than the small towns on an absolute scale.\n",
     "\n",
-    "With this in mind, let's try the image-processing technique called histogram equalization. I.e., given a set of raw counts, map these into a range for display such that every available color on the screen represents about the same number of samples in the original dataset.  The result is similar to that from the log transform, but is now non-parametric -- it will equalize any linearly or nonlinearly distributed integer data, regardless of the distribution:"
+    "With this idea of showing relative differences across a large range of data values in mind, let's try the image-processing technique called histogram equalization. I.e., given a set of raw counts, map these into a range for display such that every available color on the screen represents about the same number of samples in the original dataset.  The result is similar to that from the log transform, but is now non-parametric -- it will equalize any linearly or nonlinearly distributed integer data, regardless of the distribution:"
    ]
   },
   {
@@ -271,7 +271,7 @@
    },
    "outputs": [],
    "source": [
-    "print(Hot)\n",
+    "print(cm(Hot,0.2))\n",
     "export(tf.interpolate(agg, cmap = cm(Hot,0.2), how='eq_hist'),\"census_ds_hot_eq_hist\")"
    ]
   },

--- a/examples/census.ipynb
+++ b/examples/census.ipynb
@@ -72,10 +72,17 @@
    },
    "outputs": [],
    "source": [
-    "USA =          ((-13884029, -7453304), (2698291, 6455972))\n",
-    "LakeMichigan = ((-10206131, -9348029), (4975642, 5477059))\n",
-    "Chicago =      (( -9828281, -9717659), (5096658, 5161298))\n",
-    "Chinatown =    (( -9759210, -9754583), (5137122, 5139825))\n",
+    "USA =          ((-13884029,  -7453304), (2698291, 6455972))\n",
+    "LakeMichigan = ((-10206131,  -9348029), (4975642, 5477059))\n",
+    "Chicago =      (( -9828281,  -9717659), (5096658, 5161298))\n",
+    "Chinatown =    (( -9759210,  -9754583), (5137122, 5139825))\n",
+    "\n",
+    "NewYorkCity =  (( -8280656,  -8175066), (4940514, 4998954))\n",
+    "LosAngeles =   ((-13195052, -13114944), (3979242, 4023720))\n",
+    "Houston =      ((-10692703, -10539441), (3432521, 3517616))\n",
+    "Austin =       ((-10898752, -10855820), (3525750, 3550837))\n",
+    "NewOrleans =   ((-10059963, -10006348), (3480787, 3510555))\n",
+    "Atlanta =      (( -9448349,  -9354773), (3955797, 4007753))\n",
     "\n",
     "x_range,y_range = USA\n",
     "\n",
@@ -101,9 +108,6 @@
     "black_background = True\n",
     "\n",
     "from IPython.core.display import HTML, display\n",
-    "if black_background:\n",
-    "    display(HTML(\"<style>.output_result { background-color:black !important; color:white }</style>\"))\n",
-    "\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },
@@ -124,6 +128,8 @@
    "source": [
     "def export(img,filename,fmt=\".png\",_return=True):\n",
     "    \"\"\"Given a datashader Image object, saves it to a disk file in the requested format\"\"\"\n",
+    "    if black_background: \n",
+    "        img=tf.set_background(img,\"black\")\n",
     "    img.to_pil().save(filename+fmt)\n",
     "    return img if _return else None\n",
     "\n",
@@ -443,7 +449,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Eventually, we can zoom in far enough to see individual datapoints, which we make more visible here using the `tf.spread` function to enlarge each point to cover multiple pixels.  Here we can see that the Chinatown region of Chicago has, as expected, very high numbers of Asian residents, and that other nearby regions (separated by features like roads and highways) have other races, varying in how uniformly segregated they are:"
+    "Eventually, we can zoom in far enough to see individual datapoints.  Here we can see that the Chinatown region of Chicago has, as expected, very high numbers of Asian residents, and that other nearby regions (separated by features like roads and highways) have other races, varying in how uniformly segregated they are:"
    ]
   },
   {
@@ -461,9 +467,108 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that we've used the `tf.spread` function to enlarge each point to cover multiple pixels so that each point is clearly visible.  Instead of the default circular spreading, you could choose `shape='square'` if you prefer, or any mask shape, e.g.:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mask = np.array([[1, 1, 1, 1, 1],\n",
+    "                 [1, 0, 0, 0, 1],\n",
+    "                 [1, 0, 0, 0, 1],\n",
+    "                 [1, 0, 0, 0, 1],\n",
+    "                 [1, 1, 1, 1, 1]])\n",
+    "\n",
+    "export(tf.spread(create_image(*Chinatown), mask=mask),\"Chinatown outlines\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Other cities, for comparison\n",
+    "\n",
+    "Different cities have very different racial makeup, but they all appear highly segregated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(create_image(*NewYorkCity),\"NYC\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(create_image(*LosAngeles),\"LosAngeles\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(create_image(*Houston),\"Houston\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(create_image(*Atlanta),\"Atlanta\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(create_image(*NewOrleans),\"NewOrleans\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(create_image(*Austin),\"Austin\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Analyzing racial data through visualization\n",
     "\n",
-    "Now that we have categorical data, we can break it down and ask specific questions.  For instance, if we switch back to the full USA and then select only the black population, we can see that blacks predominantly reside in urban areas except in the South and the East Coast:"
+    "In addition to simply visualizing categorical data, we can break it down and ask specific questions.  For instance, if we switch back to the full USA and then select only the black population, we can see that blacks predominantly reside in urban areas except in the South and the East Coast:"
    ]
   },
   {
@@ -477,7 +582,7 @@
     "cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height)\n",
     "agg = cvs.points(df, 'meterswest', 'metersnorth', ds.count_cat('race'))\n",
     "\n",
-    "tf.interpolate(agg.sel(race='b'), cmap=cm(Greys9,0.25), how='eq_hist')"
+    "export(tf.interpolate(agg.sel(race='b'), cmap=cm(Greys9,0.25), how='eq_hist'),\"USA blacks\")"
    ]
   },
   {
@@ -497,7 +602,8 @@
    },
    "outputs": [],
    "source": [
-    "tf.colorize(agg.where((agg.sel(race=['w', 'b', 'a', 'h']) > 0).all(dim='race')).fillna(0), color_key, how='eq_hist')"
+    "agg2 = agg.where((agg.sel(race=['w', 'b', 'a', 'h']) > 0).all(dim='race')).fillna(0)\n",
+    "export(tf.colorize(agg2, color_key, how='eq_hist'),\"USA all\")"
    ]
   },
   {
@@ -517,7 +623,7 @@
    },
    "outputs": [],
    "source": [
-    "tf.colorize(agg.where(agg.sel(race='w') < agg.sel(race='b')).fillna(0), color_key, how='eq_hist')"
+    "export(tf.colorize(agg.where(agg.sel(race='w') < agg.sel(race='b')).fillna(0), color_key, how='eq_hist'),\"more_blacks\")"
    ]
   },
   {

--- a/examples/census.ipynb
+++ b/examples/census.ipynb
@@ -315,7 +315,7 @@
    },
    "outputs": [],
    "source": [
-    "export(tf.interpolate(agg, cmap=cm(viridis), how='eq_hist'),\"census_viridis_eq_hist.png\")"
+    "export(tf.interpolate(agg, cmap=cm(viridis), how='eq_hist'),\"census_viridis_eq_hist\")"
    ]
   },
   {

--- a/examples/nyc_taxi-nongeo.ipynb
+++ b/examples/nyc_taxi-nongeo.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Plotting non-geographic data\n",
     "\n",
-    "Most of the datashader examples use geographic data, because it is so easily interpreted.  But datashading will help exploration of any data dimensions.  Here let's plot `trip_distance` versus `fare_amount` for the 12-million-point NYC taxi dataset from nyc_taxi.ipynb. "
+    "Most of the datashader examples use geographic data, because it is so easily interpreted, but datashading will help exploration of any data dimensions.  Here let's start by plotting `trip_distance` versus `fare_amount` for the 12-million-point NYC taxi dataset from nyc_taxi.ipynb. "
    ]
   },
   {
@@ -158,6 +158,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here we're using the default histogram-equalized color mapping function to reveal density differences across this space.  If we used a linear mapping, we can mainly see that there are a lot of values near the origin, but all the rest are colored the same minimum (defaulting to light blue) color:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from datashader import transfer_functions as tf\n",
+    "import functools as ft\n",
+    "color_fn = ft.partial(tf.interpolate,how='linear')\n",
+    "\n",
+    "p = base_plot()\n",
+    "pipeline = ds.Pipeline(df, ds.Point(\"trip_distance\", \"fare_amount\"), color_fn=color_fn)\n",
+    "InteractiveImage(p, pipeline)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Fares are discretized to the nearest 50 cents, making patterns less visible, but there is both an upward trend in tips as fares increase (as expected), but also a large number of tips higher than the fare itself, which is surprising:"
    ]
   },
@@ -217,21 +242,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.4"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/examples/osm.ipynb
+++ b/examples/osm.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Data taken from Open Street Map's (OSM) [bulk GPS point data](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). This data was collected by OSM contributors' GPS devices, and is stored as a csv of `latitude,longitude` coordinates. The data was downloaded from their website, extracted, and stored in a [castra](https://github.com/blaze/castra) file for faster disk access. To run this notebook, you would need to do the same, as the data files are too large to ship with `datashader`.  Here we'll plot the points using [datashader](https://github.com/bokeh/datashader) and [dask](http://dask.pydata.org/en/latest/), after first loading them:"
+    "Data taken from Open Street Map's (OSM) [bulk GPS point data](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). This data was collected by OSM contributors' GPS devices, and is stored as a csv of `latitude,longitude` coordinates. The data was downloaded from their website, extracted, converted to use positions in Web Mercator format, and stored in a [castra](https://github.com/blaze/castra) file for faster disk access. To run this notebook, you would need to do the same, as the data files are too large to ship with `datashader`.  Here we'll plot the points using [datashader](https://github.com/bokeh/datashader) and [dask](http://dask.pydata.org/en/latest/), after first loading them:"
    ]
   },
   {
@@ -124,7 +124,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result is a decent map of world population, with Europe apparently having particularly many OpenStreetMap contributors. The long great-circle paths are presumably flight or boat trips, from devices that communicate with the OpenStreetMap servers more than 20 times during the space of one pixel in this plot."
+    "The result is a decent map of world population, with Europe apparently having particularly many OpenStreetMap contributors. The long great-circle paths are presumably flight or boat trips, from devices that log their GPS coordinates more than 20 times during the space of one pixel in this plot."
    ]
   },
   {
@@ -181,7 +181,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have enough RAM to hold the whole dataset, you can uncomment the `InteractiveImage` line below and run the cell to build an interactive plot where you can select a region for zooming. (Without enough RAM, computation has to be done out of core, and it could take several CPU-intensive minutes to process a series of pan and zoom events before the final result will be displayed.)"
+    "If you have enough RAM to hold the whole dataset (or are very patient), you can uncomment the `InteractiveImage` line below and run the cell to build an interactive plot where you can select a region for zooming. Without enough RAM, computation has to be done out of core, and it could take several CPU-intensive minutes to process a series of pan and zoom events before the final result will be displayed.\n",
+    "\n",
+    "The throttle setting can be used to make the response time match the performance of your system; for `throttle=5000` it waits 5 seconds for you to pan or zoom before initiating the re-draw, allowing you to select the appropriate region before the computation is started."
    ]
   },
   {

--- a/examples/trajectory.ipynb
+++ b/examples/trajectory.ipynb
@@ -21,7 +21,10 @@
     "import numpy as np\n",
     "import xarray as xr\n",
     "import datashader as ds\n",
-    "import datashader.transfer_functions as tf"
+    "import datashader.transfer_functions as tf\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore', category=DeprecationWarning)"
    ]
   },
   {

--- a/examples/tseries.ipynb
+++ b/examples/tseries.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# Timeseries\n",
     "\n",
-    "In many domains it is common to plot scalar values as a function of time (or other single dimensions).  As long as the total number of datapoints is relatively low (in the tens of thousands, perhaps) and there are only a few separate curves involved, most plotting packages will do well.  However, for longer or more frequent sampling, you'll be required to subsample your data before plotting, potentially missing important peaks or troughs in the data.  And even just a few timeseries visualized together quickly run into [overplotting](https://anaconda.org/jbednar/plotting_problems/notebook) issues, where only the most recently plotted curve is visible, which can be highly misleading.\n",
+    "In many domains it is common to plot scalar values as a function of time (or other single dimensions).  As long as the total number of datapoints is relatively low (in the tens of thousands, perhaps) and there are only a few separate curves involved, most plotting packages will do well.  However, for longer or more frequent sampling, you'll be required to subsample your data before plotting, potentially missing important peaks or troughs in the data.  And even just a few timeseries visualized together quickly run into highly misleading [overplotting](https://anaconda.org/jbednar/plotting_problems/notebook) issues, making the most recently plotted curves unduly prominent.\n",
     "\n",
-    "For applications with many datapoints or when visualizing multiple curves, datashader provides a principled way to view *all* of your data.  In this example, we will synthesize several time series curves so that we know their properties, and then show how datashader can reveal them."
+    "For applications with many datapoints or when visualizing multiple curves, datashader provides a principled way to view *all* of your data.  In this example, we will synthesize several time-series curves so that we know their properties, and then show how datashader can reveal them."
    ]
   },
   {
@@ -24,7 +24,10 @@
     "import xarray as xr\n",
     "import datashader as ds\n",
     "import datashader.transfer_functions as tf\n",
-    "from collections import OrderedDict"
+    "from collections import OrderedDict\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore', category=DeprecationWarning)"
    ]
   },
   {
@@ -33,7 +36,7 @@
    "source": [
     "## Create some fake timeseries data\n",
     "\n",
-    "Here we create a fake time series, then generate many noisy samples of that time series.  We will also add a couple of \"rogue\" lines, with different statistical properties, and see how well those are visible compared to the rest."
+    "Here we create a fake time series signal, then generate many noisy versions of it.  We will also add a couple of \"rogue\" lines, with different statistical properties, and see how well those stand out from the rest."
    ]
   },
   {
@@ -45,9 +48,9 @@
    "outputs": [],
    "source": [
     "# Constants\n",
-    "np.random.seed(42)\n",
+    "np.random.seed(2)\n",
     "n = 100000                           # Number of points\n",
-    "cols = list('abcdefgh')            # Column names of samples\n",
+    "cols = list('abcdefg')               # Column names of samples\n",
     "start = 1456297053                   # Start time\n",
     "end = start + 60 * 60 * 24           # End time   \n",
     "\n",
@@ -57,24 +60,26 @@
     "\n",
     "# Generate many noisy samples from the signal\n",
     "noise = lambda var, bias, n: np.random.normal(bias, var, n)\n",
-    "data = {c: noise(1, 5*(np.random.random() - 0.5), n) + signal for c in cols}\n",
+    "data = {c: signal + noise(1, 10*(np.random.random() - 0.5), n) for c in cols}\n",
     "\n",
-    "# Add one \"rogue line\" that diverges from the rest\n",
-    "cols += ['y']\n",
-    "data['y'] = signal + np.random.normal(0, 0.015, size=n).cumsum()\n",
+    "# Add some \"rogue lines\" that differ from the rest \n",
+    "cols += ['x'] ; data['x'] = signal + np.random.normal(0, 0.02, size=n).cumsum() # Gradually diverges\n",
+    "cols += ['y'] ; data['y'] = signal + noise(1, 20*(np.random.random() - 0.5), n) # Much noisier\n",
+    "cols += ['z'] ; data['z'] = signal # No noise at all\n",
     "\n",
-    "# Add another \"rogue line\" that has no noise, unlike the rest\n",
-    "cols += ['z']\n",
-    "data['z'] = signal\n",
+    "# Pick a few samples from the first line and really blow them out\n",
+    "locs = np.random.choice(n, 10)\n",
+    "data['a'][locs] *= 2\n",
+    "\n",
+    "# Default plot ranges:\n",
+    "x_range = (start, end)\n",
+    "y_range = (1.2*signal.min(), 1.2*signal.max())\n",
+    "\n",
+    "print(\"x_range: {0} y_range: {0}\".format(x_range,y_range))\n",
     "\n",
     "# Create a dataframe\n",
     "data['Time'] = np.linspace(start, end, n)\n",
     "df = pd.DataFrame(data)\n",
-    "\n",
-    "# Default plot ranges:\n",
-    "x_range = (start, end)\n",
-    "y_range = (signal.min(), signal.max())\n",
-    "\n",
     "df.tail()"
    ]
   },
@@ -82,9 +87,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Static Plots\n",
+    "## Plotting *all* the datapoints\n",
     "\n",
-    "To simulate what would happen in a standard plotting program, let's first use datashader to draw each curve into an aggregate grid, by connecting each datapoint in the series, and let's look at the first such plot."
+    "With datashader, we can plot *all* the datapoints for a given timeseries.  Let's select the first curve 'a' and draw it into an aggregate grid, connecting each datapoint in the series:"
    ]
   },
   {
@@ -96,9 +101,9 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "cvs = ds.Canvas(x_range=x_range, y_range=y_range, plot_height=300)\n",
+    "cvs = ds.Canvas(x_range=x_range, y_range=y_range, plot_height=300, plot_width=900)\n",
     "aggs= OrderedDict((c, cvs.line(df, 'Time', c)) for c in cols)\n",
-    "img = tf.interpolate(aggs['a'], cmap=[\"lighblue\", \"red\"])"
+    "img = tf.interpolate(aggs['a'])"
    ]
   },
   {
@@ -116,12 +121,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we're using all 100,000 datapoints for this curve, and could easily handle 1 million or 10 million (try \n",
-    "changing `n = ` above and re-running the notebook).  Because no downsampling was required, we know we aren't missing any stray sharp peaks (e.g. noise values) that might have been skipped in other approaches.  Other than that, the results should be similar to those in other plotting programs.\n",
+    "The result looks similar to what you might find in any plotting program, but it uses all 100,000 datapoints, and would work similarly for 1, 10, or 100 million points (determined by the `n` attribute above).  \n",
     "\n",
-    "What happens if we then overlay multiple such curves?  In a traditional plotting program, there would be serious issues with overplotting, because these curves are highly overlapping.  To show what would typically happen, let's merge the images corresponding to each of the curves:\n",
-    "\n",
-    "\n"
+    "Why is using all the datapoints important? To see, let's downsample the data by a factor of 10, plotting 10,000 datapoints for the same curve:"
    ]
   },
   {
@@ -132,35 +134,21 @@
    },
    "outputs": [],
    "source": [
-    "colors = [\"yellow\", \"green\", \"orange\", \"purple\", \"red\",\n",
-    "          \"pink\", \"brown\", \"grey\", \"black\", \"blue\"]\n",
-    "imgs = [tf.interpolate(aggs[n], cmap=[c]) for n, c in zip(cols, colors)]\n",
-    "tf.stack(*imgs)"
+    "sampling = 10\n",
+    "df2 = pd.DataFrame({'a':data['a'][::sampling], 'Time':np.linspace(start, end, n/sampling)})\n",
+    "tf.interpolate(cvs.line(df2, 'Time', 'a'))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here the last-plotted curve, which happens to be the low-noise rogue curve, is clearly visible, but due to overplotting it will be entirely invisible if we plot precisely the same data in the opposite order:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "tf.stack(*reversed(imgs))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If what we are interested in are (a) the overall trends, and (b) any curves that differ from those trends, we can avoid overplotting by combining the plots at the aggregate level, not just the image level as above.  At the aggregate level, curves have no associated color (though we could treat them as categories to add that information; see the census_race.ipynb example), and instead add together arithmetically.  First, lets try looking at data for all the timeseries merged into one aggregate:"
+    "The resulting plot is similar, but now none of the \"blown up\" datapoints (sharp spikes) that were clearly visible in the first version are visible at all!  They didn't happen to be amongst the sampled points, and thus do not show up in this plot, which should never be a problem using datashader with all the points.\n",
+    "\n",
+    "\n",
+    "## Overplotting problems\n",
+    "\n",
+    "What happens if we then overlay multiple such curves?  In a traditional plotting program, there would be serious issues with overplotting, because these curves are highly overlapping.  To show what would typically happen, let's merge the images corresponding to each of the curves:"
    ]
   },
   {
@@ -179,7 +167,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `any` operator merges all the data such that any pixel that is lit up for any curve is lit up in the final result.  Clearly, it is difficult to see any structure in this fully overplotted data.  Instead, let's merge the curves by summing them and displaying low-count pixels as light blue and high-count pixels as dark blue:"
+    "The `any` operator merges all the data such that any pixel that is lit up for any curve is lit up in the final result.  Clearly, it is difficult to see any structure in this fully overplotted data; all we can see is the envelope of these curves, i.e. the minimum and maximum value of any curve for any given time point. It remains completely unclear how the various curves in the set relate to each other.  Here we know that we put in one particularly noisy curve, which presumably determines the envelope, but there's no way to tell that from the plot.\n",
+    "\n",
+    "We can of course try giving each curve a different color:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "colors = [\"red\", \"grey\", \"black\", \"purple\", \"pink\",\n",
+    "          \"yellow\", \"brown\", \"green\", \"orange\", \"blue\"]\n",
+    "imgs = [tf.interpolate(aggs[i], cmap=[c]) for i, c in zip(cols, colors)]\n",
+    "tf.stack(*imgs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But that doesn't help much; there are 10 curves, but only three or four colors are visible, due to overplotting.  Problems like that will just get much worse if there are 100, 1000, or 1 million curves.  Moreover, the results will look entirely different if we plot them in the opposite order:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tf.stack(*reversed(imgs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Having the visualization look completely different for an arbitrary choice like the plotting order is a serious problem if we want to understand the properties of this data, from the data itself.\n",
+    "\n",
+    "## Trends and outliers\n",
+    "\n",
+    "So, what might we be interested in understanding when plotting many curves?  One possibility is the combination of (a) the overall trends, and (b) any curves (and individual datapoints) that differ from those trends.  \n",
+    "\n",
+    "To look at the trends, we should combine the plots not by overplotting as in each of the above examples, but using operators that accurately reveal overlap between the curves.  When doing so, we won't try to discern individual curves directly by assigning them unique colors, but instead try to show areas of the curves that establish the trends and differ from them.  (Assigning colors per curve could be done as for the racial categories in census.ipynb, but that won't be further investigated here.)\n",
+    "\n",
+    "Instead of the `.any()` operator above that resulted in complete overplotting, or the `tf.stack` operator that depended strongly on the plotting order, let's use the `.sum()` operator to reveal the full patterns of overlap arithmetically:"
    ]
   },
   {
@@ -191,7 +228,9 @@
    },
    "outputs": [],
    "source": [
-    "total = tf.interpolate(merged.sum(dim='cols'), cmap=[\"lightblue\", \"darkblue\"], how='linear')\n",
+    "from datashader.colors import viridis\n",
+    "\n",
+    "total = tf.interpolate(merged.sum(dim='cols'), cmap=reversed(viridis), how='linear')\n",
     "total"
    ]
   },
@@ -199,12 +238,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now the structure of this set of data should be clear -- there are numerous curves that are highly correlated apart from noise, and there is one curve that starts out being similar but gradually diverges (which shows up as a light blue curve towards the bottom right).  This structure, which we know was true from how we generated the data, only becomes clear when the data is combined in a principled way that avoids overplotting.\n",
+    "With study, the overall structure of this dataset should be clear, according to what we know we put in when we created them:\n",
+    "\n",
+    "1. Individual rogue datapoints from curve 'a' are clearly visible (the seven sharp spikes)\n",
+    "2. The trend is clearly visible (for the viridis colormap, the darkest greens show the areas of highest overlap)\n",
+    "3. Line 'x' that gradually diverges from the trend is clearly visible (as the yellow (low-count) areas that increase below the right half of the plot).\n",
+    "\n",
+    "(Note that if you change the random seed or the number of datapoints, the specific values and locations will differ from those mentioned in the text.)\n",
+    "\n",
+    "None of these observations would have been possible with downsampled, overplotted curves as would be typical of other plotting approaches.\n",
     "\n",
     "\n",
     "## Highlighting specific curves\n",
     "\n",
-    "As you may recall, we added two \"rogue\" curves, one of which we were able to detect above because it had low overlap with the other ones (due to gradually diverging values).  The other curve, however, is buried deep within the pack, because it differs only by having lower noise.  One way to detect it is to highlight each of the curves in turn, and display it in relation to the datashaded average values.  For instance, any of the noisy curves stand out very little from the pack:"
+    "The data set also includes a couple of traces that are difficult to detect in the `.sum()` plot above, one with no noise and one with much higher noise.  One way to detect such issues is to highlight each of the curves in turn, and display it in relation to the datashaded average values.  For instance, those two curves (each highlighted in red below) stand out against the pack as having less or more noise than is typical:"
    ]
   },
   {
@@ -216,28 +263,18 @@
    },
    "outputs": [],
    "source": [
-    "img = tf.interpolate(aggs['a'], cmap=[\"lightblue\", \"red\"])\n",
-    "tf.stack(total, img)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "While the no-noise curve can be seen clearly against the pack:"
+    "tf.stack(total, tf.interpolate(aggs['z'], cmap=[\"lightblue\", \"red\"]))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "scrolled": false
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "img = tf.interpolate(aggs['z'], high=[\"lightblue\", \"red\"])\n",
-    "tf.stack(total, img)"
+    "tf.stack(total, tf.interpolate(aggs['y'], cmap=[\"lightblue\", \"red\"]))"
    ]
   },
   {
@@ -246,7 +283,7 @@
    "source": [
     "## Dynamic Plots\n",
     "\n",
-    "In practice, it might be difficult to cycle through each of the curves to find the one that was different, as done above.  Perhaps a criterion based on similarity could be devised, choosing the curve most dissimilar from the rest to plot in this way, which would be an interesting topic for future research.  In any case, one thing that can always be done is to make the plot fully interactive, so that the viewer can zoom in and discover such patterns dynamically.\n",
+    "In practice, it might be difficult to cycle through each of the curves to find one that's different, as done above.  Perhaps a criterion based on similarity could be devised, choosing the curve most dissimilar from the rest to plot in this way, which would be an interesting topic for future research.  In any case, one thing that can always be done is to make the plot fully interactive, so that the viewer can zoom in and discover such patterns dynamically.\n",
     "If you are looking at a live, running version of this notebook, just enable the wheel zoom or box zoom tools, and then zoom and pan as you wish:"
    ]
   },
@@ -258,17 +295,26 @@
    },
    "outputs": [],
    "source": [
-    "from datashader.callbacks import InteractiveImage\n",
+    "from bokeh.models import DatetimeTickFormatter\n",
     "import bokeh.plotting as bp\n",
     "bp.output_notebook()\n",
     "\n",
-    "def base_plot(tools='pan,wheel_zoom,box_zoom,reset'):\n",
+    "formatter = DatetimeTickFormatter(formats = dict(\n",
+    "        microseconds=['%fus', '%H:%M %3fus', '%F %H:%M %3fus'],\n",
+    "        milliseconds=['%S.%3Ns', '%H:%M %3Nms', '%F %H:%M %3Nms'],\n",
+    "        seconds=['%Ss'],# '%H:%M:%S'],\n",
+    "        minsec=[':%M:%S', '%H:%M:%S'],\n",
+    "        hours=['%H:%M', '%F %H:%M'],\n",
+    "        days=['%F']))\n",
+    "\n",
+    "def base_plot(tools='pan,wheel_zoom,box_zoom,resize,reset'):\n",
     "    p = bp.figure(tools=tools, plot_width=600, plot_height=300,\n",
     "        x_range=x_range, y_range=y_range, outline_line_color=None,\n",
     "        min_border=0, min_border_left=0, min_border_right=0,\n",
-    "        min_border_top=0, min_border_bottom=0)   \n",
+    "        min_border_top=0, min_border_bottom=0, responsive=True)   \n",
     "    p.xgrid.grid_line_color = None\n",
     "    p.ygrid.grid_line_color = None\n",
+    "    p.xaxis.formatter = formatter\n",
     "    return p"
    ]
   },
@@ -280,23 +326,96 @@
    },
    "outputs": [],
    "source": [
+    "from datashader.callbacks import InteractiveImage\n",
     "def create_image(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(x_range=x_range, y_range=y_range,\n",
     "                    plot_height=h, plot_width=w)\n",
     "    aggs = OrderedDict((c,cvs.line(df, 'Time', c)) for c in cols)\n",
     "    merged = xr.concat(aggs.values(), dim=pd.Index(cols, name='cols'))\n",
-    "    img = tf.interpolate(merged.sum(dim='cols'), how='log')\n",
+    "    total = merged.sum(dim='cols')\n",
+    "    img = tf.interpolate(total, cmap=reversed(viridis), how='eq_hist')\n",
     "    return img\n",
     "    \n",
     "p = base_plot()\n",
-    "InteractiveImage(p, create_image)"
+    "InteractiveImage(p, create_image, throttle=500)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here the diverging \"rogue line\" is immediately apparent, and if you zoom in you can see precisely how it differs from the rest at a given time.  The low-noise \"rogue line\" is much harder to see, but if you zoom in enough (particularly if you stretch out the x axis by zooming on the axis itself), you can see that one line goes through the middle of the pack, with different properties from the rest.  The datashader team is working on support for hover-tool information to reveal what line that was, and in general on better support for exploring large timeseries (and other curve) data."
+    "Here the diverging \"rogue line\" is immediately apparent, and if you zoom in towards the right you can see precisely how it differs from the rest.  The low-noise \"rogue line\" is much harder to see, but if you zoom in enough (particularly if you stretch out the x axis by zooming on the axis itself), you can see that one line goes through the middle of the pack, with different properties from the rest.  The datashader team is working on support for hover-tool information to reveal what line that was, and in general on better support for exploring large timeseries (and other curve) data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Multiple trends\n",
+    "\n",
+    "The above curves were very highly overlapping to illustrate a worst-case scenario, but now let's look at a case with curves that diverge more strongly from each other.   For instance, imagine that we have a simulation where one of three qualitatively different decisions are made at the starting time (perhaps three different parameter settings), along with noisy samples from each group, and we want to see what effect that has on the overall expected state into the future.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's create time series in three different groups, each of which are similar to each other, but each group differing from each other as they diverge from a common starting point.  For instance, in a simulation run, each group could be from setting a different parameter, while each noisy version could be different runs with a different seed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "signals = [np.random.normal(0, 0.3, size=n).cumsum() + 50,\n",
+    "           np.random.normal(0, 0.3, size=n).cumsum() + 50,\n",
+    "           np.random.normal(0, 0.3, size=n).cumsum() + 50]\n",
+    "data = {c: signals[i%3] + noise(1+i, 5*(np.random.random() - 0.5), n)  for (i,c) in enumerate(cols)}\n",
+    "y_range = (1.2*min([s.min() for s in signals]), 1.2*max([s.max() for s in signals]))    \n",
+    "\n",
+    "data['Time'] = np.linspace(start, end, n)\n",
+    "df = pd.DataFrame(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And let's examine the result interactively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def create_image3(x_range, y_range, w, h, df=df):\n",
+    "    cvs = ds.Canvas(x_range=x_range, y_range=y_range,\n",
+    "                    plot_height=h, plot_width=w)\n",
+    "    aggs = [cvs.line(df, 'Time', c) for c in cols]\n",
+    "    merged = xr.concat(aggs, dim=pd.Index(cols, name='cols'))\n",
+    "    total = merged.mean(dim='cols')\n",
+    "    image = tf.interpolate(total, how='linear', cmap=reversed(viridis))\n",
+    "    return image\n",
+    "\n",
+    "p2 = base_plot()\n",
+    "InteractiveImage(p2, create_image3,df=df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here the three groups can clearly be seen, at least once they diverge sufficiently, as well as the areas of high overlap (high probability of being in that state at that time).  Additional patterns are visible when zooming in, all teh way down to the individual datapoints, and again it may be useful to zoom first on the x axis (to make enough room on your screen to distinguish the datapoints, since there are 100,00 of them and only a few thousand pixels at most on your screen!)."
    ]
   }
  ],


### PR DESCRIPTION
This PR is still somewhat WIP, but it's ready for the individual commits to reviewed:

> 648926c Allowed cmap to accept a reversed() list

Allows cmap=reversed(Greys9), instead of the awkward cmap=list(reversed(Greys9))

> c6162a2 Changed smallest circle shape for spreading from a + to a square

I think a square is less visually distracting, but could be persuaded otherwise.

> d2e3d9b Changed default bin number for eq_hist improve accuracy of float normalization

eq_hist ignores the bin number for integers, which is what we usually use it for, but for floats it's crucial to have enough bins.  256 is clearly not enough, but I'm not sure how high to go.

> 4611376 Added spreading support for Pipeline, now defaulting to dynspread

A Pipeline is meant as a simple object that covers most cases, and in e.g. the non-geo example we definitely need spreading by default, since the datapoints are all very far from each other.

> a55302f Expanded and updated timeseries notebook

Incorporated Peter's edits and clarified why downsampling is dangerous for time series.

> 0a640e9 Changed default interpolate and colorize method to eq_hist

The two defensible choices for the default interpolate method are eq_hist and linear.  eq_hist seems safer since it reveals structure that one might not realize was there otherwise.

> 8305880 Minor census cleanup
> 85792d9 Updated non-geo example to use eq_hist

Minor updates to bring notebooks up to date.