### PR TITLE
InteractiveImage callback checks if underscore is available

### DIFF
--- a/datashader/bokeh_ext.py
+++ b/datashader/bokeh_ext.py
@@ -85,7 +85,7 @@ class InteractiveImage(object):
         var throttled_cb = Bokeh._throttle['{ref}'];
         if (throttled_cb) {{
             throttled_cb()
-        }} else {{
+        }} else if (_ !== undefined) {{
             Bokeh._throttle['{ref}'] = _.throttle(update_plot, {throttle},
                                                   {{leading: false}});
             Bokeh._throttle['{ref}']()


### PR DESCRIPTION
Small fix to ensure zooming does not break on static pages.