### PR TITLE
added initial support for raster datasets

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -172,6 +172,7 @@ class Canvas(object):
                source,
                band=1,
                resample_method='bilinear',
+               use_overviews=True,
                missing=None):
         """Sample a raster dataset by canvas size and bounds. Note: requires
         `rasterio` and `scikit-image`.
@@ -188,6 +189,8 @@ class Canvas(object):
         resample_method : str, optional default=bilinear
             resample mode when resizing raster.
             options include: nearest, bilinear.
+        use_overviews : bool, optional default=True
+            flag to indicate whether to use overviews or use native resolution
 
         Returns
         -------
@@ -226,7 +229,11 @@ class Canvas(object):
         rmin, cmin = source.index(self.x_range[0], self.y_range[0])
         rmax, cmax = source.index(self.x_range[1], self.y_range[1])
 
-        data = source.read(band, window=((rmax, rmin), (cmin, cmax)))
+        if use_overviews:
+            data = np.empty(shape=(w, h)).astype(source.profile['dtype'])
+            data = source.read(band, out=data, window=((rmax, rmin), (cmin, cmax)))
+        else:
+            data = source.read(band, window=((rmax, rmin), (cmin, cmax)))
 
         if missing and source.nodata:
             data[data == source.nodata] = missing

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -113,7 +113,7 @@ def _normalize_interpolate_how(how):
     raise ValueError("Unknown interpolation method: {0}".format(how))
 
 
-def interpolate(agg, low=None, high=None, cmap=None, how='eq_hist', alpha=255):
+def interpolate(agg, low=None, high=None, cmap=None, how='eq_hist', alpha=255, span=None):
     """Convert a 2D DataArray to an image.
 
     Data is converted to an image either by interpolating between a `low` and
@@ -140,6 +140,8 @@ def interpolate(agg, low=None, high=None, cmap=None, how='eq_hist', alpha=255):
         Value between 0 - 255 representing the alpha value of pixels which contain 
         data (i.e. non-nan values). Regardless of this value, `NaN` values are
         set to fully transparent.
+    span : list of min-max range
+        Min-max data values for interpolation, use this to override autoranging
     """
     if not isinstance(agg, xr.DataArray):
         raise TypeError("agg must be instance of DataArray")
@@ -171,7 +173,7 @@ def interpolate(agg, low=None, high=None, cmap=None, how='eq_hist', alpha=255):
         offset = data[~mask].min()
         interp = data - offset
     data = how(interp, mask)
-    span = [np.nanmin(data), np.nanmax(data)]
+    span = span if span else [np.nanmin(data), np.nanmax(data)]
     if isinstance(cmap, Iterator):
         cmap = list(cmap)
     if isinstance(cmap, list):

--- a/examples/get_raster_data.sh
+++ b/examples/get_raster_data.sh
@@ -1,0 +1,7 @@
+mkdir -p data
+cd data
+wget http://s3.amazonaws.com/bokeh_data/geotiff_example.zip
+unzip geotiff_example.zip
+rm geotiff_example.zip
+cd ..
+

--- a/examples/raster.py
+++ b/examples/raster.py
@@ -32,10 +32,7 @@ def update_image():
                        x_range=(xmin, xmax),
                        y_range=(ymin, ymax))
 
-    agg = canvas.raster(raster_data,
-                        nodata=-32768,
-                        replace_nodata=-100)
-
+    agg = canvas.raster(raster_data)
     img = tf.interpolate(agg, cmap=Hot, how='linear')
 
     new_data = {}

--- a/examples/raster.py
+++ b/examples/raster.py
@@ -1,17 +1,11 @@
 from __future__ import division
 
-import math
-
 from bokeh.io import curdoc
 from bokeh.plotting import Figure
 from bokeh.models import ColumnDataSource, CustomJS
 from bokeh.tile_providers import STAMEN_TONER
 
-import numpy as np
 import rasterio as rio
-
-from xarray import DataArray
-
 import datashader as ds
 import datashader.transfer_functions as tf
 from datashader.colors import Hot
@@ -21,8 +15,8 @@ def on_dims_change(attr, old, new):
 
 def update_image():
 
-    global dims, raster_data, angle, altitude
-    
+    global dims, raster_data
+
     dims_data = dims.data
 
     if not dims_data['width'] or not dims_data['height']:
@@ -54,7 +48,7 @@ def update_image():
 
 # load nyc taxi data
 path = './data/projected.tif'
-raster_data = rio.open(path) 
+raster_data = rio.open(path)
 
 # manage client-side dimensions
 dims = ColumnDataSource(data=dict(width=[], height=[], xmin=[], xmax=[], ymin=[], ymax=[]))

--- a/examples/raster.py
+++ b/examples/raster.py
@@ -1,0 +1,114 @@
+from __future__ import division
+
+import math
+
+from bokeh.io import curdoc
+from bokeh.plotting import Figure
+from bokeh.models import ColumnDataSource, CustomJS
+from bokeh.tile_providers import STAMEN_TONER
+
+import numpy as np
+import rasterio as rio
+
+from xarray import DataArray
+
+import datashader as ds
+import datashader.transfer_functions as tf
+from datashader.colors import Hot
+
+def on_dims_change(attr, old, new):
+    update_image()
+
+def update_image():
+
+    global dims, raster_data, angle, altitude
+    
+    dims_data = dims.data
+
+    if not dims_data['width'] or not dims_data['height']:
+        return
+
+    xmin = max(dims_data['xmin'][0], raster_data.bounds.left)
+    ymin = max(dims_data['ymin'][0], raster_data.bounds.bottom)
+    xmax = min(dims_data['xmax'][0], raster_data.bounds.right)
+    ymax = min(dims_data['ymax'][0], raster_data.bounds.top)
+
+    canvas = ds.Canvas(plot_width=dims_data['width'][0],
+                       plot_height=dims_data['height'][0],
+                       x_range=(xmin, xmax),
+                       y_range=(ymin, ymax))
+
+    agg = canvas.raster(raster_data,
+                        nodata=-32768,
+                        replace_nodata=-100)
+
+    img = tf.interpolate(agg, cmap=Hot, how='linear')
+
+    new_data = {}
+    new_data['image'] = [img.data]
+    new_data['x'] = [xmin]
+    new_data['y'] = [ymin]
+    new_data['dh'] = [ymax - ymin]
+    new_data['dw'] = [xmax - xmin]
+    image_source.stream(new_data, 1)
+
+# load nyc taxi data
+path = './data/projected.tif'
+raster_data = rio.open(path) 
+
+# manage client-side dimensions
+dims = ColumnDataSource(data=dict(width=[], height=[], xmin=[], xmax=[], ymin=[], ymax=[]))
+dims.on_change('data', on_dims_change)
+dims_jscode = """
+var update_dims = function () {
+    var new_data = {};
+    new_data['height'] = [plot.get('frame').get('height')];
+    new_data['width'] = [plot.get('frame').get('width')];
+    new_data['xmin'] = [plot.get('x_range').get('start')];
+    new_data['ymin'] = [plot.get('y_range').get('start')];
+    new_data['xmax'] = [plot.get('x_range').get('end')];
+    new_data['ymax'] = [plot.get('y_range').get('end')];
+    dims.set('data', new_data);
+};
+
+if (typeof throttle != 'undefined' && throttle != null) {
+    clearTimeout(throttle);
+}
+
+throttle = setTimeout(update_dims, 100, "replace");
+"""
+
+# Create plot -------------------------------
+xmin = -8240227.037
+ymin = 4974203.152
+xmax = -8231283.905
+ymax = 4979238.441
+
+path = './data/projected.tif'
+
+fig = Figure(x_range=(xmin, xmax),
+             y_range=(ymin, ymax),
+             plot_height=600,
+             plot_width=900,
+             tools='pan,wheel_zoom')
+fig.background_fill_color = 'black'
+fig.add_tile(STAMEN_TONER, alpha=0) # used to set axis ranges
+fig.x_range.callback = CustomJS(code=dims_jscode, args=dict(plot=fig, dims=dims))
+fig.y_range.callback = CustomJS(code=dims_jscode, args=dict(plot=fig, dims=dims))
+fig.axis.visible = False
+fig.grid.grid_line_alpha = 0
+fig.min_border_left = 0
+fig.min_border_right = 0
+fig.min_border_top = 0
+fig.min_border_bottom = 0
+
+image_source = ColumnDataSource(dict(image=[], x=[], y=[], dw=[], dh=[]))
+fig.image_rgba(source=image_source,
+               image='image',
+               x='x',
+               y='y',
+               dw='dw',
+               dh='dh',
+               dilate=False)
+
+curdoc().add_root(fig)


### PR DESCRIPTION
Adds support for raster dataset through integration with `rasterio`

- [x] add spelling for `Canvas.raster()`
- [x] add `raster.py` example.  To run example use `bokeh serve raster.py --show`
- [ ] test when example is outside data bounds
- [ ] add tests

Below is of raster with `colors.Hot` transfer function:
<img width="897" alt="screen shot 2016-05-16 at 4 02 44 pm" src="https://cloud.githubusercontent.com/assets/433221/15303893/d3561dfe-1b7f-11e6-8759-0ea51339e1cc.png">
