### PR TITLE
Notebook colors

### DIFF
--- a/datashader/colors.py
+++ b/datashader/colors.py
@@ -677,9 +677,9 @@ def colormap_select(base_colormap, start=0, end=1.0, reverse=False):
     For instance:
     
     >>> cmap = ["#000000", "#969696", "#d9d9d9", "#ffffff"]
-    >>> cm(cmap,reverse=True)
+    >>> colormap_select(cmap,reverse=True)
         ['#ffffff', '#d9d9d9', '#969696', '#000000']
-    >>> cm(cmap,0.3,reverse=True)
+    >>> colormap_select(cmap,0.3,reverse=True)
         ['#d9d9d9', '#969696', '#000000']
     """
     full = list(reversed(base_colormap) if reverse else base_colormap)

--- a/datashader/colors.py
+++ b/datashader/colors.py
@@ -667,3 +667,21 @@ _viridis_data = [[0.267004, 0.004874, 0.329415],
                  [0.993248, 0.906157, 0.143936]]
 viridis = _mpl_cmdata_to_bokeh_palette(_viridis_data)
 
+
+def colormap_select(base_colormap, start=0, end=1.0, reverse=False):
+    """
+    Given a colormap in the form of a list, such as a Bokeh palette,
+    return a version of the colormap reversed if requested, and selecting
+    a subset (on a scale 0,1.0) of the elements in the colormap list.
+    
+    For instance:
+    
+    >>> cmap = ["#000000", "#969696", "#d9d9d9", "#ffffff"]
+    >>> cm(cmap,reverse=True)
+        ['#ffffff', '#d9d9d9', '#969696', '#000000']
+    >>> cm(cmap,0.3,reverse=True)
+        ['#d9d9d9', '#969696', '#000000']
+    """
+    full = reversed(base_colormap) if reverse else base_colormap
+    num = len(full)
+    return full[int(start*num):int(end*num)]

--- a/datashader/colors.py
+++ b/datashader/colors.py
@@ -682,6 +682,6 @@ def colormap_select(base_colormap, start=0, end=1.0, reverse=False):
     >>> cm(cmap,0.3,reverse=True)
         ['#d9d9d9', '#969696', '#000000']
     """
-    full = reversed(base_colormap) if reverse else base_colormap
+    full = list(reversed(base_colormap) if reverse else base_colormap)
     num = len(full)
     return full[int(start*num):int(end*num)]

--- a/datashader/colors.py
+++ b/datashader/colors.py
@@ -678,9 +678,9 @@ def colormap_select(base_colormap, start=0, end=1.0, reverse=False):
     
     >>> cmap = ["#000000", "#969696", "#d9d9d9", "#ffffff"]
     >>> colormap_select(cmap,reverse=True)
-        ['#ffffff', '#d9d9d9', '#969696', '#000000']
+    ['#ffffff', '#d9d9d9', '#969696', '#000000']
     >>> colormap_select(cmap,0.3,reverse=True)
-        ['#d9d9d9', '#969696', '#000000']
+    ['#d9d9d9', '#969696', '#000000']
     """
     full = list(reversed(base_colormap) if reverse else base_colormap)
     num = len(full)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import os
+
 from inspect import getmro
 
 import numba as nb
@@ -10,7 +12,6 @@ from xarray import DataArray
 from datashape import Unit
 from datashape.predicates import launder
 from datashape.typesets import real
-
 
 ngjit = nb.jit(nopython=True, nogil=True)
 
@@ -118,3 +119,19 @@ def hold(f):
             last[:] = args, f(*args)
         return last[1]
     return _
+
+
+def export_image(img, filename, fmt=".png", _return=True, export_path=".", background=""):
+    """Given a datashader Image object, saves it to a disk file in the requested format"""
+    
+    from datashader.transfer_functions import set_background
+
+    if not os.path.exists(export_path):
+        os.mkdir(export_path)
+
+    if background:
+        img=set_background(img,background)
+        
+    img.to_pil().save(os.path.join(export_path,filename+fmt))
+    return img if _return else None
+                                    

--- a/examples/census.ipynb
+++ b/examples/census.ipynb
@@ -131,7 +131,7 @@
     "from IPython.core.display import HTML, display\n",
     "\n",
     "export = partial(export_image, background = background)\n",
-    "cm = partial(colormap_select, reverse=(background==\"black\"))\n",
+    "cm = partial(colormap_select, reverse=(background!=\"black\"))\n",
     "\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]

--- a/examples/census.ipynb
+++ b/examples/census.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "### Load data and set up\n",
     "\n",
-    "First, let's load this data using [dask](http://dask.pydata.org).  Dask lets you work with data in a variety of formats, and supports both in-core and out-of-core operation.  In-core operation is faster, so here we'll direct dask to load the entire dataset into memory (`df.cache(cache=dict)` below), but if you have less than 16GB RAM you may want to comment out that line to enable the out-of-core support. The data have been converted into castra format, which supports quick access, but CSV could have been used (with some performance penalty)."
+    "First, let's load this data into a Pandas or dask dataframe. Dask supports out of core operation, which is useful if you have less than 16GB of memory (in which case comment out the `df.cache(cache=dict)` line below).  Here we're using dask if the data is in the fast but not portable castra file format, and pandas if it's in HDF5:"
    ]
   },
   {
@@ -24,7 +24,6 @@
    "source": [
     "import datashader as ds\n",
     "import datashader.transfer_functions as tf\n",
-    "import dask.dataframe as dd\n",
     "import numpy as np\n",
     "import pandas as pd"
    ]
@@ -39,6 +38,7 @@
    "source": [
     "%%time\n",
     "try:\n",
+    "    import dask.dataframe as dd\n",
     "    df = dd.from_castra('data/census.castra')\n",
     "    df = df.cache(cache=dict)\n",
     "except:\n",
@@ -63,7 +63,7 @@
    "source": [
     "The output of `.tail()` shows that there are more than 300 million datapoints (one per person), each with a location in Web Mercator format, and that the race for each datapoint has been encoded as a single character (where 'w' is white, 'b' is black, 'a' is Asian, 'h' is Hispanic, and 'o' is other (typically Native American)).\n",
     "\n",
-    "Let's define some geographic ranges to look at later, and also a default plot size.  Feel free to increase `plot_width` to 2000 or more if you have a very large monitor or want to save files to disk, which shouldn't *greatly* affect the processing time or memory requirements.  "
+    "Let's define some geographic ranges to look at later, and also a default plot size.  Feel free to increase `plot_width` to 2000 or more if you have a very large monitor or want to save big files to disk, which shouldn't *greatly* affect the processing time or memory requirements.  "
    ]
   },
   {
@@ -96,7 +96,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's also choose a background color for our results.  A black background makes bright colors more vivid, and works well when later adding relatively dark satellite image backgrounds, but white backgrounds are good for examining the weakest patterns, and work well when adding vector-based maps with light colors.  Try it both ways and decide for yourself!"
+    "Let's also choose a background color for our results.  A black background makes bright colors more vivid, and works well when later adding relatively dark satellite image backgrounds, but white backgrounds (`background=None`) are good for examining the weakest patterns, and work well when adding vector-based maps with light colors.  Try it both ways and decide for yourself!"
    ]
   },
   {
@@ -107,17 +107,14 @@
    },
    "outputs": [],
    "source": [
-    "black_background = True\n",
-    "\n",
-    "from IPython.core.display import HTML, display\n",
-    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
+    "background = \"black\""
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll also need some utility functions:"
+    "We'll also need some utility functions and colormaps, and to make the page as big as possible:"
    ]
   },
   {
@@ -128,37 +125,15 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
-    "export_path=\"export\"\n",
-    "if not os.path.exists(export_path):\n",
-    "    os.mkdir(export_path)\n",
+    "from functools import partial\n",
+    "from datashader.utils import export_image\n",
+    "from datashader.colors import colormap_select, Greys9, Hot, viridis, inferno\n",
+    "from IPython.core.display import HTML, display\n",
     "\n",
-    "def export(img,filename,fmt=\".png\",_return=True):\n",
-    "    \"\"\"Given a datashader Image object, saves it to a disk file in the requested format\"\"\"\n",
-    "    if black_background: \n",
-    "        img=tf.set_background(img,\"black\")\n",
-    "    img.to_pil().save(os.path.join(export_path,filename+fmt))\n",
-    "    return img if _return else None\n",
+    "export = partial(export_image, background = background)\n",
+    "cm = partial(colormap_select, reverse=(background==\"black\"))\n",
     "\n",
-    "def cm(base_colormap, start=0, end=1.0, reverse=not black_background):\n",
-    "    \"\"\"\n",
-    "    Given a colormap in the form of a list, such as a Bokeh palette,\n",
-    "    return a version of the colormap reversed if requested, and selecting\n",
-    "    a subset (on a scale 0,1.0) of the elements in the colormap list.\n",
-    "    \n",
-    "    For instance:\n",
-    "    \n",
-    "    >>> cmap = [\"#000000\", \"#969696\", \"#d9d9d9\", \"#ffffff\"]\n",
-    "    >>> cm(cmap,reverse=True)\n",
-    "    ['#ffffff', '#d9d9d9', '#969696', '#000000']\n",
-    "    >>> cm(cmap,0.3,reverse=True)\n",
-    "    ['#d9d9d9', '#969696', '#000000']\n",
-    "    \"\"\"\n",
-    "    full = reversed(base_colormap) if reverse else base_colormap\n",
-    "    num = len(full)\n",
-    "    return full[int(start*num):int(end*num)]\n",
-    "\n",
-    "from datashader.colors import Greys9, Hot, viridis, inferno"
+    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },
   {
@@ -371,7 +346,7 @@
    },
    "outputs": [],
    "source": [
-    "if black_background:\n",
+    "if background == \"black\":\n",
     "      color_key = {'w':'aqua', 'b':'lime',  'a':'red', 'h':'fuchsia', 'o':'yellow' }\n",
     "else: color_key = {'w':'blue', 'b':'green', 'a':'red', 'h':'orange',  'o':'saddlebrown'}"
    ]
@@ -655,7 +630,7 @@
     "bp.output_notebook()\n",
     "\n",
     "def base_plot(tools='pan,wheel_zoom,reset',webgl=False):\n",
-    "    p = bp.figure(tools=tools, \n",
+    "    p = bp.figure(tools=tools,\n",
     "        plot_width=int(900*1.5), plot_height=int(500*1.5),\n",
     "        x_range=x_range, y_range=y_range, outline_line_color=None,\n",
     "        min_border=0, min_border_left=0, min_border_right=0,\n",
@@ -664,7 +639,6 @@
     "    p.axis.visible = False\n",
     "    p.xgrid.grid_line_color = None\n",
     "    p.ygrid.grid_line_color = None\n",
-    "    p.responsive = True\n",
     "    \n",
     "    return p"
    ]
@@ -697,7 +671,7 @@
     "url=\"http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.png\"\n",
     "#url=\"http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png\"\n",
     "tile_renderer = p.add_tile(WMTSTileSource(url=url))\n",
-    "tile_renderer.alpha=1.0 if black_background else 0.15\n",
+    "tile_renderer.alpha=1.0 if background == \"black\" else 0.15\n",
     "\n",
     "InteractiveImage(p, image_callback, throttle=2000)"
    ]
@@ -735,38 +709,29 @@
    "source": [
     "The dashboard.py example shows this same Census data in the context of an interactive dashboard, including color keys and hover information that help reveal the magnitudes at every location even while the plot faithfully reveals the structure."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   },
   "widgets": {
    "state": {},
-   "version": "1.1.1"
+   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/examples/nyc_taxi.ipynb
+++ b/examples/nyc_taxi.ipynb
@@ -56,10 +56,12 @@
     "\n",
     "output_notebook()\n",
     "\n",
-    "x_range=(-8250000,-8210000)\n",
-    "y_range=(4965000,4990000)\n",
+    "NYC = x_range, y_range = ((-8242000,-8210000), (4965000,4990000))\n",
     "\n",
-    "def base_plot(tools='pan,wheel_zoom,reset',plot_width=750, plot_height=500, **plot_args):\n",
+    "plot_width  = int(750)\n",
+    "plot_height = int(plot_width//1.2)\n",
+    "\n",
+    "def base_plot(tools='pan,wheel_zoom,reset',plot_width=plot_width, plot_height=plot_height, **plot_args):\n",
     "    p = figure(tools=tools, plot_width=plot_width, plot_height=plot_height,\n",
     "        x_range=x_range, y_range=y_range, outline_line_color=None,\n",
     "        min_border=0, min_border_left=0, min_border_right=0,\n",
@@ -70,10 +72,7 @@
     "    p.ygrid.grid_line_color = None\n",
     "    return p\n",
     "    \n",
-    "options = dict(line_color=None, fill_color='blue', size=5)\n",
-    "\n",
-    "from IPython.core.display import HTML, display\n",
-    "display(HTML(\"<style>.container { width:90% !important; }</style>\"))"
+    "options = dict(line_color=None, fill_color='blue', size=5)"
    ]
   },
   {
@@ -206,7 +205,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "cvs = ds.Canvas(plot_width=800, plot_height=500, x_range=x_range, y_range=y_range)\n",
+    "cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height, x_range=x_range, y_range=y_range)\n",
     "agg = cvs.points(df, 'dropoff_x', 'dropoff_y',  ds.count('passenger_count'))\n",
     "img = tf.interpolate(agg, cmap=[\"white\", 'darkblue'], how='linear')"
    ]
@@ -334,7 +333,7 @@
     "\n",
     "### 10-million-point datashaded plots: interactive\n",
     "\n",
-    "Although the above plots reveal the entire dataset at once, the full power of datashading requires an interactive plot, because a big dataset will usually have structure at very many different levels (such as different geographic regions).  Datashading allows auto-ranging and other automatic operations to be recomputed dynamically for the specific selected viewport, automatically revealing local structure that may not be visible from a global view.  Here we'll embed the generated images into a Bokeh plot to support fully interactive zooming.  For the highest detailon large monitors, you should increase the plot width and height below:"
+    "Although the above plots reveal the entire dataset at once, the full power of datashading requires an interactive plot, because a big dataset will usually have structure at very many different levels (such as different geographic regions).  Datashading allows auto-ranging and other automatic operations to be recomputed dynamically for the specific selected viewport, automatically revealing local structure that may not be visible from a global view.  Here we'll embed the generated images into a Bokeh plot to support fully interactive zooming.  For the highest detail on large monitors, you should increase the plot width and height above."
    ]
   },
   {
@@ -348,15 +347,23 @@
    "source": [
     "import datashader as ds\n",
     "from datashader.bokeh_ext import InteractiveImage\n",
-    "from datashader.colors import Hot, inferno\n",
+    "from functools import partial\n",
+    "from datashader.utils import export_image\n",
+    "from datashader.colors import colormap_select, Greys9, Hot, viridis, inferno\n",
+    "from IPython.core.display import HTML, display\n",
     "\n",
-    "def create_image(x_range, y_range, w, h):\n",
+    "background = \"black\"\n",
+    "export = partial(export_image, export_path=\"export\", background=background)\n",
+    "cm = partial(colormap_select, reverse=(background==\"black\"))\n",
+    "\n",
+    "def create_image(x_range, y_range, w=plot_width, h=plot_height):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
     "    agg = cvs.points(df, 'dropoff_x', 'dropoff_y',  ds.count('passenger_count'))\n",
     "    img = tf.interpolate(agg, cmap=Hot, how='eq_hist')\n",
     "    return tf.dynspread(img, threshold=0.5, max_px=4)\n",
     "\n",
-    "p = base_plot(background_fill_color=\"black\",responsive=True)\n",
+    "p = base_plot(background_fill_color=background)\n",
+    "export(create_image(*NYC),\"NYCT_hot\")\n",
     "InteractiveImage(p, create_image)"
    ]
   },
@@ -384,7 +391,7 @@
     "import numpy as np\n",
     "from functools import partial\n",
     "\n",
-    "def create_image90(x_range, y_range, w, h):\n",
+    "def create_image90(x_range, y_range, w=plot_width, h=plot_height):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
     "    agg = cvs.points(df, 'dropoff_x', 'dropoff_y',  ds.count('passenger_count'))\n",
     "    img = tf.interpolate(agg.where(agg>np.percentile(agg,90)), cmap=inferno, how='eq_hist')\n",
@@ -392,6 +399,7 @@
     "    \n",
     "p = base_plot()\n",
     "p.add_tile(STAMEN_TERRAIN)\n",
+    "export(create_image(*NYC),\"NYCT_90th\")\n",
     "InteractiveImage(p, create_image90)"
    ]
   },
@@ -413,16 +421,17 @@
    },
    "outputs": [],
    "source": [
-    "def merged_images(x_range, y_range, w, h, how='log'):\n",
+    "def merged_images(x_range, y_range, w=plot_width, h=plot_height, how='log'):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
     "    picks = cvs.points(df, 'pickup_x',  'pickup_y',  ds.count('passenger_count'))\n",
     "    drops = cvs.points(df, 'dropoff_x', 'dropoff_y', ds.count('passenger_count'))\n",
-    "    more_drops = tf.interpolate(drops.where(drops > picks), cmap=[\"lightblue\", 'blue'], how=how)\n",
-    "    more_picks = tf.interpolate(picks.where(picks > drops), cmap=[\"lightpink\", 'red'],  how=how)\n",
+    "    more_drops = tf.interpolate(drops.where(drops > picks), cmap=[\"darkblue\", 'cornflowerblue'], how=how)\n",
+    "    more_picks = tf.interpolate(picks.where(picks > drops), cmap=[\"darkred\", 'orangered'],  how=how)\n",
     "    img = tf.stack(more_picks,more_drops)\n",
     "    return tf.dynspread(img, threshold=0.3, max_px=4)\n",
     "\n",
-    "p = base_plot()\n",
+    "p = base_plot(background_fill_color=background)\n",
+    "export(merged_images(*NYC),\"NYCT_pickups_vs_dropoffs\")\n",
     "InteractiveImage(p, merged_images)"
    ]
   },
@@ -458,15 +467,28 @@
     "          \"#00FF00\",\"#00FF3F\",\"#00FF7F\",\"#00FFBF\",\"#00FFFF\",\"#00BFFF\",\"#007FFF\",\"#003FFF\",\n",
     "          \"#0000FF\",\"#3F00FF\",\"#7F00FF\",\"#BF00FF\",\"#FF00FF\",\"#FF00BF\",\"#FF007F\",\"#FF003F\",]\n",
     "\n",
-    "def colorized_images(x_range, y_range, w, h):\n",
+    "def colorized_images(x_range, y_range, w=plot_width, h=plot_height, dataset=\"pickup\"):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    agg = cvs.points(df, 'pickup_x', 'pickup_y', ds.count_cat('hour'))\n",
+    "    agg = cvs.points(df, dataset+'_x', dataset+'_y', ds.count_cat('hour'))\n",
     "    img = tf.colorize(agg, colors)\n",
     "    return tf.dynspread(img, threshold=0.3, max_px=4)\n",
     "\n",
-    "p = base_plot()\n",
-    "p.add_tile(STAMEN_TERRAIN)\n",
-    "InteractiveImage(p, colorized_images)"
+    "p = base_plot(background_fill_color=background)\n",
+    "#p.add_tile(STAMEN_TERRAIN)\n",
+    "export(colorized_images(*NYC, dataset=\"pickup\"),\"NYCT_pickup_times\")\n",
+    "InteractiveImage(p, colorized_images, dataset=\"pickup\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(colorized_images(*NYC, dataset=\"dropoff\"),\"NYCT_dropoff_times\")\n",
+    "InteractiveImage(p, colorized_images, dataset=\"dropoff\")"
    ]
   },
   {

--- a/examples/osm.ipynb
+++ b/examples/osm.ipynb
@@ -64,11 +64,32 @@
    "outputs": [],
    "source": [
     "bound = 20026376.39\n",
-    "cvs = ds.Canvas(plot_width=1000, plot_height=1000,\n",
-    "                x_range=(-bound, bound), y_range=(-bound, bound))\n",
+    "bounds = dict(x_range = (-bound, bound), y_range = (int(-bound*0.4), int(bound*0.6)))\n",
+    "plot_width = 1000\n",
+    "plot_height = int(plot_width*0.5)\n",
+    "\n",
+    "cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height, **bounds)\n",
     "\n",
     "with ProgressBar(), Profiler() as prof, ResourceProfiler(0.5) as rprof:\n",
     "    agg = cvs.points(df, 'x', 'y', ds.count())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from functools import partial\n",
+    "from datashader.utils import export_image\n",
+    "from datashader.colors import colormap_select, Greys9, Hot, viridis, inferno\n",
+    "from IPython.core.display import HTML, display\n",
+    "\n",
+    "background = \"black\"\n",
+    "export = partial(export_image, export_path=\"export\", background=background)\n",
+    "cm = partial(colormap_select, reverse=(background==\"black\"))"
    ]
   },
   {
@@ -117,7 +138,29 @@
    },
    "outputs": [],
    "source": [
-    "tf.interpolate(agg.where(agg > 20), cmap=[\"lightcyan\", \"darkblue\"], how=\"log\")"
+    "export(tf.interpolate(agg.where(agg > 20), cmap=[\"lightcyan\", \"darkblue\"], how=\"log\"), \"OSM_blue\", background=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(tf.interpolate(agg.where(agg > 20), cmap=cm([\"lightcyan\", \"darkblue\"]), how=\"log\"), \"OSM_black_blue\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "export(tf.interpolate(agg.where(agg > 20), cmap=Hot, how=\"log\"), \"OSM_hot\")"
    ]
   },
   {
@@ -204,8 +247,7 @@
     "    agg = cvs.points(df, 'x', 'y', ds.count())\n",
     "    return tf.interpolate(agg.where(agg > 20), cmap=[\"lightcyan\", \"darkblue\"], how=\"log\")\n",
     "\n",
-    "p = figure(tools='pan,wheel_zoom,box_zoom,reset', plot_width=800, plot_height=800, \n",
-    "           x_range=(-bound, bound), y_range=(-bound, bound))\n",
+    "p = figure(tools='pan,wheel_zoom,box_zoom,reset', plot_width=plot_width, plot_height=plot_height, **bounds)\n",
     "           \n",
     "p.axis.visible = False\n",
     "p.xgrid.grid_line_color = None\n",
@@ -231,6 +273,10 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.11"
+  },
+  "widgets": {
+   "state": {},
+   "version": "1.1.2"
   }
  },
  "nbformat": 4,

--- a/examples/tseries.ipynb
+++ b/examples/tseries.ipynb
@@ -412,7 +412,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here the three groups can clearly be seen, at least once they diverge sufficiently, as well as the areas of high overlap (high probability of being in that state at that time).  Additional patterns are visible when zooming in, all the way down to the individual datapoints, and again it may be useful to zoom first on the x axis (to make enough room on your screen to distinguish the datapoints, since there are 100,00 of them and only a few thousand pixels at most on your screen!). And note again that the interactive plots require a running server if you want to see more datapoints as you zoom in; static exports of this notebook won't support full zooming."
+    "Here the three groups can clearly be seen, at least once they diverge sufficiently, as well as the areas of high overlap (high probability of being in that state at that time).  Additional patterns are visible when zooming in, all the way down to the individual datapoints, and again it may be useful to zoom first on the x axis (to make enough room on your screen to distinguish the datapoints, since there are 100,000 of them and only a few thousand pixels at most on your screen!). And note again that the interactive plots require a running server if you want to see more datapoints as you zoom in; static exports of this notebook won't support full zooming."
    ]
   }
  ],


### PR DESCRIPTION
This PR moves some convenience functions previously defined in census.ipynb into datashader proper, so that they can be used from multiple notebooks.  There was no obvious place to put `export()`, so it went into utils.py, but if anyone has another suggestion that's fine by me.

The PR also improves the taxi notebook, by switching the more colorful plots at the end to have a black background, so that the colors are more vibrant, and to add a comparison between pickups and dropoffs by time of day.  It also crops out the areas of New Jersey that are mostly empty, to focus on the more interesting areas of NYC.