### PR TITLE
Removed optional ujson usage in InteractiveImage

### DIFF
--- a/datashader/bokeh_ext.py
+++ b/datashader/bokeh_ext.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
 
 import uuid
-
-try:
-    import ujson as json
-except:
-    import json
+import json
 
 import numpy as np
 


### PR DESCRIPTION
It seems ujson doesn't always work correctly and since the speed gain from using it is fairly minor I think we should just drop support for it. Fixes issue https://github.com/bokeh/datashader/issues/207. Thanks to @apiszcz for finding the issue.