### PR TITLE
Added command for copying examples

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -9,6 +9,7 @@ SRC_DIR=$RECIPE_DIR/..
 pushd $SRC_DIR
 
 $PYTHON setup.py --quiet install --single-version-externally-managed --record=record.txt
+cp -r $SRC_DIR/examples $PREFIX/share/datashader-examples
 
 popd
 

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -28,23 +28,20 @@ def test():
     pytest.main(os.path.dirname(__file__))
 
 
-def examples(path='.', verbose=False):
+def examples(path='datashader-examples', verbose=False):
     """
     Copies the examples to the supplied path.
     """
 
     import os, glob
-    from shutil import copyfile
+    from shutil import copytree, ignore_patterns
 
-    path = os.path.abspath(path)
-    if not os.path.exists(path):
-        os.makedirs(path)
-        if verbose: print('Created directory %s' % path)
-        
-    notebook_glob = os.path.join(__path__[0], '..', 'examples', '*')
-    notebooks = glob.glob(notebook_glob)
-    
-    for notebook in notebooks:
-        nb_path = os.path.join(path, os.path.basename(notebook))
-        copyfile(notebook, nb_path)
-        if verbose: print("%s copied to %s" % (os.path.basename(notebook), path))
+    candidates = [os.path.join(__path__[0], '../examples'),
+                  os.path.join(__path__[0], '../../../../share/datashader-examples')]
+
+    for source in candidates:
+        if os.path.exists(source):
+            copytree(source, path, ignore=ignore_patterns('data','.ipynb_checkpoints','*.pyc','*~'))
+            if verbose:
+                print("%s copied to %s" % (source, path))
+            break

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -26,3 +26,25 @@ def test():
         sys.stderr.write("You need to install py.test to run tests.\n\n")
         raise
     pytest.main(os.path.dirname(__file__))
+
+
+def examples(path='.', verbose=False):
+    """
+    Copies the examples to the supplied path.
+    """
+
+    import os, glob
+    from shutil import copyfile
+
+    path = os.path.abspath(path)
+    if not os.path.exists(path):
+        os.makedirs(path)
+        if verbose: print('Created directory %s' % path)
+        
+    notebook_glob = os.path.join(__path__[0], '..', 'examples', '*')
+    notebooks = glob.glob(notebook_glob)
+    
+    for notebook in notebooks:
+        nb_path = os.path.join(path, os.path.basename(notebook))
+        copyfile(notebook, nb_path)
+        if verbose: print("%s copied to %s" % (os.path.basename(notebook), path))

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,25 +1,26 @@
 # Datashader Examples
 
-Some of the examples create their own synthetic datasets, but others
-require real-world sample data that will need to be downloaded first.
-The total download size is currently about 2.5GB to transfer,
-requiring about 7.5GB on disk when unpacked, which can take some time
-depending on the speed of your connection.  The files involved are
-specified in the text file `datasets.yml` in this directory and can be
-downloaded individually by hand if you prefer.  However, the easiest
-approach is just to get them all at once, by running the
-`datashader-download-data` command that is installed with datashader:
+A variety of example notebooks and applications are maintained in the
+examples/ subdirectory of the git repository, and these will be
+installed somewhere on your local system when you install datashader.
+To get a copy of the examples in your own directory so that you can
+run and edit them, you can run these commands in your terminal:
 
 ```bash
-datashader-download-data
+1. mkdir ~/datashader-examples
+2. cd ~/datashader-examples
+3. python -c 'from datashader import examples ; examples()'
+4. python download_sample_data.py
 ```
-or else (e.g. if you have a git checkout) you can call the Python
-script directly:
 
-```bash
-cd examples
-python download_sample_data.py
-```
+Steps 1-3 steps will give you a copy of the notebooks and apps, and
+step 4 will download various datasets used by them.  The total
+download size is currently about 2.5GB to transfer, requiring about
+7.5GB on disk when unpacked, which can take some time depending on the
+speed of your connection.  The files involved are specified in the
+text file `datasets.yml` that was copied to your directory in step 3,
+and instead of step 4 you can download each file individually if you
+prefer.
 
 The "Census" example data is the largest file and should be the last
 thing to be downloaded, so you should be able to start running all of

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,9 +7,9 @@ To get a copy of the examples in your own directory so that you can
 run and edit them, you can run these commands in your terminal:
 
 ```bash
-1. mkdir ~/datashader-examples
-2. cd ~/datashader-examples
-3. python -c 'from datashader import examples ; examples()'
+1. cd ~
+2. python -c 'from datashader import examples ; examples("datashader-examples")'
+3. cd datashader-examples
 4. python download_sample_data.py
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,4 @@ setup(name='datashader',
       description='Data visualization toolchain based on aggregating into a grid',
       url='http://github.com/bokeh/datashader',
       install_requires=install_requires,
-      entry_points={
-          'console_scripts': [
-              'datashader-download-data = examples.download_sample_data:main'
-          ]
-      },
       packages=['datashader', 'datashader.tests'])


### PR DESCRIPTION
As described in #194, our instructions for downloading the sample data don't currently work for the conda package.  It's also difficult for people to get the code for the examples if they use conda, because it's not clear to users where the files get installed.  This PR adds a command to fetch the example code and then shows users how to run it and run the data download script.  

I think this is ready to merge for what it does, but I presume there will be changes needed to setup.py (to delete `entry_points`) and to the conda recipe (to preserve examples/) to finish the job.