### PR TITLE
Added safety check for non-positive log axis range

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import math
+
 import numpy as np
 from datashape.predicates import istabular
 from odo import discover
@@ -71,6 +73,10 @@ class Axis(object):
 
         """
         start, end = map(self.mapper, range)
+
+        if math.isinf(start) or math.isnan(start) or math.isinf(end) or math.isnan(end):
+            raise ValueError("Axis range must be a real number after transformation")
+        
         s = (n - 1)/(end - start)
         t = -start * s
         return s, t
@@ -122,6 +128,12 @@ class Canvas(object):
         self.y_range = tuple(y_range) if y_range else y_range
         self.x_axis = _axis_lookup[x_axis_type]
         self.y_axis = _axis_lookup[y_axis_type]
+
+        if x_axis_type=='log' and x_range and x_range[0]<=0:
+            raise ValueError("x_range must be >0 for a log x axis")
+        if y_axis_type=='log' and y_range and y_range[0]<=0:
+            raise ValueError("y_range must be >0 for a log y axis")
+
 
     def points(self, source, x, y, agg=None):
         """Compute a reduction by pixel, mapping data to pixels as points.


### PR DESCRIPTION
As reported in issue #226, datashader segfaults for a y_range starting at 0 or a negative number.  

This PR adds a check for this condition at the Canvas level, which provides a clear error message for cases where the user has explicitly set a y_range or an x_range with such an invalid starting value.  

This PR also adds a low-level error check within the Axis itself, to handle the case where the range has been determined automatically based on the data.  In this case, the name and type of the axis are not known, so the message is much more obscure, but there appears to be no simple way around that.  And even an obscure message is better than a segfault!

