### PR TITLE
Fixed handling of NaN between line segments

### DIFF
--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -190,7 +190,7 @@ def _build_extend_line(draw_line):
             # the entire segment.
             if np.isnan(x0) or np.isnan(y0) or np.isnan(x1) or np.isnan(y1):
                 plot_start = True
-                i += 2
+                i += 1
                 continue
 
             # Use Cohen-Sutherland to clip the segment to a bounding box


### PR DESCRIPTION
As reported in #230, the behavior for line segments separated by NaN does not appear to be consistent:

```python
import datashader
import datashader.transfer_functions as tf
import numpy as np
import pandas as pd

y = [1, 0, 1, np.NaN, np.NaN, 0, 1, 0]
x = range(len(y))

df = pd.DataFrame(dict(x=x, y=y))
cvs = datashader.Canvas(x_range=[min(x), max(x)], y_range=[-1, 2], plot_width=100, plot_height=100)
agg = cvs.line(df, "x", "y")
tf.shade(agg)
```

![image](https://cloud.githubusercontent.com/assets/1695496/18329010/4612a6aa-7517-11e6-80c2-1c89b25b13df.png)

Here there should be two V shapes, but the first part of the second one is cut off.  Turns out that the first sample after np.NaN was erroneously being ignored.  After fixing that (applying this PR) it works fine:

![image](https://cloud.githubusercontent.com/assets/1695496/18329149/bd9c1b48-7517-11e6-9d54-34e5784fa719.png)