### PR TITLE
Landsat updates

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -203,10 +203,11 @@ class Canvas(object):
                source,
                band=1,
                resample_method='bilinear',
-               use_overviews=True,
-               missing=None):
+               use_overviews=True):
         """Sample a raster dataset by canvas size and bounds. Note: requires
-        `rasterio` and `scikit-image`.
+        `rasterio` and `scikit-image`.  Missing values (those having the value
+        indicated by the "nodata" attribute of the raster) are replaced with 
+        `NaN` if floats, and 0 if int.
 
         Parameters
         ----------
@@ -214,9 +215,6 @@ class Canvas(object):
             input datasource most likely obtain from `rasterio.open()`.
         band : int
             source band number : optional default=1
-        missing : number, optional
-            Missing flag, default is `None` and missing values are replaced with `NaN`
-            if floats, and 0 if int.
         resample_method : str, optional default=bilinear
             resample mode when resizing raster.
             options include: nearest, bilinear.
@@ -285,10 +283,7 @@ class Canvas(object):
         else:
             data = source.read(band, window=((rmax, rmin), (cmin, cmax)))
 
-        if missing and source.nodata:
-            data[data == source.nodata] = missing
-        elif source.nodata:
-            data[data == source.nodata] = 0 if 'i' in data.dtype.str else np.nan
+        data[data == source.nodata] = 0 if 'i' in data.dtype.str else np.nan
 
         # TODO: this resize should go away once rasterio has overview resample
         data = resize(data,

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -38,18 +38,13 @@ def test_raster_aggregate_without_overviews():
         agg = cvs.raster(src, use_overviews=False)
         assert agg is not None
 
-def test_raster_set_missing():
-    with rio.open(TEST_RASTER_PATH) as src:
-        agg = cvs.raster(src, missing=-100)
-        assert agg is not None
-
 def test_out_of_bounds_return_correct_size():
     with rio.open(TEST_RASTER_PATH) as src:
         cvs = ds.Canvas(plot_width=2,
                         plot_height=2,
                         x_range=[1e10, 1e20],
                         y_range=[1e10, 1e20])
-        agg = cvs.raster(src, missing=-100)
+        agg = cvs.raster(src)
         assert agg.shape == (2,2)
         assert agg is not None
 
@@ -61,7 +56,7 @@ def test_partial_extent_returns_correct_size():
                         plot_height=256,
                         x_range=[src.bounds.left-half_width, src.bounds.left+half_width],
                         y_range=[src.bounds.bottom-half_height, src.bounds.bottom+half_height])
-        agg = cvs.raster(src, missing=-100)
+        agg = cvs.raster(src)
         assert agg.shape == (256, 512)
         assert agg is not None
 

--- a/examples/landsat.ipynb
+++ b/examples/landsat.ipynb
@@ -4,15 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Datashader: Custom Transfer Functions for LandSat8"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Setup\n",
-    "The following imports will be needed to complete the exercises or provide for an improved notebook display:"
+    "# Datashading LandSat8 raster satellite imagery\n",
+    "\n",
+    "Datashader is fundamentally a rasterizing library, turning data into rasters (image-like arrays), but it is also useful for already-rasterized data like satellite imagery.  For raster data, datashader uses the separate [rasterio](https://mapbox.github.io/rasterio) library to re-render the data to whatever new bounding box and resolution the user requests, and the rest of the datashader pipeline can then be used to visualize and analyze the data.  This demo shows how to work with a set of raster satellite data, generating images as needed and overlaying them on geographic coordinates."
    ]
   },
   {
@@ -45,22 +39,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load Landsat Data \n",
+    "### Load LandSat Data \n",
     "\n",
-    "Bands\tWavelength\n",
-    "(micrometers)\tResolution\n",
-    "(meters)\n",
-    "- Band 1 - Coastal aerosol\t0.43 - 0.45\t30\n",
-    "- Band 2 - Blue\t0.45 - 0.51\t30\n",
-    "- Band 3 - Green\t0.53 - 0.59\t30\n",
-    "- Band 4 - Red\t0.64 - 0.67\t30\n",
-    "- Band 5 - Near Infrared (NIR)\t0.85 - 0.88\t30\n",
-    "- Band 6 - SWIR 1\t1.57 - 1.65\t30\n",
-    "- Band 7 - SWIR 2\t2.11 - 2.29\t30\n",
-    "- Band 8 - Panchromatic\t0.50 - 0.68\t15\n",
-    "- Band 9 - Cirrus\t1.36 - 1.38\t30\n",
-    "- Band 10 - Thermal Infrared (TIRS) 1\t10.60 - 11.19\t100 * (30)\n",
-    "- Band 11 - Thermal Infrared (TIRS) 2\t11.50 - 12.51\t100 * (30)"
+    "LandSat data is measured in different frequency bands, revealing different types of information:\n",
+    "\n",
+    "```\n",
+    "Band      Wavelength     Resolution   Description\n",
+    "          (micrometers)  (meters)\n",
+    "\n",
+    "Band 1     0.43 - 0.45     30         Coastal aerosol\n",
+    "Band 2     0.45 - 0.51     30         Blue\n",
+    "Band 3     0.53 - 0.59     30         Green\n",
+    "Band 4     0.64 - 0.67     30         Red\n",
+    "Band 5     0.85 - 0.88     30         Near Infrared (NIR)\n",
+    "Band 6     1.57 - 1.65     30         SWIR 1\n",
+    "Band 7     2.11 - 2.29     30         SWIR 2\n",
+    "Band 8     0.50 - 0.68     15         Panchromatic\n",
+    "Band 9     1.36 - 1.38     30         Cirrus\n",
+    "Band 10   10.60 - 11.19   100 * (30)  Thermal Infrared (TIRS) 1\n",
+    "Band 11   11.50 - 12.51   100 * (30)  Thermal Infrared (TIRS) 2\n",
+    "```"
    ]
   },
   {
@@ -100,7 +98,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Datashader Transfer Functions"
+    "### Define geographic plot\n",
+    "\n",
+    "We'll plot this data using Bokeh, overlaying it on map tiles for context:"
    ]
   },
   {
@@ -130,7 +130,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Just the Blue Band"
+    "## Rendering LandSat data as images\n",
+    "\n",
+    "The bands measured by LandSat include wavelengths covering the visible spectrum, but also other ranges, and so it's possible to visualize this data in many different ways, in both true color (using the visible spectrum directly) or false color (usually showing other bands).  Some examples are shown in the sections below.\n",
+    "\n",
+    "### Just the Blue Band\n",
+    "\n",
+    "Using datashader's default histogram-equalized colormapping, the full range of data is visible in the plot:"
    ]
   },
   {
@@ -150,6 +156,15 @@
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
     "InteractiveImage(p, update_image)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You will usually want to zoom in, which will re-rasterize the image if you are in a live notebook, and then re-equalize the colormap to show all the detail available.  If you are on a static copy of the notebook, only the original resolution at which the image was rendered will be available, but zooming will still update the map tiles to whatever resolution is requested.\n",
+    "\n",
+    "The plots below use a different type of colormap processing, implemented as a custom transfer function:"
    ]
   },
   {
@@ -203,7 +218,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### True Color (Red=Red, Green=Green, Blue=Blue)"
+    "### True Color (Red=Red, Green=Green, Blue=Blue)\n",
+    "\n",
+    "Mapping the Red, Green, and Blue bands to the R, G, and B channels of an image reconstructs the image as it would appear to an ordinary camera from that viewpoint:"
    ]
   },
   {
@@ -227,6 +244,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Other combinations highlight particular features of interest based on the different spectral properties of reflectances from various objects and surfaces:\n",
+    "\n",
     "### Color Infrared (Vegetation) (Red=Near Infrared, Green=Red, Blue=Green)"
    ]
   },
@@ -343,6 +362,13 @@
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
     "InteractiveImage(p, shortwave_infrared)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All the various ways of combining aggregates supported by [xarray](http://xarray.pydata.org) are available for these channels, making it simple to make your own custom visualizations highlighting any combination of bands that reveal something of interest."
    ]
   }
  ],

--- a/examples/landsat.ipynb
+++ b/examples/landsat.ipynb
@@ -145,7 +145,7 @@
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
     "    agg = cvs.raster(band2)\n",
     "    agg.data[agg.data<nodata]=np.nan\n",
-    "    blue_img = tf.shade(agg,cmap=['black','white'],how='linear')\n",
+    "    blue_img = tf.shade(agg,cmap=['black','white'])\n",
     "    return blue_img\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",

--- a/examples/landsat.ipynb
+++ b/examples/landsat.ipynb
@@ -85,13 +85,15 @@
     "band10 = rio.open(path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_B10.TIF'))\n",
     "band11 = rio.open(path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_B11.TIF'))\n",
     "band12 = rio.open(path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_BQA.TIF'))\n",
-    "\n",
     "# Notice the MERCATOR prefix which indicates the data was project to Mercator CRS\n",
     "\n",
     "xmin = band1.bounds.left\n",
     "ymin = band1.bounds.bottom\n",
     "xmax = band1.bounds.right\n",
-    "ymax = band1.bounds.top"
+    "ymax = band1.bounds.top\n",
+    "\n",
+    "# Declare value used in the above files for no-data values, as bandX.nodata was not filled in\n",
+    "nodata=1"
    ]
   },
   {
@@ -109,7 +111,7 @@
    },
    "outputs": [],
    "source": [
-    "def base_plot(tools='pan,wheel_zoom,reset',plot_width=900, plot_height=500, x_range=None, y_range=None, **plot_args):\n",
+    "def base_plot(tools='pan,wheel_zoom,reset',plot_width=720, plot_height=400, x_range=None, y_range=None, **plot_args):\n",
     "    p = Figure(tools=tools, plot_width=plot_width, plot_height=plot_height,\n",
     "        x_range=x_range, y_range=y_range, outline_line_color=None,\n",
     "        background_fill_color='black',\n",
@@ -141,9 +143,9 @@
    "source": [
     "def update_image(x_range, y_range, w, h, how='log'):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    blue_img = tf.shade(cvs.raster(band2),\n",
-    "                        cmap=['black','white'],\n",
-    "                        how='linear')\n",
+    "    agg = cvs.raster(band2)\n",
+    "    agg.data[agg.data<nodata]=np.nan\n",
+    "    blue_img = tf.shade(agg,cmap=['black','white'],how='linear')\n",
     "    return blue_img\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -188,11 +190,11 @@
    "outputs": [],
    "source": [
     "def combine_bands(r, g, b):\n",
+    "    a = (np.where(np.logical_or(np.isnan(r),r<=nodata),0,255)).astype(np.uint8)    \n",
     "    r = (normalize_data(r)).astype(np.uint8)\n",
     "    g = (normalize_data(g)).astype(np.uint8)\n",
     "    b = (normalize_data(b)).astype(np.uint8)\n",
     "    col, rows = r.shape\n",
-    "    a = (np.zeros_like(r) + 255).astype(np.uint8)\n",
     "    img = np.dstack([r, g, b, a]).view(np.uint32).reshape(r.shape)\n",
     "    return tf.Image(data=img)"
    ]


### PR DESCRIPTION
The landsat notebook had a variety of problems:

- At 33MB, it was too large for the updated anaconda.org to display, now that there is a 25MB limit
- Images had a black border around them, obscuring the map in the immediate area when first displaying, and covering the entire map on zooming
- There wasn't much explanation of what was going on

I've decreased the image size slightly, making the rendered notebook be 18MB, and uploaded that to anaconda.org.  @brendancol and I debugged the black-border issues, finding that these images failed to declare that they were using "1" as a value indicating pixels with no data, which we've now hardcoded into the notebook.  I also changed the blue-only channel to use eq_hist, which makes a lot more detail show up than the previous linear colormapping.  The remaining images all used a custom nonlinear normalization, so I left those as is.  Finally, I added text to explain how everything works and how to use it.  Should be ready to merge.