### PR TITLE
Remove .create on Select creation and convert options to list.

### DIFF
--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -420,8 +420,6 @@ class AppView(object):
 
     def update_image(self):
         self.model.shader_url_vars['cachebust'] = str(uuid.uuid4())
-        print('update_image() service_url:', self.model.service_url)        ## TEST
-        print('               extra_url_vars:', self.model.shader_url_vars)        ## TEST
         self.image_renderer.image_source = ImageSource(url=self.model.service_url,
                                                        extra_url_vars=self.model.shader_url_vars)
 

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -357,28 +357,28 @@ class AppView(object):
         # add ui components
         controls = []
         axes_options = zip(self.model.axes.keys(), self.model.axes.keys())
-        axes_select = Select.create(name='Axes', options=axes_options)
+        axes_select = Select(name='Axes', options=list(self.model.axes.keys()))
         axes_select.on_change('value', self.on_axes_change)
         controls.append(axes_select)
 
         fields_options = zip(self.model.fields.keys(), self.model.fields.keys())
-        self.field_select = Select.create(name='Field', options=fields_options)
+        self.field_select = Select(name='Field', options=list(fields_options))
         self.field_select.on_change('value', self.on_field_change)
         controls.append(self.field_select)
 
         agg_options = zip(self.model.aggregate_functions.keys(), self.model.aggregate_functions.keys())
-        self.aggregate_select = Select.create(name='Aggregate', options=agg_options)
+        self.aggregate_select = Select(name='Aggregate', options=list(agg_options))
         self.aggregate_select.on_change('value', self.on_aggregate_change)
         controls.append(self.aggregate_select)
 
         transfer_options = zip(self.model.transfer_functions.keys(), self.model.transfer_functions.keys())
-        transfer_select = Select.create(name='Transfer Function',
-                                        options=transfer_options)
+        transfer_select = Select(name='Transfer Function',
+                                        options=list(transfer_options))
         transfer_select.on_change('value', self.on_transfer_function_change)
         controls.append(transfer_select)
 
         color_options = zip(self.model.color_ramps.keys(), self.model.color_ramps.keys())
-        color_ramp_select = Select.create(name='Color Ramp', options=color_options)
+        color_ramp_select = Select(name='Color Ramp', options=list(color_options))
         color_ramp_select.on_change('value', self.on_color_ramp_change)
         controls.append(color_ramp_select)
 
@@ -397,7 +397,7 @@ class AppView(object):
 
         # add map components
         basemap_options = zip(self.model.basemaps.keys(), self.model.basemaps.keys())
-        basemap_select = Select.create(name='Basemap', value='Imagery', options=basemap_options)
+        basemap_select = Select(name='Basemap', value='Imagery', options=list(basemap_options))
         basemap_select.on_change('value', self.on_basemap_change)
 
         image_opacity_slider = Slider(title="Opacity", value=100, start=0,
@@ -416,7 +416,7 @@ class AppView(object):
 
         self.controls = VBox(height=600, children=controls)
         self.map_controls = HBox(width=self.fig.plot_width, children=map_controls)
-        
+
         # legends (temporarily disabled)
         self.map_area = VBox(width=900, height=600, children=[self.map_controls,
                                                                   self.fig])

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -356,29 +356,24 @@ class AppView(object):
 
         # add ui components
         controls = []
-        axes_options = zip(self.model.axes.keys(), self.model.axes.keys())
         axes_select = Select(name='Axes', options=list(self.model.axes.keys()))
         axes_select.on_change('value', self.on_axes_change)
         controls.append(axes_select)
 
-        fields_options = zip(self.model.fields.keys(), self.model.fields.keys())
-        self.field_select = Select(name='Field', options=list(fields_options))
+        self.field_select = Select(name='Field', options=list(self.model.fields.keys()))
         self.field_select.on_change('value', self.on_field_change)
         controls.append(self.field_select)
 
-        agg_options = zip(self.model.aggregate_functions.keys(), self.model.aggregate_functions.keys())
-        self.aggregate_select = Select(name='Aggregate', options=list(agg_options))
+        self.aggregate_select = Select(name='Aggregate', options=list(self.model.aggregate_functions.keys()))
         self.aggregate_select.on_change('value', self.on_aggregate_change)
         controls.append(self.aggregate_select)
 
-        transfer_options = zip(self.model.transfer_functions.keys(), self.model.transfer_functions.keys())
         transfer_select = Select(name='Transfer Function',
-                                        options=list(transfer_options))
+                                        options=list(self.model.transfer_functions.keys()))
         transfer_select.on_change('value', self.on_transfer_function_change)
         controls.append(transfer_select)
 
-        color_options = zip(self.model.color_ramps.keys(), self.model.color_ramps.keys())
-        color_ramp_select = Select(name='Color Ramp', options=list(color_options))
+        color_ramp_select = Select(name='Color Ramp', options=list(self.model.color_ramps.keys()))
         color_ramp_select.on_change('value', self.on_color_ramp_change)
         controls.append(color_ramp_select)
 
@@ -396,8 +391,7 @@ class AppView(object):
         # controls.append(self.model.legend_side_vbox)
 
         # add map components
-        basemap_options = zip(self.model.basemaps.keys(), self.model.basemaps.keys())
-        basemap_select = Select(name='Basemap', value='Imagery', options=list(basemap_options))
+        basemap_select = Select(name='Basemap', value='Imagery', options=list(self.model.basemaps.keys()))
         basemap_select.on_change('value', self.on_basemap_change)
 
         image_opacity_slider = Slider(title="Opacity", value=100, start=0,
@@ -426,6 +420,8 @@ class AppView(object):
 
     def update_image(self):
         self.model.shader_url_vars['cachebust'] = str(uuid.uuid4())
+        print('update_image() service_url:', self.model.service_url)        ## TEST
+        print('               extra_url_vars:', self.model.shader_url_vars)        ## TEST
         self.image_renderer.image_source = ImageSource(url=self.model.service_url,
                                                        extra_url_vars=self.model.shader_url_vars)
 


### PR DESCRIPTION
The .create function has been removed from Select. Need to pass a list of string or a list of tuples to Select. Will not accept a generator, which is what is returned by zip() in python 3.