### PR TITLE
Replace {get,set}() with getters and setters

### DIFF
--- a/datashader/bokeh_ext.py
+++ b/datashader/bokeh_ext.py
@@ -86,10 +86,10 @@ class InteractiveImage(object):
 
         var plot = x_range.plots[0];
         // Generate a command to execute in Python
-        var ranges = {{xmin: x_range.attributes.start,
-                       ymin: y_range.attributes.start,
-                       xmax: x_range.attributes.end,
-                       ymax: y_range.attributes.end,
+        var ranges = {{xmin: x_range.start,
+                       ymin: y_range.start,
+                       xmax: x_range.end,
+                       ymax: y_range.end,
                        w: Math.floor(plot.width),
                        h: Math.floor(plot.height)}}
         var range_str = JSON.stringify(ranges)
@@ -127,7 +127,7 @@ class InteractiveImage(object):
         self.timeout = timeout
         if throttle:
             print("Warning: throttle parameter no longer supported; will not be accepted in future versions")
-            
+
         # Initialize the image and callback
         self.ds, self.renderer = self._init_image()
         callback = self._init_callback()
@@ -293,7 +293,7 @@ class HoverLayer(object):
                                      size=size)
         self.tooltips = []
 
-        code = "source.set('selected', cb_data['index']);"
+        code = "source.selected = cb_data['index'];"
         self._callback = CustomJS(args={'source': self.hover_data}, code=code)
 
         self.renderer = GlyphRenderer()

--- a/examples/raster.py
+++ b/examples/raster.py
@@ -52,14 +52,15 @@ dims = ColumnDataSource(data=dict(width=[], height=[], xmin=[], xmax=[], ymin=[]
 dims.on_change('data', on_dims_change)
 dims_jscode = """
 var update_dims = function () {
-    var new_data = {};
-    new_data['height'] = [plot.get('frame').get('height')];
-    new_data['width'] = [plot.get('frame').get('width')];
-    new_data['xmin'] = [plot.get('x_range').get('start')];
-    new_data['ymin'] = [plot.get('y_range').get('start')];
-    new_data['xmax'] = [plot.get('x_range').get('end')];
-    new_data['ymax'] = [plot.get('y_range').get('end')];
-    dims.set('data', new_data);
+    var new_data = {
+        height: [plot.frame.height],
+        width: [plot.frame.width],
+        xmin: [plot.x_range.start],
+        ymin: [plot.y_range.start],
+        xmax: [plot.x_range.end],
+        ymax: [plot.y_range.end]
+    };
+    dims.data = new_data;
 };
 
 if (typeof throttle != 'undefined' && throttle != null) {

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -112,14 +112,15 @@ bin_data()
 dims = ColumnDataSource(data=dict(width=[], height=[], xmin=[], xmax=[], ymin=[], ymax=[]))
 dims_jscode = """
 var update_dims = function () {
-    var new_data = {};
-    new_data['height'] = [plot.get('frame').get('height')];
-    new_data['width'] = [plot.get('frame').get('width')];
-    new_data['xmin'] = [plot.get('x_range').get('start')];
-    new_data['ymin'] = [plot.get('y_range').get('start')];
-    new_data['xmax'] = [plot.get('x_range').get('end')];
-    new_data['ymax'] = [plot.get('y_range').get('end')];
-    dims.set('data', new_data);
+    var new_data = {
+        height: [plot.frame.height],
+        width: [plot.frame.width],
+        xmin: [plot.x_range.start],
+        ymin: [plot.y_range.start],
+        xmax: [plot.x_range.end],
+        ymax: [plot.y_range.end]
+    };
+    dims.data = new_data;
 };
 
 if (typeof throttle != 'undefined' && throttle != null) {


### PR DESCRIPTION
This prepares datashader for bokehjs 0.12.3, where `get()` and `set()` will be deprecated. If you used `obj.get('prop_name')` or `obj.set('prop_name', value)` before, those become `obj.prop_name` and `obj.prop_name = value` respectively.