### PR TITLE
Changed census.ipynb bounding boxes to use longitude, latitude

### DIFF
--- a/examples/census.ipynb
+++ b/examples/census.ipynb
@@ -73,23 +73,23 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "USA =          ((-13884029,  -7453304), (2698291, 6455972))\n",
-    "LakeMichigan = ((-10206131,  -9348029), (4975642, 5477059))\n",
-    "Chicago =      (( -9828281,  -9717659), (5096658, 5161298))\n",
-    "Chinatown =    (( -9759210,  -9754583), (5137122, 5139825))\n",
+    "USA           = ((-124.72,  -66.95), (23.55, 50.06))\n",
+    "LakeMichigan  = (( -91.68,  -83.97), (40.75, 44.08))\n",
+    "Chicago       = (( -88.29,  -87.30), (41.57, 42.00))\n",
+    "Chinatown     = (( -87.67,  -87.63), (41.84, 41.86))\n",
+    "NewYorkCity   = (( -74.39,  -73.44), (40.51, 40.91))\n",
+    "LosAngeles    = ((-118.53, -117.81), (33.63, 33.96))\n",
+    "Houston       = (( -96.05,  -94.68), (29.45, 30.11))\n",
+    "Austin        = (( -97.91,  -97.52), (30.17, 30.37))\n",
+    "NewOrleans    = (( -90.37,  -89.89), (29.82, 30.05))\n",
+    "Atlanta       = (( -84.88,  -84.04), (33.45, 33.84))\n",
     "\n",
-    "NewYorkCity =  (( -8280656,  -8175066), (4940514, 4998954))\n",
-    "LosAngeles =   ((-13195052, -13114944), (3979242, 4023720))\n",
-    "Houston =      ((-10692703, -10539441), (3432521, 3517616))\n",
-    "Austin =       ((-10898752, -10855820), (3525750, 3550837))\n",
-    "NewOrleans =   ((-10059963, -10006348), (3480787, 3510555))\n",
-    "Atlanta =      (( -9448349,  -9354773), (3955797, 4007753))\n",
-    "\n",
-    "x_range,y_range = USA\n",
+    "from datashader.utils import lnglat_to_meters as webm\n",
+    "x_range,y_range = webm(*USA)\n",
     "\n",
     "plot_width  = int(900)\n",
     "plot_height = int(plot_width*7.0/12)"
@@ -158,7 +158,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "cvs = ds.Canvas(plot_width, plot_height, *USA)\n",
+    "cvs = ds.Canvas(plot_width, plot_height, *webm(*USA))\n",
     "agg = cvs.points(df, 'meterswest', 'metersnorth')"
    ]
   },
@@ -373,7 +373,8 @@
    },
    "outputs": [],
    "source": [
-    "def create_image(x_range, y_range, w=plot_width, h=plot_height):\n",
+    "def create_image(longitude_range, latitude_range, w=plot_width, h=plot_height):\n",
+    "    x_range,y_range=webm(longitude_range,latitude_range)\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
     "    agg = cvs.points(df, 'meterswest', 'metersnorth', ds.count_cat('race'))\n",
     "    img = tf.shade(agg, color_key=color_key, how='eq_hist')\n",


### PR DESCRIPTION
Previously, all datashader examples used Web Mercator coordinates throughout, because that's what Bokeh supports.  However, as requested in issue #265 (amongst others), it's difficult for users to work with those coordinates directly; they can much more easily look up locations in using longitude and latitude.  This PR switches all Web Mercator coordinates in Census.ipynb to use longitude and latitude, so that it is clear to users how to work with their own set of locations.
