### PR TITLE
Filetimes script improvements, pt 2

### DIFF
--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -229,9 +229,11 @@ def main(argv):
     if args.cache_enabled:
         from dask.cache import Cache
         Cache(p.cachesize).register()
-        print("Cache enabled")
+        if args.debug:
+            print("Cache enabled")
     else:
-        print("Cache disabled")
+        if args.debug:
+            print("Cache disabled")
 
     filepath = args.filepath
     basename, extension = os.path.splitext(filepath)

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -90,12 +90,12 @@ def benchmark(fn, args):
 
 
 read = odict([(f,odict()) for f in ["parq","bcolz","feather","castra","h5","csv"]])
-               
+
 read["csv"]     ["dask"]   = lambda filepath,p:  benchmark(dd.read_csv, (filepath, Kwargs(usecols=p.columns)))
 read["h5"]      ["dask"]   = lambda filepath,p:  benchmark(dd.read_hdf, (filepath, p.base, Kwargs(chunksize=p.chunksize, columns=p.columns)))
 #read["castra"]  ["dask"]   = lambda filepath,p:  benchmark(dd.from_castra, (filepath,))
 read["bcolz"]   ["dask"]   = lambda filepath,p:  benchmark(dd.from_bcolz, (filepath, Kwargs(chunksize=1000000)))
-read["parq"]    ["dask"]   = lambda filepath,p:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, categories=p.categories, columns=p.columns)))
+read["parq"]    ["dask"]   = lambda filepath,p:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, columns=p.columns))) # categories=p.categories, 
 
 read["csv"]     ["pandas"] = lambda filepath,p:  benchmark(pd.read_csv, (filepath, Kwargs(usecols=p.columns)))
 read["h5"]      ["pandas"] = lambda filepath,p:  benchmark(pd.read_hdf, (filepath, p.base, Kwargs(columns=p.columns)))
@@ -215,6 +215,8 @@ def get_size(path):
 
 
 def main(argv):
+    global DEBUG
+
     parser = argparse.ArgumentParser(epilog=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('filepath')
     parser.add_argument('dftype')

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -10,20 +10,31 @@
 #    python -c "import filetimes as ft ; ft.p.base='census' ; ft.p.x='meterswest' ; ft.p.y='metersnorth' ; ft.p.categories=['race']; ft.timed_write('data/tinycensus.csv',dftype='pandas')"
 #    # (or 'data/census.h5' and/or dftype='dask')
 #    ./filetimes.sh times/tinycensus
-#    # (add a second argument to filetimes.sh to set the ft.DEBUG variable)
+#    # (add a third argument to filetimes.sh to set the ft.DEBUG variable)
+#
+#    More examples of filetimes.sh:
+#      1) Use no caching, but enable DEBUG messages:
+#             ./filetimes.sh times/tinycensus '' debug
+#      2) Use "persist" caching mode:
+#             ./filetimes.sh times/tinycensus persist
+#      3) Use "cachey" caching mode (force-loads dask dataframes), enable DEBUG messages:
+#             ./filetimes.sh times/tinycensus cachey debug
 
 timer=/usr/bin/time
 timer="" # External timing disabled to avoid unhelpful "Command terminated abnormally" messages
 
-#${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
-#${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
-${timer} python filetimes.py ${1}.parq        pandas  census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.snappy.parq pandas  census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.castra      dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
-${timer} python filetimes.py ${1}.castra      pandas  census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.bcolz       dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
-${timer} python filetimes.py ${1}.h5          dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
-${timer} python filetimes.py ${1}.h5          pandas  census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.csv         dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
-${timer} python filetimes.py ${1}.csv         pandas  census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.feather     pandas  census meterswest metersnorth race ${2:+--debug}
+# Display each command if a third argument is provided
+test -z "$3" && set -x
+
+#${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+#${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.parq        pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.snappy.parq pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.castra      dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.castra      pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.bcolz       dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.h5          dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.h5          pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.csv         dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.csv         pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.feather     pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-#    \rm -rf times && mkdir times && python -c "import filetimes as ft ; ft.p.base='census' ; ft.p.x='meterswest' ; ft.p.y='metersnorth' ; ft.p.categories=['race']; ft.timed_write('data/tinycensus.csv',dftype='dask')"
-
 # Usage:
 #    conda-env create -f filetimes.yml
 #    source activate filetimes

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 
 # Usage:
-#    conda-env create -f filetimes.yml
+#    conda env create -f filetimes.yml
 #    source activate filetimes
+#    pip install --upgrade git+https://github.com/dask/dask@964b377    # auto-detect categoricals for dd.read_parquet
+#    pip install --upgrade git+https://github.com/dask/fastparquet@4106c30    # auto-detect categoricals for dd.read_parquet
+#    pip install --upgrade git+https://github.com/andrix/python-snappy@0d1ab38    # For releasing the GIL
 #    mkdir times
 #    python -c "import filetimes as ft ; ft.p.base='census' ; ft.p.x='meterswest' ; ft.p.y='metersnorth' ; ft.p.categories=['race']; ft.timed_write('data/tinycensus.csv',dftype='pandas')"
 #    # (or 'data/census.h5' and/or dftype='dask')

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -24,7 +24,7 @@ timer=/usr/bin/time
 timer="" # External timing disabled to avoid unhelpful "Command terminated abnormally" messages
 
 # Display each command if a third argument is provided
-test -z "$3" && set -x
+test -n "$3" && set -x
 
 #${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 #${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -10,6 +10,7 @@
 #    python -c "import filetimes as ft ; ft.p.base='census' ; ft.p.x='meterswest' ; ft.p.y='metersnorth' ; ft.p.categories=['race']; ft.timed_write('data/tinycensus.csv',dftype='pandas')"
 #    # (or 'data/census.h5' and/or dftype='dask')
 #    ./filetimes.sh times/tinycensus
+#    # (add a second argument to filetimes.sh to set the caching mode)
 #    # (add a third argument to filetimes.sh to set the ft.DEBUG variable)
 #
 #    More examples of filetimes.sh:

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -14,8 +14,8 @@
 timer=/usr/bin/time
 timer="" # External timing disabled to avoid unhelpful "Command terminated abnormally" messages
 
-${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${2:+--debug}
+#${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${2:+--debug}
+#${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${2:+--debug}
 ${timer} python filetimes.py ${1}.parq        pandas  census meterswest metersnorth race ${2:+--debug}
 ${timer} python filetimes.py ${1}.snappy.parq pandas  census meterswest metersnorth race ${2:+--debug}
 ${timer} python filetimes.py ${1}.castra      dask    census meterswest metersnorth race ${2:+--debug}

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -15,15 +15,15 @@
 timer=/usr/bin/time
 timer="" # External timing disabled to avoid unhelpful "Command terminated abnormally" messages
 
-#${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${2:+--debug}
-#${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${2:+--debug}
+#${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
+#${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
 ${timer} python filetimes.py ${1}.parq        pandas  census meterswest metersnorth race ${2:+--debug}
 ${timer} python filetimes.py ${1}.snappy.parq pandas  census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.castra      dask    census meterswest metersnorth race ${2:+--debug}
+${timer} python filetimes.py ${1}.castra      dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
 ${timer} python filetimes.py ${1}.castra      pandas  census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.bcolz       dask    census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.h5          dask    census meterswest metersnorth race ${2:+--debug}
+${timer} python filetimes.py ${1}.bcolz       dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
+${timer} python filetimes.py ${1}.h5          dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
 ${timer} python filetimes.py ${1}.h5          pandas  census meterswest metersnorth race ${2:+--debug}
-${timer} python filetimes.py ${1}.csv         dask    census meterswest metersnorth race ${2:+--debug}
+${timer} python filetimes.py ${1}.csv         dask    census meterswest metersnorth race ${2:+--debug} --dd-force-load
 ${timer} python filetimes.py ${1}.csv         pandas  census meterswest metersnorth race ${2:+--debug}
 ${timer} python filetimes.py ${1}.feather     pandas  census meterswest metersnorth race ${2:+--debug}

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -2,7 +2,7 @@ name: filetimes
 channels:
 - defaults
 - conda-forge
-- gbrener # for updated python-snappy (releases GIL)
+- gbrener # for updated python-snappy (releases GIL), fastparquet
 - bccp # for cachey
 dependencies:
 - bokeh
@@ -21,7 +21,7 @@ dependencies:
 - python=3.5.2=0
 - python-snappy=0.5=py35_1
 - snappy=1.1.4=1
-- fastparquet==0.0.5
+- fastparquet==1.1
 - cachey==0.1.1
 - bloscpack==0.10.0
 - blosc==1.9.2

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -2,6 +2,7 @@ name: filetimes
 channels:
 - defaults
 - conda-forge
+- gbrener # for updated python-snappy (releases GIL)
 - bccp # for cachey
 dependencies:
 - bokeh
@@ -18,7 +19,7 @@ dependencies:
 - pandas=0.19.2=np111py35_0
 - pytest
 - python=3.5.2=0
-- python-snappy=0.5=py35_0
+- python-snappy=0.5=py35_1
 - snappy=1.1.4=1
 - fastparquet==0.0.5
 - cachey==0.1.1

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -25,6 +25,6 @@ dependencies:
 - cachey==0.1.1
 - bloscpack==0.10.0
 - blosc==1.9.2
+- pytables==3.3.0
 - pip:
-  - tables==3.3.0
   - castra==0.1.7

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -2,7 +2,7 @@ name: filetimes
 channels:
 - defaults
 - conda-forge
-- gbrener # for updated python-snappy (releases GIL), fastparquet
+- gbrener # for updated python-snappy (releases GIL)
 - bccp # for cachey
 dependencies:
 - bokeh
@@ -21,7 +21,7 @@ dependencies:
 - python=3.5.2=0
 - python-snappy=0.5=py35_1
 - snappy=1.1.4=1
-- fastparquet==1.1
+- fastparquet==0.0.5
 - cachey==0.1.1
 - bloscpack==0.10.0
 - blosc==1.9.2

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -1,28 +1,23 @@
 name: filetimes
-channels:
-- defaults
-- conda-forge
-- gbrener # for updated python-snappy (releases GIL)
-- bccp # for cachey
 dependencies:
 - bokeh
 - matplotlib
 - jupyter
-- bcolz=1.1.2=np111py35_0
+- bcolz=1.1.2=np112py35_0
 - bokeh::datashader=0.4.0=py35_0
 - conda-forge::feather-format=0.3.1=py35_1
 - dask=0.14.1=py35_0
 - hdf5=1.8.17=1
-- numba=0.31.0=np111py35_0
-- numexpr=2.6.2=np111py35_0
-- numpy=1.11.1=py35_0
-- pandas=0.19.2=np111py35_0
+- numba=0.31.0=np112py35_0
+- numexpr=2.6.2=np112py35_0
+- numpy=1.12.1=py35_0
+- pandas=0.19.2=np112py35_1
 - pytest
 - python=3.5.2=0
 - python-snappy=0.5=py35_1
 - snappy=1.1.4=1
 - fastparquet==0.0.5
-- cachey==0.1.1
+- bccp::cachey==0.1.1
 - bloscpack==0.10.0
 - blosc==1.9.2
 - pytables==3.3.0


### PR DESCRIPTION
As a continuation of efforts to address #129, this PR includes the (hopefully final set of) improvements to the filetimes scripts:
- filetimes.py
- filetimes.sh
- filetimes.yml

Remaining TODO items for this PR:
- Upload the census.parq data files (that are written out with categorical dtypes) to S3
- Verify that dask now implicitly detects categorical dtypes when loading said parquet files