### PR TITLE
Add memory profiling, datashader-data S3 bucket

### DIFF
--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -19,8 +19,7 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
     dsk, name = glyph_dispatch(glyph, df, schema, canvas, summary)
 
     get = _globals['get'] or df._default_get
-    dsk.update(df.dask)
-    dsk = df._optimize(dsk, name)
+    dsk.update(df._optimize(df.dask, df._keys()))
 
     return get(dsk, name)
 

--- a/examples/datasets.yml
+++ b/examples/datasets.yml
@@ -36,4 +36,4 @@ data:
   - url: http://s3.amazonaws.com/bokeh_data/census.zip
     title: 'Census Synthetic People'
     files:
-      - census.h5
+      - census.parq

--- a/examples/datasets.yml
+++ b/examples/datasets.yml
@@ -2,22 +2,22 @@
 
 data:
 
-  - url: http://s3.amazonaws.com/bokeh_data/austin_dem.zip
+  - url: http://s3.amazonaws.com/datashader-data/austin_dem.zip
     title: 'Austin, TX Elevation Data'
     files:
       - austin_dem.tif
 
-  - url: http://s3.amazonaws.com/bokeh_data/nyc_crime.zip
+  - url: http://s3.amazonaws.com/datashader-data/nyc_crime.zip
     title: 'NYC Crime Data'
     files:
       - nyc_crime.csv
 
-  - url: http://s3.amazonaws.com/bokeh_data/nyc_taxi.zip
+  - url: http://s3.amazonaws.com/datashader-data/nyc_taxi.zip
     title: 'NYC Taxi Data'
     files:
       - nyc_taxi.csv
 
-  - url: http://s3.amazonaws.com/bokeh_data/mobile_landsat8.zip
+  - url: http://s3.amazonaws.com/datashader-data/mobile_landsat8.zip
     title: 'Mobile, AL Landsat8 Data'
     files:
       - MERCATOR_LC80210392016114LGN00_B1.TIF
@@ -33,7 +33,7 @@ data:
       - MERCATOR_LC80210392016114LGN00_B11.TIF
       - MERCATOR_LC80210392016114LGN00_BQA.TIF
 
-  - url: http://s3.amazonaws.com/bokeh_data/census.zip
+  - url: http://s3.amazonaws.com/datashader-data/census.zip
     title: 'Census Synthetic People'
     files:
       - census.parq

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -49,7 +49,7 @@ p=Parameters()
 filetypes_storing_categories = {'parq','castra'}
 
 
-class Kwargs(dict):
+class Kwargs(odict):
     """Used to distinguish between dictionary argument values, and
     keyword-arguments.
     """

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -261,10 +261,10 @@ def main(argv):
 
     if DEBUG:
         print('DEBUG: Memory usage (after read):\t{} bytes'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss, flush=True))
-        mem_usage = df.memory_usage(deep=True)
-        print('DEBUG: DataFrame size:\t\t\t{} bytes'.format(mem_usage.sum(), flush=True))
     img,aggtime1 = timed_agg(df,filepath,5,5)
     if DEBUG:
+        mem_usage = df.memory_usage(deep=True)
+        print('DEBUG: DataFrame size:\t\t\t{} bytes'.format(mem_usage.sum(), flush=True))
         print('DEBUG: Memory usage (after agg1):\t{} bytes'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss, flush=True))
 
     img,aggtime2 = timed_agg(df,filepath)

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -90,7 +90,7 @@ def benchmark(fn, args, filetype=None):
         if p.dftype == 'dask' and DD_FORCE_LOAD:
             if DEBUG:
                 print("DEBUG: Force-loading Dask dataframe", flush=True)
-            df = res.persist()
+            res = res.persist()
 
     end = time.time()
 

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -11,7 +11,7 @@ Test files may be generated starting from any file format supported by Pandas:
 import time
 global_start = time.time()
 
-import io, os, os.path, sys, shutil, glob, argparse
+import io, os, os.path, sys, shutil, glob, argparse, resource
 import pandas as pd
 import dask.dataframe as dd
 import numpy as np
@@ -41,10 +41,7 @@ class Parameters(object):
     cat_width=1 # Size of fixed-width string for representing categories
     columns=None
     cachesize=9e9
-
-    @property
-    def parq_opts(self):
-        return dict(file_scheme='hive', has_nulls=False, write_index=False)
+    parq_opts=dict(file_scheme='hive', has_nulls=False, write_index=False)
 
 
 p=Parameters()
@@ -92,7 +89,7 @@ def benchmark(fn, args, filetype=None):
         # Force loading
         if p.dftype == 'dask' and DD_FORCE_LOAD:
             if DEBUG:
-                print("DEBUG: Force-loading Dask dataframe")
+                print("DEBUG: Force-loading Dask dataframe", flush=True)
             df = res.persist()
 
     end = time.time()
@@ -149,7 +146,7 @@ def timed_write(filepath,dftype,output_directory="times"):
         basename, extension = os.path.splitext(filename)
         fname = output_directory+os.path.sep+basename+"."+ext
         if os.path.exists(fname):
-            print("{:28} (keeping existing)".format(fname))
+            print("{:28} (keeping existing)".format(fname), flush=True)
         else:
             filetype=ext.split(".")[-1]
             if not filetype in filetypes_storing_categories:
@@ -162,10 +159,10 @@ def timed_write(filepath,dftype,output_directory="times"):
             code = write[ext].get(dftype,None)
 
             if code is None:
-                print("{:28} {:7} Operation not supported".format(fname,dftype))
+                print("{:28} {:7} Operation not supported".format(fname,dftype), flush=True)
             else:
                 duration, res = code(df,fname,p)
-                print("{:28} {:7} {:05.2f}".format(fname,dftype,duration))
+                print("{:28} {:7} {:05.2f}".format(fname,dftype,duration), flush=True)
 
             if not filetype in filetypes_storing_categories:
                 for c in p.categories:
@@ -178,12 +175,6 @@ def timed_read(filepath,dftype):
     filetype=extension.split(".")[-1]
     code = read[extension].get(dftype,None)
 
-    if filetype=="csv":
-        if dftype=="dask":
-            filepath = filepath.replace(".csv","*.csv")
-        else:
-            filepath = glob.glob(filepath.replace(".csv","*.csv"))[0]
-    
     if code is None:
         return (None,-1)
 
@@ -231,7 +222,7 @@ def main(argv):
 
     if args.cache is None:
         if args.debug:
-            print("DEBUG: Cache disabled")
+            print("DEBUG: Cache disabled", flush=True)
     else:
         if args.cache == 'cachey':
             from dask.cache import Cache
@@ -240,7 +231,7 @@ def main(argv):
             DD_FORCE_LOAD = True
 
         if args.debug:
-            print('DEBUG: Cache "{}" mode enabled'.format(args.cache))
+            print('DEBUG: Cache "{}" mode enabled'.format(args.cache), flush=True)
 
     filepath = args.filepath
     basename, extension = os.path.splitext(filepath)
@@ -251,24 +242,41 @@ def main(argv):
     p.categories  = args.categories
     DEBUG = args.debug
 
+    if filepath.endswith("csv"):
+        if p.dftype=="dask":
+            filepath = filepath.replace(".csv", "*.csv")
+        else:
+            filepath = glob.glob(filepath.replace(".csv","*.csv"))[0]
+    
+    if DEBUG:
+        print('DEBUG: Memory usage (before read):\t{} bytes'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss, flush=True))
     df,loadtime = timed_read(filepath, p.dftype)
 
     if df is None:
         if loadtime == -1:
-            print("{:28} {:6}  Operation not supported".format(filepath, p.dftype))
+            print("{:28} {:6}  Operation not supported".format(filepath, p.dftype), flush=True)
         elif loadtime == -2:
-            print("{:28} {:6}  File does not exist".format(filepath, p.dftype))
+            print("{:28} {:6}  File does not exist".format(filepath, p.dftype), flush=True)
         return 1
 
+    if DEBUG:
+        print('DEBUG: Memory usage (after read):\t{} bytes'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss, flush=True))
+        mem_usage = df.memory_usage(deep=True)
+        print('DEBUG: DataFrame size:\t\t\t{} bytes'.format(mem_usage.sum(), flush=True))
     img,aggtime1 = timed_agg(df,filepath,5,5)
+    if DEBUG:
+        print('DEBUG: Memory usage (after agg1):\t{} bytes'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss, flush=True))
+
     img,aggtime2 = timed_agg(df,filepath)
+    if DEBUG:
+        print('DEBUG: Memory usage (after agg2):\t{} bytes'.format(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss, flush=True))
     
     in_size  = get_size(filepath)
-    out_size = get_size("{}.png".format(filepath))
+    out_size = get_size(filepath+".png")
     
     global_end = time.time()
     print("{:28} {:6}  Aggregate1:{:06.2f} ({:06.2f}+{:06.2f})  Aggregate2:{:06.2f}  In:{:011d}  Out:{:011d}  Total:{:06.2f}"\
-          .format(filepath, p.dftype, loadtime+aggtime1, loadtime, aggtime1, aggtime2, in_size, out_size, global_end-global_start))
+          .format(filepath, p.dftype, loadtime+aggtime1, loadtime, aggtime1, aggtime2, in_size, out_size, global_end-global_start), flush=True)
 
     return 0
 

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -3,9 +3,10 @@
 # Usage:
 #    conda env create -f filetimes.yml
 #    source activate filetimes
-#    pip install --upgrade git+https://github.com/dask/dask@964b377    # auto-detect categoricals for dd.read_parquet
-#    pip install --upgrade git+https://github.com/dask/fastparquet@4106c30    # auto-detect categoricals for dd.read_parquet
-#    pip install --upgrade git+https://github.com/andrix/python-snappy@0d1ab38    # For releasing the GIL
+#    conda uninstall --force dask fastparquet python-snappy
+#    pip install --no-cache-dir --upgrade git+https://github.com/dask/dask@964b377    # auto-detect categoricals for dd.read_parquet
+#    pip install --no-cache-dir --upgrade git+https://github.com/dask/fastparquet@4106c30    # auto-detect categoricals for dd.read_parquet
+#    pip install --no-cache-dir --upgrade llvmlite==0.17.0 git+https://github.com/andrix/python-snappy@0d1ab38    # For releasing the GIL. Pin llvmlite to the version that numba depends on
 #    mkdir times
 #    python -c "import filetimes as ft ; ft.p.base='census' ; ft.p.x='meterswest' ; ft.p.y='metersnorth' ; ft.p.categories=['race']; ft.timed_write('data/tinycensus.csv',dftype='pandas')"
 #    # (or 'data/census.h5' and/or dftype='dask')

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -27,8 +27,8 @@ timer="" # External timing disabled to avoid unhelpful "Command terminated abnor
 # Display each command if a third argument is provided
 test -n "$3" && set -x
 
-#${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
-#${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.parq        pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.snappy.parq pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.castra      dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -8,7 +8,7 @@ dependencies:
 - conda-forge::feather-format=0.3.1=py35_1
 - dask=0.14.1=py35_0
 - hdf5=1.8.17=1
-- numba=0.31.0=np112py35_0
+- numba=0.32.0=np112py35_0
 - numexpr=2.6.2=np112py35_0
 - numpy=1.12.1=py35_0
 - pandas=0.19.2=np112py35_1


### PR DESCRIPTION
- The census.zip archive in the `bokeh_data` S3 bucket now contains a census.parq file that was written out uncompressed with a categorical dtype for the "race" column. Will shortly create a new `datashader-data` bucket and move this file into it (see TODOs below).

- filetimes.py now has some rudimentary memory profiling features which measure:
    a) the memory of the overall process (max resident set size) at various points in the program, and
    b) the memory of the dataframe after it's read into memory

- A CSV file-detection issue is fixed (it was happening when dask wrote out the CSV files)

This PR is still a work-in-progress:
- [x] Create a new S3 bucket called `datashader-data`. Move the files that only relate to datashader from `bokeh_data` to the new S3 bucket. Underscores are no longer allowed in S3 bucket names, so the underscore is now a dash
- [x] Investigate runtime performance issue for Agg2
- [x] Investigate memory issue that happens after the first `timed_agg()`
- [x] Update `datashader-data` bucket with a SNAPPY-compressed version of census.parq, provided that it ends up being faster to load than the uncompressed version