### PR TITLE
Added environment file for examples

### DIFF
--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -257,7 +257,7 @@ def _colorize(agg, color_key, how, min_alpha):
     data = agg.data
     total = data.sum(axis=2)
     # zero-count pixels will be 0/0, but it's safe to ignore that when dividing
-    with np.errstate(invalid='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         r = (data.dot(rs)/total).astype(np.uint8)
         g = (data.dot(gs)/total).astype(np.uint8)
         b = (data.dot(bs)/total).astype(np.uint8)

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -1,0 +1,45 @@
+name: ds
+channels:
+ - conda-forge
+ - ioam/label/dev
+ - ioam
+ - scitools/label/dev
+
+dependencies:
+ - attrs
+ - bokeh
+ - cartopy
+ - colorcet
+ - dask
+ - datashader
+ - dill
+ - distributed
+ - geoviews
+ - holoviews
+ - iris
+ - jupyter
+ - krb5
+ - matplotlib
+ - networkx
+ - numba
+ - numpy
+ - pandas
+ - paramnb
+ - pyproj
+ - pytables
+ - pytest
+ - python=3.6
+ - rasterio
+ - requests
+ - scipy
+ - shapely
+ - statsmodels
+ - tblib
+ - xarray
+ - yaml
+ - fastparquet
+ - snappy
+ - python-snappy
+ - jupyter_dashboards 
+ - pip:
+   - cachey


### PR DESCRIPTION
The examples can be difficult to get running all at the same time, since they have various different and potentially incompatible dependencies, but this file should help set up a conda environment that works for all of them.  Thanks to Peter Steinberg for making the first version of this file.

Also silenced an unrelated float division warning.