### PR TITLE
Fix bogus column and row at edge

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -49,8 +49,8 @@ class Axis(object):
         Parameters
         ----------
         range : tuple
-            A tuple representing the boundary inclusive range ``[min, max]``
-            along the axis, in data space.
+            A tuple representing the range ``[min, max]`` along the axis, in
+            data space. min is inclusive and max is exclusive.
         n : int
             The number of bins along the axis.
 
@@ -61,7 +61,7 @@ class Axis(object):
 
         """
         start, end = map(self.mapper, range)
-        s = (n - 1)/(end - start)
+        s = n/(end - start)
         t = -start * s
         return s, t
 

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -57,7 +57,7 @@ class Point(_PointLike):
             for i in range(xs.shape[0]):
                 x = xs[i]
                 y = ys[i]
-                if (xmin <= x <= xmax) and (ymin <= y <= ymax):
+                if (xmin <= x < xmax) and (ymin <= y < ymax):
                     append(i,
                            int(x_mapper(x) * sx + tx),
                            int(y_mapper(y) * sy + ty),

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -1,11 +1,13 @@
+from dask.async import get_sync
+from dask.context import set_options
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import xarray as xr
-import dask.dataframe as dd
-from dask.context import set_options
-from dask.async import get_sync
 
 import datashader as ds
+
+import pytest
 
 set_options(get=get_sync)
 
@@ -25,13 +27,13 @@ df.f64[2] = np.nan
 
 ddf = dd.from_pandas(df, npartitions=3)
 
-c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
-c_logx = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 10),
-                   y_range=(0, 1), x_axis_type='log')
-c_logy = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1),
-                   y_range=(1, 10), y_axis_type='log')
-c_logxy = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 10),
-                    y_range=(1, 10), x_axis_type='log', y_axis_type='log')
+c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 2), y_range=(0, 2))
+c_logx = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 11),
+                   y_range=(0, 2), x_axis_type='log')
+c_logy = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 2),
+                   y_range=(1, 11), y_axis_type='log')
+c_logxy = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 11),
+                    y_range=(1, 11), x_axis_type='log', y_axis_type='log')
 
 coords = [np.arange(2, dtype='f8'), np.arange(2, dtype='f8')]
 dims = ['y_axis', 'x_axis']
@@ -152,14 +154,15 @@ def test_multiple_aggregates():
 
 
 def test_log_axis():
+    x_max_index = 10 ** (1 / (2 / np.log10(11)))
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
-    out = xr.DataArray(sol, coords=[np.array([0., 1.]), np.array([1., 10.])],
+    out = xr.DataArray(sol, coords=[np.array([0., 1.]), np.array([1., x_max_index])],
                        dims=dims)
     assert_eq(c_logx.points(ddf, 'log_x', 'y', ds.count('i32')), out)
-    out = xr.DataArray(sol, coords=[np.array([1., 10.]), np.array([0., 1.])],
+    out = xr.DataArray(sol, coords=[np.array([1., x_max_index]), np.array([0., 1.])],
                        dims=dims)
     assert_eq(c_logy.points(ddf, 'x', 'log_y', ds.count('i32')), out)
-    out = xr.DataArray(sol, coords=[np.array([1., 10.]), np.array([1., 10.])],
+    out = xr.DataArray(sol, coords=[np.array([1., x_max_index]), np.array([1., x_max_index])],
                        dims=dims)
     assert_eq(c_logxy.points(ddf, 'log_x', 'log_y', ds.count('i32')), out)
 
@@ -169,15 +172,15 @@ def test_line():
                        'y': [0, -4, 0, 1, 2, 2.1, 4, 20, 30, 4, 0]})
     ddf = dd.from_pandas(df, npartitions=3)
     cvs = ds.Canvas(plot_width=7, plot_height=7,
-                    x_range=(-3, 3), y_range=(-3, 3))
+                    x_range=(-3, 4), y_range=(-3, 4))
     agg = cvs.line(ddf, 'x', 'y', ds.count())
     sol = np.array([[0, 0, 1, 0, 1, 0, 0],
                     [0, 1, 0, 0, 0, 1, 0],
                     [1, 0, 0, 0, 0, 0, 1],
                     [0, 0, 0, 0, 0, 0, 0],
-                    [1, 0, 0, 0, 0, 0, 1],
+                    [3, 0, 0, 0, 0, 0, 1],
                     [0, 2, 0, 0, 0, 1, 0],
                     [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
-    out = xr.DataArray(sol, coords=[np.arange(-3, 4), np.arange(-3, 4)],
+    out = xr.DataArray(sol, coords=[np.arange(-3., 4.), np.arange(-3., 4.)],
                        dims=['y_axis', 'x_axis'])
     assert_eq(agg, out)

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -154,6 +154,7 @@ def test_multiple_aggregates():
 
 
 def test_log_axis():
+    # Upper bound for scale/index of x-axis
     x_max_index = 10 ** (1 / (2 / np.log10(11)))
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
     out = xr.DataArray(sol, coords=[np.array([0., 1.]), np.array([1., x_max_index])],

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -4,6 +4,8 @@ import xarray as xr
 
 import datashader as ds
 
+import pytest
+
 
 df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                    'y': np.array(([0.] * 5 + [1] * 5 + [0] * 5 + [1] * 5)),
@@ -19,13 +21,13 @@ df.cat = df.cat.astype('category')
 df.f32[2] = np.nan
 df.f64[2] = np.nan
 
-c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
-c_logx = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 10),
-                   y_range=(0, 1), x_axis_type='log')
-c_logy = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1),
-                   y_range=(1, 10), y_axis_type='log')
-c_logxy = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 10),
-                    y_range=(1, 10), x_axis_type='log', y_axis_type='log')
+c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 2), y_range=(0, 2))
+c_logx = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 11),
+                   y_range=(0, 2), x_axis_type='log')
+c_logy = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 2),
+                   y_range=(1, 11), y_axis_type='log')
+c_logxy = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 11),
+                    y_range=(1, 11), x_axis_type='log', y_axis_type='log')
 
 coords = [np.arange(2, dtype='f8'), np.arange(2, dtype='f8')]
 dims = ['y_axis', 'x_axis']
@@ -146,14 +148,15 @@ def test_multiple_aggregates():
 
 
 def test_log_axis():
+    x_max_index = 10 ** (1 / (2 / np.log10(11)))
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
-    out = xr.DataArray(sol, coords=[np.array([0., 1.]), np.array([1., 10.])],
+    out = xr.DataArray(sol, coords=[np.array([0., 1.]), np.array([1., x_max_index])],
                        dims=dims)
     assert_eq(c_logx.points(df, 'log_x', 'y', ds.count('i32')), out)
-    out = xr.DataArray(sol, coords=[np.array([1., 10.]), np.array([0., 1.])],
+    out = xr.DataArray(sol, coords=[np.array([1., x_max_index]), np.array([0., 1.])],
                        dims=dims)
     assert_eq(c_logy.points(df, 'x', 'log_y', ds.count('i32')), out)
-    out = xr.DataArray(sol, coords=[np.array([1., 10.]), np.array([1., 10.])],
+    out = xr.DataArray(sol, coords=[np.array([1., x_max_index]), np.array([1., x_max_index])],
                        dims=dims)
     assert_eq(c_logxy.points(df, 'log_x', 'log_y', ds.count('i32')), out)
 
@@ -162,15 +165,15 @@ def test_line():
     df = pd.DataFrame({'x': [4, 0, -4, -3, -2, -1.9, 0, 10, 10, 0, 4],
                        'y': [0, -4, 0, 1, 2, 2.1, 4, 20, 30, 4, 0]})
     cvs = ds.Canvas(plot_width=7, plot_height=7,
-                    x_range=(-3, 3), y_range=(-3, 3))
+                    x_range=(-3, 4), y_range=(-3, 4))
     agg = cvs.line(df, 'x', 'y', ds.count())
     sol = np.array([[0, 0, 1, 0, 1, 0, 0],
                     [0, 1, 0, 0, 0, 1, 0],
                     [1, 0, 0, 0, 0, 0, 1],
                     [0, 0, 0, 0, 0, 0, 0],
-                    [1, 0, 0, 0, 0, 0, 1],
+                    [3, 0, 0, 0, 0, 0, 1],
                     [0, 2, 0, 0, 0, 1, 0],
                     [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
-    out = xr.DataArray(sol, coords=[np.arange(-3, 4), np.arange(-3, 4)],
+    out = xr.DataArray(sol, coords=[np.arange(-3., 4.), np.arange(-3., 4.)],
                        dims=['y_axis', 'x_axis'])
     assert_eq(agg, out)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -148,6 +148,7 @@ def test_multiple_aggregates():
 
 
 def test_log_axis():
+    # Upper bound for scale/index of x-axis
     x_max_index = 10 ** (1 / (2 / np.log10(11)))
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
     out = xr.DataArray(sol, coords=[np.array([0., 1.]), np.array([1., x_max_index])],

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -72,7 +72,7 @@ def test_sum():
 
 
 def test_min():
-    out = xr.DataArray(df.i64.reshape((2, 2, 5)).min(axis=2).astype('f8').T,
+    out = xr.DataArray(df.i64.values.reshape((2, 2, 5)).min(axis=2).astype('f8').T,
                        coords=coords, dims=dims)
     assert_eq(c.points(df, 'x', 'y', ds.min('i32')), out)
     assert_eq(c.points(df, 'x', 'y', ds.min('i64')), out)


### PR DESCRIPTION
I applied @jbednar's changes to make the upper bound exclusive.

I also updated the test data to reflect the new upper bound semantics. In particular, the log axis tests required a seemingly magic value, `x_max_index`. This value results from scaling, translating, and indexing the original x range from `(1, 11)` to `(1, sqrt(11))`. To account for precision errors, I calculated the final value using the same formula used by Datashader.

Fix #259