### PR TITLE
Add latest numba build + debugging stmts for memory usage

### DIFF
--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -6,10 +6,10 @@
 #    conda uninstall --force dask fastparquet python-snappy
 #    pip install --no-cache-dir --upgrade git+https://github.com/dask/dask@964b377    # auto-detect categoricals for dd.read_parquet
 #    pip install --no-cache-dir --upgrade git+https://github.com/dask/fastparquet@4106c30    # auto-detect categoricals for dd.read_parquet
-#    pip install --no-cache-dir --upgrade llvmlite==0.17.0 git+https://github.com/andrix/python-snappy@0d1ab38    # For releasing the GIL. Pin llvmlite to the version that numba depends on
+#    pip install --no-cache-dir git+https://github.com/andrix/python-snappy@0d1ab38    # For releasing the GIL. May need to pin llvmlite to the version that numba depends on
 #    mkdir times
-#    python -c "import filetimes as ft ; ft.p.base='census' ; ft.p.x='meterswest' ; ft.p.y='metersnorth' ; ft.p.categories=['race']; ft.timed_write('data/tinycensus.csv',dftype='pandas')"
-#    # (or 'data/census.h5' and/or dftype='dask')
+#    python -c "import filetimes as ft ; ft.p.base='census' ; ft.p.x='meterswest' ; ft.p.y='metersnorth' ; ft.p.categories=['race']; ft.timed_write('data/tinycensus.csv',dftype='pandas',fsize='double')"
+#    # (dftype can also be 'dask', fsize can also be 'single')
 #    ./filetimes.sh times/tinycensus
 #    # (add a second argument to filetimes.sh to set the caching mode)
 #    # (add a third argument to filetimes.sh to set the ft.DEBUG variable)

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -8,7 +8,7 @@ dependencies:
 - conda-forge::feather-format=0.3.1=py35_1
 - dask=0.14.1=py35_0
 - hdf5=1.8.17=1
-- numba=0.32.0=np112py35_0
+- numba::numba=0.33.0.dev=np112py35_21
 - numexpr=2.6.2=np112py35_0
 - numpy=1.12.1=py35_0
 - pandas=0.19.2=np112py35_1


### PR DESCRIPTION
This PR includes the recent numba dev build, which contains some performance fixes (useful for benchmarking), into the benchmarking/filetimes environment.

Also included are some additional debug/print statements related to memory usage, per issue #313 and issue #313 .

A flag is added to `timed_write()` so we can control the floating-point precision when writing out files, and see how it affects both file-size, write performance, and (more importantly) read performance.