### PR TITLE
Fix issues with csv benchmarks

### DIFF
--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -98,7 +98,7 @@ def benchmark(fn, args, filetype=None):
     
 
 
-read = odict([(f,odict()) for f in ["parq","bcolz","feather","castra","h5","csv"]])
+read = odict([(f,odict()) for f in ["parq","snappy.parq","gz.parq","bcolz","feather","castra","h5","csv"]])
 
 def read_csv_dask(__filepath, usecols=None):
     # Pandas writes CSV files out as a single file
@@ -111,7 +111,10 @@ read["csv"]     ["dask"]   = lambda filepath,p,filetype:  benchmark(read_csv_das
 read["h5"]      ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.read_hdf, (filepath, p.base, Kwargs(chunksize=p.chunksize, columns=p.columns)), filetype)
 #read["castra"]  ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.from_castra, (filepath,), filetype)
 read["bcolz"]   ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.from_bcolz, (filepath, Kwargs(chunksize=1000000)), filetype)
-read["parq"]    ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, columns=p.columns)), filetype) # categories=p.categories, 
+read["parq"]    ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, columns=p.columns)), filetype)
+read["gz.parq"]    ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, columns=p.columns)), filetype)
+read["snappy.parq"]    ["dask"]   = lambda filepath,p,filetype:  benchmark(dd.read_parquet, (filepath, Kwargs(index=False, columns=p.columns)), filetype)
+
 
 def read_csv_pandas(__filepath, usecols=None):
     # Pandas writes CSV files out as a single file
@@ -127,6 +130,8 @@ read["feather"] ["pandas"] = lambda filepath,p,filetype:  benchmark(feather.read
 def read_parq_pandas(__filepath):
     return fp.ParquetFile(__filepath).to_pandas()
 read["parq"]    ["pandas"] = lambda filepath,p,filetype:  benchmark(read_parq_pandas, (filepath,), filetype)
+read["gz.parq"]    ["pandas"] = lambda filepath,p,filetype:  benchmark(read_parq_pandas, (filepath,), filetype)
+read["snappy.parq"]    ["pandas"] = lambda filepath,p,filetype:  benchmark(read_parq_pandas, (filepath,), filetype)
 
 
 write = odict([(f,odict()) for f in ["parq","snappy.parq","gz.parq","bcolz","feather","castra","h5","csv"]])

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -154,7 +154,6 @@ write["feather"]      ["pandas"] = lambda df,filepath,p:  benchmark(feather.writ
 write["parq"]         ["pandas"] = lambda df,filepath,p:  benchmark(fp.write, (filepath, df, Kwargs(**p.parq_opts)))
 write["gz.parq"]  ["pandas"] = lambda df,filepath,p:  benchmark(fp.write, (filepath, df, Kwargs(compression='GZIP', **p.parq_opts)))
 write["snappy.parq"]  ["pandas"] = lambda df,filepath,p:  benchmark(fp.write, (filepath, df, Kwargs(compression='SNAPPY', **p.parq_opts)))
-#write["gz.parq"]      ["pandas"] = lambda df,filepath,p:  benchmark(fp.write, (filepath, df, Kwargs(fixed_text={c:p.cat_width for c in p.categories}, compression='GZIP', **p.parq_opts)))
 
 
 def timed_write(filepath,dftype,fsize='double',output_directory="times"):

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -6,7 +6,7 @@
 #    conda uninstall --force dask fastparquet python-snappy
 #    pip install --no-cache-dir --upgrade git+https://github.com/dask/dask@964b377    # auto-detect categoricals for dd.read_parquet
 #    pip install --no-cache-dir --upgrade git+https://github.com/dask/fastparquet@4106c30    # auto-detect categoricals for dd.read_parquet
-#    pip install --no-cache-dir git+https://github.com/andrix/python-snappy@0d1ab38    # For releasing the GIL. May need to pin llvmlite to the version that numba depends on
+#    pip install --no-cache-dir --upgrade git+https://github.com/andrix/python-snappy@0d1ab38    # For releasing the GIL. May need to pin llvmlite to the version that numba depends on
 #    mkdir times
 #    python -c "import filetimes as ft ; ft.p.base='census' ; ft.p.x='meterswest' ; ft.p.y='metersnorth' ; ft.p.categories=['race']; ft.timed_write('data/tinycensus.csv',dftype='pandas',fsize='double')"
 #    # (dftype can also be 'dask', fsize can also be 'single')

--- a/examples/filetimes.sh
+++ b/examples/filetimes.sh
@@ -30,8 +30,10 @@ test -n "$3" && set -x
 
 ${timer} python filetimes.py ${1}.parq        dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.snappy.parq dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.gz.parq     dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.parq        pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.snappy.parq pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
+${timer} python filetimes.py ${1}.gz.parq     pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.castra      dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.castra      pandas  census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}
 ${timer} python filetimes.py ${1}.bcolz       dask    census meterswest metersnorth race ${3:+--debug} ${2:+--cache=$2}

--- a/examples/filetimes.yml
+++ b/examples/filetimes.yml
@@ -8,7 +8,7 @@ dependencies:
 - conda-forge::feather-format=0.3.1=py35_1
 - dask=0.14.1=py35_0
 - hdf5=1.8.17=1
-- numba::numba=0.33.0.dev=np112py35_21
+- numba::numba=0.33.0.dev=np112py35_33
 - numexpr=2.6.2=np112py35_0
 - numpy=1.12.1=py35_0
 - pandas=0.19.2=np112py35_1


### PR DESCRIPTION
The "filetimes" benchmarks have had some issues with CSV files in the past, due to the fact that dask writes out CSV data as separate files (due to partitioning), but pandas writes the CSV data as a single large file. This PR corrects the file size calculations to account for all CSV files (when dask writes them out), and the benchmarks will involve loading all CSVs, regardless of whether they were written out by dask or pandas.

This has the implication that when pandas writes out the CSV data, pandas should have an advantage at CSV read-time, and when dask writes out CSV data, dask will have an advantage at CSV read-time (pandas takes an additional "concatenation" step after reading in each file).