### PR TITLE
Improvements to distributed scheduler benchmarks

### DIFF
--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -95,6 +95,7 @@ def benchmark(fn, args, filetype=None):
                 #   aggregation performance (both --distributed and
                 #   --cache=persist were provided)
                 res = DASK_CLIENT.persist(res)
+                distributed.wait(res)
             else:
                 if DEBUG:
                     print("DEBUG: Force-loading Dask dataframe", flush=True)


### PR DESCRIPTION
Add `distibuted.wait(dask_df)` after `client.persist(dask_df)` for distributed scheduler, based on suggestion from @mrocklin in #332 .