### PR TITLE
NREL - Solar Anywhere data examples with holoviews

### DIFF
--- a/examples/datasets.yml
+++ b/examples/datasets.yml
@@ -67,3 +67,31 @@ data:
     files:
       - census.parq
 
+  - url: http://rredc.nrel.gov/solar/old_data/nsrdb/1991-2010/targzs/
+    title: 'Solar Radiation NREL - NSRDB'
+    files:
+      - 726710.tar.gz
+      - 725690.tar.gz
+      - 725640.tar.gz
+      - 726700.tar.gz
+      - 725685.tar.gz
+      - 725686.tar.gz
+      - 725775.tar.gz
+      - 726650.tar.gz
+      - 725776.tar.gz
+      - 726654.tar.gz
+      - 725760.tar.gz
+      - 725645.tar.gz
+      - 725745.tar.gz
+      - 725765.tar.gz
+      - 725744.tar.gz
+      - 726660.tar.gz
+      - 726667.tar.gz
+      - 725763.tar.gz
+      - 726665.tar.gz
+
+  - url: http://rredc.nrel.gov/solar/old_data/nsrdb/1991-2010/NSRDB_StationsMeta.csv
+    title: 'Solar Radiation NREL - NSRDB Meta'
+    files:
+      - NSRDB_StationsMeta.csv
+

--- a/examples/download_sample_data.py
+++ b/examples/download_sample_data.py
@@ -222,18 +222,22 @@ def _extract_downloaded_archive(output_path):
     if output_path.endswith("tar.gz"):
         with tarfile.open(output_path, "r:gz") as tar:
             tar.extractall()
+        os.remove(output_path)
     elif output_path.endswith("tar"):
         with tarfile.open(output_path, "r:") as tar:
             tar.extractall()
+        os.remove(output_path)
     elif output_path.endswith("tar.bz2"):
         with tarfile.open(output_path, "r:bz2") as tar:
             tar.extractall()
+        os.remove(output_path)
     elif output_path.endswith("zip"):
         with zipfile.ZipFile(output_path, 'r') as zipf:
             zipf.extractall()
+        os.remove(output_path)
     elif output_path.endswith('7z'):
         _unzip_7z(output_path)
-    os.remove(output_path)
+        os.remove(output_path)
 
 
 def _process_dataset(dataset, output_dir, here):
@@ -267,7 +271,8 @@ def _process_dataset(dataset, output_dir, here):
             urls = [url + f for f in dataset['files']]
             output_paths = [os.path.join(here, 'data', fname)
                             for fname in dataset['files']]
-            unpacked = ['.'.join(output_path.split('.')[:-1]) + '.*'
+
+            unpacked = ['.'.join(output_path.split('.')[:(-2 if output_path.endswith('gz') else -1)]) + '*'
                         for output_path in output_paths]
         else:
             urls = [url]
@@ -278,7 +283,7 @@ def _process_dataset(dataset, output_dir, here):
         zipped = zip(urls, output_paths, unpacked)
         for idx, (url, output_path, unpack) in enumerate(zipped):
             running_title = title_fmt.format(idx + 1, len(urls))
-            if glob.glob(unpack):
+            if glob.glob(unpack) or os.path.exists(unpack.replace('*','')):
                 # Skip a file if a similar one is downloaded, e.g.:
                 #    skip q47122d2101.7z if q47122d2101.gnd exists
                 print('Skipping {0}'.format(running_title))

--- a/examples/solar.ipynb
+++ b/examples/solar.ipynb
@@ -4,7 +4,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solar Anywhere"
+    "# Visualize Solar Radation Data\n",
+    "\n",
+    "The data in this notebook come from the [National Solar Radiation Data Base](http://rredc.nrel.gov/solar/old_data/nsrdb/), specifically the [1991 - 2010 update to the National Solar Radiation Database](http://rredc.nrel.gov/solar/old_data/nsrdb/1991-2010/).  The data set consists of CSV files [measured at USAF weather stations](http://rredc.nrel.gov/solar/old_data/nsrdb/1991-2010/hourly/list_by_USAFN.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Run the `download_sample_data.py` script to download Lidar from [Puget Sound LiDAR consortium](http://pugetsoundlidar.ess.washington.edu) and other example data sets.  \n",
+    "\n",
+    "From your local clone of the `datashader` repository:\n",
+    "```\n",
+    "cd examples\n",
+    "conda env create environment.yml\n",
+    "source activate ds \n",
+    "python download_sample_data.py\n",
+    "```\n",
+    "Note on Windows, replace `source activate ds` with `activate ds`."
    ]
   },
   {
@@ -51,16 +71,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "NUM_STATIONS = 4 # adjust to limit to subset of SOLAR_FILES"
+    "NUM_STATIONS = None # adjust to and integer limit to subset of SOLAR_FILES"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "SOLAR_FNAME_PATTERN = os.path.join('data', '72*', '*solar.csv')\n",
@@ -72,8 +96,12 @@
     "for fname in SOLAR_FILES:\n",
     "    k, v = get_station_yr(fname)\n",
     "    STATION_COMBOS[k].append([v, fname])\n",
-    "STATION_COMBOS = {k: STATION_COMBOS[k] for k in tuple(STATION_COMBOS)[:NUM_STATIONS]}\n",
-    "files_for_station = lambda station: [x[1] for x in STATION_COMBOS[station]]"
+    "choices = tuple(STATION_COMBOS)\n",
+    "if NUM_STATIONS:\n",
+    "    choices = choices[:NUM_STATIONS]\n",
+    "STATION_COMBOS = {k: STATION_COMBOS[k] for k in choices}\n",
+    "files_for_station = lambda station: [x[1] for x in STATION_COMBOS[station]]\n",
+    "station_year_files = lambda station, year: [x for x in files_for_station(station) if '_{}_'.format(year) in x]"
    ]
   },
   {
@@ -119,24 +147,28 @@
    },
    "outputs": [],
    "source": [
+    "keep_cols = ['date', 'y', 'x', 'julian_hr', 'year', 'usaf', 'month', 'hour']\n",
+    "\n",
     "@dask.delayed\n",
     "def read_one_fname(usaf_station, fname):\n",
     "    dframe = clean_col_names(pd.read_csv(fname))\n",
     "    station_data = meta_df.loc[usaf_station]\n",
-    "    hour_offset = dframe.hh_mm_lst.map(lambda x:pd.Timedelta(hours=int(x.split(':')[0])))\n",
-    "    keep_cols = ['date', 'y', 'x', 'julian_hr', 'year', 'usaf']\n",
-    "    keep_cols += [col for col in dframe.columns\n",
-    "                  if ('metstat' in col or 'suny' in col or col in keep_cols)\n",
-    "                  and 'flg' not in col]\n",
+    "    hour_offset = dframe.hh_mm_lst.map(lambda x: pd.Timedelta(hours=int(x.split(':')[0])))   \n",
+    "    keep = keep_cols + [col for col in dframe.columns\n",
+    "                        if ('metstat' in col or col in keep_cols)\n",
+    "                        and 'flg' not in col]\n",
     "    dframe['date'] = pd.to_datetime(dframe.yyyy_mm_dd) + hour_offset\n",
+    "    dframe['month'] = dframe.date.dt.month\n",
+    "    dframe['hour'] = dframe.date.dt.hour\n",
     "    dframe['usaf'] = usaf_station\n",
     "    dframe['y'], dframe['x'] = station_data.nsrdb_lat_dd, station_data.nsrdb_lon_dd \n",
     "    dframe['julian_hr'] = dframe.date.dt.hour + (dframe.date.dt.dayofyear - 1) * 24\n",
     "    dframe['year'] = dframe.date.dt.year\n",
     "    dframe[dframe <= -999] = np.NaN\n",
-    "    return dframe.loc[:, keep_cols]\n",
+    "    return dframe.loc[:, keep]\n",
     "\n",
     "def read_one_station(station):\n",
+    "    '''Read one USAF station's 1991 to 2001 CSVs - dask.delayed for each each year'''\n",
     "    files = files_for_station(station)\n",
     "    return dd.from_delayed([read_one_fname(station, fname) for fname in files]).compute()"
    ]
@@ -145,6 +177,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -168,7 +201,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.date.describe()"
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "desc = df.date.describe()\n",
+    "desc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next cell makes some labels for the time series groupby operations' plots and boxplots."
    ]
   },
   {
@@ -177,47 +227,71 @@
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
-   "source": [
-    "def get_station_quantiles(station=None, grouper='julian_hr', usaf_data=None):\n",
-    "    if usaf_data is None:\n",
-    "        usaf_data = read_one_station(station).groupby(grouper)\n",
-    "    low = usaf_data.quantile(0.25)\n",
-    "    median = usaf_data.median()\n",
-    "    hi = usaf_data.quantile(0.75)\n",
-    "    median[grouper] = median.index.values\n",
-    "    median['usaf'] = station\n",
-    "    summary_df = median.join(low, \n",
-    "                             rsuffix='_low').join(hi, rsuffix='_hi')\n",
-    "    return summary_df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "julian_summary = get_station_quantiles(station=example_usaf)\n",
-    "julian_summary.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
    "outputs": [],
    "source": [
     "direct, dif_h, glo_h = ('Direct Normal', \n",
     "                        'Diffuse Horizontal', \n",
     "                        'Global Horizontal',)\n",
-    "labels = []\n",
+    "labels = {}\n",
     "watt_hrs_m2_cols = [col for col in df.columns if 'wh_m_2' in col and not 'suny' in col]\n",
     "for col in watt_hrs_m2_cols:\n",
-    "    word1 = \"Clear Sky \" if 'csky' in col else \"Measured\"\n",
-    "    word2 = direct if '_dir_' in col else dif_h if '_dif_' else glo_h\n",
-    "    labels.append('{} - {}'.format(word1, word2))\n",
-    "watt_hrs_m2_cols, labels"
+    "    label_1 = \"Clear Sky \" if 'csky' in col else \"Measured \"\n",
+    "    label_2 = direct if '_dir_' in col else glo_h if '_glo_' in col else dif_h\n",
+    "    labels[col] = label_1 + label_2\n",
+    "labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_station_quantiles(station=None, grouper='julian_hr', usaf_data=None):\n",
+    "    '''Given a station name or dataframe do groupby on time bins\n",
+    "    Parameters:\n",
+    "        station:    Integer name of a USAF weather station \n",
+    "                    (folder names holding years' CSVs)\n",
+    "        groupby:    One of \"julian_hr\" \"hour\" \"month_hour\"\n",
+    "                    (Note the julian_hr does not standardize relative to leap\n",
+    "                    years: non-leap years have 8760 hrs, leap years 8784 hrs)\n",
+    "        usaf_data:  Give CSVs' dataframe instead of station name\n",
+    "    Returns:\n",
+    "        summary_df  Dataframe with 25%, 50%, 75% for each column\n",
+    "    '''\n",
+    "\n",
+    "    if usaf_data is None:\n",
+    "        usaf_data = read_one_station(station)\n",
+    "    if grouper == 'hour':\n",
+    "        group_var = usaf_data.date.dt.hour\n",
+    "    elif grouper == 'month':\n",
+    "        group_var = usaf_data.date.dt.month\n",
+    "    elif grouper == 'month_hour':\n",
+    "        group_var = [usaf_data.date.dt.month, usaf_data.date.dt.hour]\n",
+    "    else:\n",
+    "        group_var = grouper\n",
+    "    usaf_data = usaf_data.groupby(group_var)\n",
+    "    usaf_data = usaf_data[keep_cols + watt_hrs_m2_cols]\n",
+    "    low = usaf_data.quantile(0.25)\n",
+    "    median = usaf_data.median()\n",
+    "    hi = usaf_data.quantile(0.75)\n",
+    "    median[grouper] = median.index.values\n",
+    "    median['usaf'] = station\n",
+    "    # For the low, hi quartiles subset the columns\n",
+    "    # for smaller joins - do not include 3 copies of x,y,date, etc\n",
+    "    join_arg_cols = [col for col in low.columns if col not in keep_cols]\n",
+    "    summary_df = median.join(low[join_arg_cols], \n",
+    "                             rsuffix='_low').join(hi[join_arg_cols], rsuffix='_hi')\n",
+    "    return summary_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get Julian day of year summary for one USAF station using `pandas.DataFrame.groupby`. "
    ]
   },
   {
@@ -226,30 +300,75 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_gen():\n",
+    "julian_summary = get_station_quantiles(station=example_usaf, grouper='julian_hr',)\n",
+    "julian_summary.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function `get_station_quantiles` returns a `DataFrame` with\n",
+    " * spatial coordinates `x` and `y`\n",
+    " * columns related to clear sky solar radiation (columns with `_csky_` as a token)\n",
+    " * measured solar radiation (columns without `_csky_` as a token)\n",
+    " * some date / time related columns helpful for `groupby` operations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "julian_summary.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def plot_gen(station=None, grouper='julian_hr', usaf_data=None):\n",
+    "    '''Given a station name or dataframe do groupby on time bins\n",
+    "    Parameters:\n",
+    "        station:    Integer name of a USAF weather station \n",
+    "                    (folder names holding years' CSVs)\n",
+    "        groupby:    One of \"julian_hr\" \"hour\" \"month_hour\"\n",
+    "        usaf_data:  Give CSVs' dataframe instead of station name\n",
+    "    Returns:\n",
+    "        curves:     Dictionary of hv.Curve objects showing \n",
+    "                    25%, 50%, 75% percentiles\n",
+    "    '''\n",
+    "    summary_df = get_station_quantiles(station=station, \n",
+    "                                       grouper=grouper, \n",
+    "                                       usaf_data=usaf_data)\n",
     "    curves = {}\n",
     "    kw = dict(style=dict(s=2,alpha=0.5))\n",
     "    for col, label in zip(watt_hrs_m2_cols, labels):\n",
     "        dates = pd.DatetimeIndex(start=pd.Timestamp('2001-01-01'),\n",
     "                                 freq='H', \n",
-    "                                 periods=julian_summary.shape[0])\n",
-    "        median_col = julian_summary[col]\n",
-    "        low_col = julian_summary[col + '_low']\n",
-    "        hi_col = julian_summary[col + '_hi']\n",
-    "        hi = hv.Curve((dates, hi_col), label=label + ' (75%)')(**kw)\n",
-    "        low = hv.Curve((dates, low_col),label=label + ' (25%)')(**kw)\n",
+    "                                 periods=summary_df.shape[0])\n",
+    "        median_col = summary_df[col]\n",
+    "        low_col = summary_df[col + '_low']\n",
+    "        hi_col = summary_df[col + '_hi']\n",
+    "        hi = hv.Curve((dates, hi_col), label=label + ' (upper quartile)')(**kw)\n",
+    "        low = hv.Curve((dates, low_col),label=label + ' (lower quartile)')(**kw)\n",
     "        median = hv.Curve((dates, median_col), label=label)(**kw)\n",
-    "        curves[tuple(col.replace('metstat_', '').replace('_wh_m_2', '').split('_'))] = low * median * hi\n",
+    "        plot_id = tuple(col.replace('metstat_', '').replace('_wh_m_2', '').split('_'))\n",
+    "        curves[plot_id] = low * median * hi\n",
+    "        curves[plot_id].group = labels[col]\n",
     "    return curves"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "plots = plot_gen()"
+    "Run `plot_gen` (function above) with an example USAF station to get a dictionary of `holoviews.Curve` objects that have been combined with the overloaded `holoviews` `*` operator for `Curves` or other `holoviews.element` objects.  The `*` operator is used to show 25%, 50%, and 75% time series."
    ]
   },
   {
@@ -258,7 +377,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "list(plots)"
+    "hour_of_year = plot_gen(station=example_usaf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have a dictionary with short keys for different plots of 25%, 50%, 75% of:\n",
+    " * `(glo,)`: Measured Global Horizontal\n",
+    " * `(dir,)`: Measured Direct Normal\n",
+    " * `(dif,)`: Measured Diffuse Horizontal\n",
+    " * `('csky', 'glo')`: Clear Sky Global Horizontal\n",
+    " * `('csky', 'dir')`: Clear Sky Direct Normal\n",
+    " * `('csky', 'dif')`: Clear Sky Diffuse Horizontal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list(hour_of_year)"
    ]
   },
   {
@@ -270,19 +411,40 @@
    "outputs": [],
    "source": [
     "%%opts Curve [width=700 height=500]\n",
-    "%%opts Layout [sublabel_format=\"\" tight=True]\n",
-    "plots[('csky', 'dir')]"
+    "%%opts Layout [tabs=True]\n",
+    "hour_of_year[('dir',)] + hour_of_year[('csky', 'dir')] "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
-    "%%opts Curve [width=700 height=500]\n",
-    "%%opts Layout [sublabel_format=\"\" tight=True]\n",
-    "plots[('dir',)]"
+    "%%opts Curve [width=700 height=500 ]\n",
+    "%%opts Layout [tabs=True]\n",
+    "hour_of_year[('glo',)] + hour_of_year[('csky', 'glo')] + hour_of_year[('dif',)] + hour_of_year[('csky', 'dif',)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next cells repeat the groupby operations for hour of day."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "usaf_data = read_one_station(example_usaf)\n",
+    "hour_of_day = plot_gen(grouper='hour', usaf_data=usaf_data)"
    ]
   },
   {
@@ -294,9 +456,41 @@
    "outputs": [],
    "source": [
     "%%opts Curve [width=700 height=500]\n",
-    "%%opts Layout [sublabel_format=\"\" tight=True]\n",
-    "plots[('dif',)] + plots[('csky', 'dif',)]"
+    "%%opts Layout [tabs=True]\n",
+    "hour_of_day[('dir',)] + hour_of_day[('csky', 'dir')] "
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When grouping by hour of day or month of year, the number of groups on the horizontal axis is small enough for box plots to show distributions legibly.  The next cell uses `holoviews.BoxWhisker` plots to show the direct normal radiation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts BoxWhisker [width=600 height=600]\n",
+    "%%opts Layout [tabs=True]\n",
+    "(hv.BoxWhisker(usaf_data, kdims=['hour'], vdims=['metstat_dir_wh_m_2'],\n",
+    "               group='Direct Normal - Hour of Day') +\n",
+    " hv.BoxWhisker(usaf_data, kdims=['month'], vdims=['metstat_dir_wh_m_2'],\n",
+    "               group='Direct Normal - Month of Year'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -304,6 +498,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/examples/solar.ipynb
+++ b/examples/solar.ipynb
@@ -1,0 +1,311 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Solar Anywhere"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import OrderedDict\n",
+    "import glob\n",
+    "import os\n",
+    "import re\n",
+    "import sys\n",
+    "\n",
+    "from bokeh.models import WMTSTileSource\n",
+    "from cartopy import crs as ccrs\n",
+    "from collections import defaultdict\n",
+    "from dask.distributed import Client\n",
+    "from holoviews.operation import decimate\n",
+    "from holoviews.operation.datashader import aggregate, shade, datashade, dynspread\n",
+    "from pyproj import Proj, transform\n",
+    "import dask\n",
+    "import dask.dataframe as dd\n",
+    "import datashader as ds\n",
+    "import datashader.transfer_functions as tf\n",
+    "import geoviews as gv\n",
+    "import holoviews as hv\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import rasterio as rio\n",
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "import datashader as ds\n",
+    "\n",
+    "hv.notebook_extension('bokeh')\n",
+    "decimate.max_samples=1000\n",
+    "dynspread.max_px=20\n",
+    "dynspread.threshold=0.5\n",
+    "\n",
+    "client = Client()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUM_STATIONS = 4 # adjust to limit to subset of SOLAR_FILES"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SOLAR_FNAME_PATTERN = os.path.join('data', '72*', '*solar.csv')\n",
+    "SOLAR_FILES = glob.glob(SOLAR_FNAME_PATTERN)\n",
+    "META_FILE = os.path.join('data', 'NSRDB_StationsMeta.csv')\n",
+    "\n",
+    "get_station_yr = lambda fname: tuple(map(int, os.path.basename(fname).split('_')[:2]))\n",
+    "STATION_COMBOS = defaultdict(lambda: [])\n",
+    "for fname in SOLAR_FILES:\n",
+    "    k, v = get_station_yr(fname)\n",
+    "    STATION_COMBOS[k].append([v, fname])\n",
+    "STATION_COMBOS = {k: STATION_COMBOS[k] for k in tuple(STATION_COMBOS)[:NUM_STATIONS]}\n",
+    "files_for_station = lambda station: [x[1] for x in STATION_COMBOS[station]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def clean_col_names(dframe):\n",
+    "    cols = [re.sub('_$', '', re.sub('[/:\\(\\)_\\s^-]+', '_', col.replace('%', '_pcent_'))).lower()\n",
+    "            for col in dframe.columns]\n",
+    "    dframe.columns = cols\n",
+    "    return dframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "meta_df = clean_col_names(pd.read_csv(META_FILE, index_col='USAF'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta_df.loc[list(STATION_COMBOS)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "@dask.delayed\n",
+    "def read_one_fname(usaf_station, fname):\n",
+    "    dframe = clean_col_names(pd.read_csv(fname))\n",
+    "    station_data = meta_df.loc[usaf_station]\n",
+    "    hour_offset = dframe.hh_mm_lst.map(lambda x:pd.Timedelta(hours=int(x.split(':')[0])))\n",
+    "    keep_cols = ['date', 'y', 'x', 'julian_hr', 'year', 'usaf']\n",
+    "    keep_cols += [col for col in dframe.columns\n",
+    "                  if ('metstat' in col or 'suny' in col or col in keep_cols)\n",
+    "                  and 'flg' not in col]\n",
+    "    dframe['date'] = pd.to_datetime(dframe.yyyy_mm_dd) + hour_offset\n",
+    "    dframe['usaf'] = usaf_station\n",
+    "    dframe['y'], dframe['x'] = station_data.nsrdb_lat_dd, station_data.nsrdb_lon_dd \n",
+    "    dframe['julian_hr'] = dframe.date.dt.hour + (dframe.date.dt.dayofyear - 1) * 24\n",
+    "    dframe['year'] = dframe.date.dt.year\n",
+    "    dframe[dframe <= -999] = np.NaN\n",
+    "    return dframe.loc[:, keep_cols]\n",
+    "\n",
+    "def read_one_station(station):\n",
+    "    files = files_for_station(station)\n",
+    "    return dd.from_delayed([read_one_fname(station, fname) for fname in files]).compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "example_usaf = tuple(STATION_COMBOS)[0]\n",
+    "df = read_one_station(example_usaf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.date.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "def get_station_quantiles(station=None, grouper='julian_hr', usaf_data=None):\n",
+    "    if usaf_data is None:\n",
+    "        usaf_data = read_one_station(station).groupby(grouper)\n",
+    "    low = usaf_data.quantile(0.25)\n",
+    "    median = usaf_data.median()\n",
+    "    hi = usaf_data.quantile(0.75)\n",
+    "    median[grouper] = median.index.values\n",
+    "    median['usaf'] = station\n",
+    "    summary_df = median.join(low, \n",
+    "                             rsuffix='_low').join(hi, rsuffix='_hi')\n",
+    "    return summary_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "julian_summary = get_station_quantiles(station=example_usaf)\n",
+    "julian_summary.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "direct, dif_h, glo_h = ('Direct Normal', \n",
+    "                        'Diffuse Horizontal', \n",
+    "                        'Global Horizontal',)\n",
+    "labels = []\n",
+    "watt_hrs_m2_cols = [col for col in df.columns if 'wh_m_2' in col and not 'suny' in col]\n",
+    "for col in watt_hrs_m2_cols:\n",
+    "    word1 = \"Clear Sky \" if 'csky' in col else \"Measured\"\n",
+    "    word2 = direct if '_dir_' in col else dif_h if '_dif_' else glo_h\n",
+    "    labels.append('{} - {}'.format(word1, word2))\n",
+    "watt_hrs_m2_cols, labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_gen():\n",
+    "    curves = {}\n",
+    "    kw = dict(style=dict(s=2,alpha=0.5))\n",
+    "    for col, label in zip(watt_hrs_m2_cols, labels):\n",
+    "        dates = pd.DatetimeIndex(start=pd.Timestamp('2001-01-01'),\n",
+    "                                 freq='H', \n",
+    "                                 periods=julian_summary.shape[0])\n",
+    "        median_col = julian_summary[col]\n",
+    "        low_col = julian_summary[col + '_low']\n",
+    "        hi_col = julian_summary[col + '_hi']\n",
+    "        hi = hv.Curve((dates, hi_col), label=label + ' (75%)')(**kw)\n",
+    "        low = hv.Curve((dates, low_col),label=label + ' (25%)')(**kw)\n",
+    "        median = hv.Curve((dates, median_col), label=label)(**kw)\n",
+    "        curves[tuple(col.replace('metstat_', '').replace('_wh_m_2', '').split('_'))] = low * median * hi\n",
+    "    return curves"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plots = plot_gen()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list(plots)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Curve [width=700 height=500]\n",
+    "%%opts Layout [sublabel_format=\"\" tight=True]\n",
+    "plots[('csky', 'dir')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Curve [width=700 height=500]\n",
+    "%%opts Layout [sublabel_format=\"\" tight=True]\n",
+    "plots[('dir',)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Curve [width=700 height=500]\n",
+    "%%opts Layout [sublabel_format=\"\" tight=True]\n",
+    "plots[('dif',)] + plots[('csky', 'dif',)]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR is a notebook demo using solar radiation time series from the [NREL - NSRDB Solar Anywhere data set](http://rredc.nrel.gov/solar/old_data/nsrdb/).  The dataset downloaded currently is limited to the Wyoming locations and 20 years of hourly data, including clear sky solar radiation and measured radiation and their direct normal, diffuse horizontal, and global horizontal components.

Work in progress.  TODO:

 * [ ] More explanation of `hv.Curve` in notebook.  I have accidentally done `hv.Curve(x,y)` several times when I intended `hv.Curve((x,y))`, and the error string when I get it wrong is a bit wordy.  I'll check docs as well for places to clarify this.
 * [x] More viz options for median +/- high/low quartiles of time averaged averaged radiation
   * [x] Find the best fix for the leap year Julian hour averaging issue (i.e. does the standard average Julian hour or day average get labeled or adjusted for leap year effects: 8760 or 8784 rows in the results dataframe?)
 * [x] Provide some hour of day summary plots not just Julian hour of year as it is now
 * [ ] Provide a spatial summary plot (currently everything is a time series plot at a point in space)
 * [ ] EDIT: Also use this notebook to explain tab completion in notebooks `%%opts` magic command 

Other ideas welcome.  I hope to use this dataset a bit later for [machine learning with `elm`](https://github.com/ContinuumIO/elm), such as ML to infill data gaps in spatial time series.  I'll try to finalize this PR this week, then revisit the topic later.
 
cc @jbednar @gbrener 