### PR TITLE
Fix exclusive upper bound for line aggregation

### DIFF
--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -89,10 +89,11 @@ class Line(_PointLike):
         y_name = self.y
 
         def extend(aggs, df, vt, bounds, plot_start=True):
+            mapped_bounds = map_onto_pixel(vt, *bounds)
             xs = df[x_name].values
             ys = df[y_name].values
             cols = aggs + info(df)
-            extend_line(vt, bounds, xs, ys, plot_start, *cols)
+            extend_line(vt, bounds, mapped_bounds, xs, ys, plot_start, *cols)
 
         return extend
 
@@ -151,7 +152,7 @@ def _build_draw_line(append, map_onto_pixel):
         transformed onto the pixel grid before use in the calculations.
         """
         x0i, x1i, y0i, y1i = map_onto_pixel(vt, x0, x1, y0, y1)
-        xmin, xmax, ymin, ymax = map_onto_pixel(vt, *bounds)
+        xmin, xmax, ymin, ymax = bounds
 
         dx = x1i - x0i
         ix = (dx > 0) - (dx < 0)
@@ -197,7 +198,7 @@ def _build_draw_line(append, map_onto_pixel):
 
 def _build_extend_line(draw_line):
     @ngjit
-    def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
+    def extend_line(vt, bounds, mapped_bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate along a line formed by ``xs`` and ``ys``"""
         sx, tx, sy, ty = vt
         xmin, xmax, ymin, ymax = bounds
@@ -257,7 +258,7 @@ def _build_extend_line(draw_line):
                                                     ymin, ymax)
 
             if accept:
-                draw_line(vt, bounds, x0, y0, x1, y1, i, plot_start, clipped,
+                draw_line(vt, mapped_bounds, x0, y0, x1, y1, i, plot_start, clipped,
                           *aggs_and_cols)
                 plot_start = False
             i += 1

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -201,7 +201,6 @@ def _build_extend_line(draw_line):
     @ngjit
     def extend_line(vt, bounds, mapped_bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate along a line formed by ``xs`` and ``ys``"""
-        sx, tx, sy, ty = vt
         xmin, xmax, ymin, ymax = bounds
         nrows = xs.shape[0]
         i = 0

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -148,8 +148,9 @@ def _build_draw_line(append, map_onto_pixel):
         given bounds have an inclusive lower bound and exclusive upper bound.
         Any pixels drawn on the x-axis or y-axis upper bound are ignored.
 
-        The vertices of the line segment and the bounds are scaled and
-        transformed onto the pixel grid before use in the calculations.
+        The vertices of the line segment are scaled and transformed onto the
+        pixel grid before use in the calculations. The given bounds are
+        assumed to have already been scaled and transformed.
         """
         x0i, x1i, y0i, y1i = map_onto_pixel(vt, x0, x1, y0, y1)
         xmin, xmax, ymin, ymax = bounds

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -153,7 +153,7 @@ def test_multiple_aggregates():
     assert_eq(agg.i32_count, f(np.array([[5, 5], [5, 5]], dtype='i4')))
 
 
-def test_log_axis():
+def test_log_axis_points():
     # Upper bound for scale/index of x-axis
     x_max_index = 10 ** (1 / (2 / np.log10(11)))
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
@@ -185,3 +185,18 @@ def test_line():
     out = xr.DataArray(sol, coords=[np.arange(-3., 4.), np.arange(-3., 4.)],
                        dims=['y_axis', 'x_axis'])
     assert_eq(agg, out)
+
+
+def test_log_axis_line():
+    # Upper bound for scale/index of x-axis
+    x_max_index = 10 ** (1 / (2 / np.log10(11)))
+    sol = np.array([[5, 5], [5, 5]], dtype='i4')
+    out = xr.DataArray(sol, coords=[np.array([0., 1.]), np.array([1., x_max_index])],
+                       dims=dims)
+    assert_eq(c_logx.line(ddf, 'log_x', 'y', ds.count('i32')), out)
+    out = xr.DataArray(sol, coords=[np.array([1., x_max_index]), np.array([0., 1.])],
+                       dims=dims)
+    assert_eq(c_logy.line(ddf, 'x', 'log_y', ds.count('i32')), out)
+    out = xr.DataArray(sol, coords=[np.array([1., x_max_index]), np.array([1., x_max_index])],
+                       dims=dims)
+    assert_eq(c_logxy.line(ddf, 'log_x', 'log_y', ds.count('i32')), out)

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -37,6 +37,7 @@ extend_line = _build_extend_line(draw_line)
 
 bounds = (-3, 1, -3, 1)
 vt = (1., 3., 1., 3.)
+mbounds = map_onto_pixel(vt, *bounds)
 
 
 def test_draw_line():
@@ -48,18 +49,18 @@ def test_draw_line():
                     [0, 0, 0, 1, 0],
                     [0, 0, 0, 0, 0]])
     agg = new_agg()
-    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
+    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, False, agg)
     np.testing.assert_equal(agg, out)
     agg = new_agg()
-    draw_line(vt, bounds, x1, y1, x0, y0, 0, True, False, agg)
+    draw_line(vt, mbounds, x1, y1, x0, y0, 0, True, False, agg)
     np.testing.assert_equal(agg, out)
     # plot_start = False
     agg = new_agg()
-    draw_line(vt, bounds, x0, y0, x1, y1, 0, False, False, agg)
+    draw_line(vt, mbounds, x0, y0, x1, y1, 0, False, False, agg)
     out[0, 0] = 0
     np.testing.assert_equal(agg, out)
     agg = new_agg()
-    draw_line(vt, bounds, x1, y1, x0, y0, 0, False, False, agg)
+    draw_line(vt, mbounds, x1, y1, x0, y0, 0, False, False, agg)
     out[0, 0] = 1
     out[3, 3] = 0
     np.testing.assert_equal(agg, out)
@@ -72,18 +73,18 @@ def test_draw_line():
                     [0, 1, 0, 0, 0],
                     [0, 0, 0, 0, 0]])
     agg = new_agg()
-    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
+    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, False, agg)
     np.testing.assert_equal(agg, out)
     agg = new_agg()
-    draw_line(vt, bounds, x1, y1, x0, y0, 0, True, False, agg)
+    draw_line(vt, mbounds, x1, y1, x0, y0, 0, True, False, agg)
     np.testing.assert_equal(agg, out)
     # plot_start = False
     agg = new_agg()
-    draw_line(vt, bounds, x0, y0, x1, y1, 0, False, False, agg)
+    draw_line(vt, mbounds, x0, y0, x1, y1, 0, False, False, agg)
     out[4, 0] = 0
     np.testing.assert_equal(agg, out)
     agg = new_agg()
-    draw_line(vt, bounds, x1, y1, x0, y0, 0, False, False, agg)
+    draw_line(vt, mbounds, x1, y1, x0, y0, 0, False, False, agg)
     out[4, 0] = 1
     out[1, 3] = 0
 
@@ -92,15 +93,15 @@ def test_draw_line_same_point():
     x0, y0 = (0, 0)
     x1, y1 = (0.1, 0.1)
     agg = new_agg()
-    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
+    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, False, agg)
     assert agg.sum() == 2
     assert agg[3, 3] == 2
     agg = new_agg()
-    draw_line(vt, bounds, x0, y0, x1, y1, 0, False, False, agg)
+    draw_line(vt, mbounds, x0, y0, x1, y1, 0, False, False, agg)
     assert agg.sum() == 1
     assert agg[3, 3] == 1
     agg = new_agg()
-    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, True, agg)
+    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, True, agg)
     assert agg.sum() == 1
     assert agg[3, 3] == 1
 
@@ -110,13 +111,13 @@ def test_draw_line_vertical_horizontal():
     x0, y0 = (0, 0)
     x1, y1 = (0, -3)
     agg = new_agg()
-    draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
+    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, False, agg)
     out = new_agg()
     out[:4, 3] = 1
     np.testing.assert_equal(agg, out)
     # Horizontal
     agg = new_agg()
-    draw_line(vt, bounds, y0, x0, y1, x1, 0, True, False, agg)
+    draw_line(vt, mbounds, y0, x0, y1, x1, 0, True, False, agg)
     out = new_agg()
     out[3, :4] = 1
     np.testing.assert_equal(agg, out)
@@ -131,12 +132,12 @@ def test_extend_lines():
                     [0, 1, 0, 1, 0],
                     [0, 0, 0, 0, 0]])
     agg = new_agg()
-    extend_line(vt, bounds, xs, ys, False, agg)
+    extend_line(vt, bounds, mbounds, xs, ys, False, agg)
     np.testing.assert_equal(agg, out)
     # plot_start = True
     out[2, 3] += 1
     agg = new_agg()
-    extend_line(vt, bounds, xs, ys, True, agg)
+    extend_line(vt, bounds, mbounds, xs, ys, True, agg)
     np.testing.assert_equal(agg, out)
 
     xs = np.array([2, 1, 0, -1, -4, -1, -100, -1, 2])
@@ -147,7 +148,7 @@ def test_extend_lines():
                     [1, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0]])
     agg = new_agg()
-    extend_line(vt, bounds, xs, ys, True, agg)
+    extend_line(vt, bounds, mbounds, xs, ys, True, agg)
     np.testing.assert_equal(agg, out)
 
 
@@ -155,7 +156,7 @@ def test_extend_lines_all_out_of_bounds():
     xs = np.array([-100, -200, -100])
     ys = np.array([0, 0, 1])
     agg = new_agg()
-    extend_line(vt, bounds, xs, ys, True, agg)
+    extend_line(vt, bounds, mbounds, xs, ys, True, agg)
     assert agg.sum() == 0
 
 
@@ -163,6 +164,6 @@ def test_extend_lines_nan():
     xs = np.array([-3, -2, np.nan, 0, 1])
     ys = np.array([-3, -2, np.nan, 0, 1])
     agg = new_agg()
-    extend_line(vt, bounds, xs, ys, True, agg)
+    extend_line(vt, bounds, mbounds, xs, ys, True, agg)
     out = np.diag([1, 1, 0, 1, 0])
     np.testing.assert_equal(agg, out)

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -32,92 +32,93 @@ def new_agg():
 
 mapper = ngjit(lambda x: x)
 map_onto_pixel = _build_map_onto_pixel(mapper, mapper)
-draw_line = _build_draw_line(append, map_onto_pixel)
-extend_line = _build_extend_line(draw_line)
+draw_line = _build_draw_line(append)
+extend_line = _build_extend_line(draw_line, map_onto_pixel)
 
 bounds = (-3, 1, -3, 1)
 vt = (1., 3., 1., 3.)
-mbounds = map_onto_pixel(vt, *bounds)
+xmin, xmax, ymin, ymax = map_onto_pixel(vt, *bounds)
+mbounds = (xmin, xmax - 1, ymin, ymax - 1)
 
 
 def test_draw_line():
-    x0, y0 = (-3, -3)
-    x1, y1 = (0, 0)
+    x0, y0 = (0, 0)
+    x1, y1 = (3, 3)
     out = np.array([[1, 0, 0, 0, 0],
                     [0, 1, 0, 0, 0],
                     [0, 0, 1, 0, 0],
                     [0, 0, 0, 1, 0],
                     [0, 0, 0, 0, 0]])
     agg = new_agg()
-    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, False, agg)
+    draw_line(x0, y0, x1, y1, 0, True, False, agg)
     np.testing.assert_equal(agg, out)
     agg = new_agg()
-    draw_line(vt, mbounds, x1, y1, x0, y0, 0, True, False, agg)
+    draw_line(x1, y1, x0, y0, 0, True, False, agg)
     np.testing.assert_equal(agg, out)
     # plot_start = False
     agg = new_agg()
-    draw_line(vt, mbounds, x0, y0, x1, y1, 0, False, False, agg)
+    draw_line(x0, y0, x1, y1, 0, False, False, agg)
     out[0, 0] = 0
     np.testing.assert_equal(agg, out)
     agg = new_agg()
-    draw_line(vt, mbounds, x1, y1, x0, y0, 0, False, False, agg)
+    draw_line(x1, y1, x0, y0, 0, False, False, agg)
     out[0, 0] = 1
     out[3, 3] = 0
     np.testing.assert_equal(agg, out)
     # Flip coords
-    x0, y0 = (-3, 1)
-    x1, y1 = (0, -2)
+    x0, y0 = (0, 4)
+    x1, y1 = (3, 1)
     out = np.array([[0, 0, 0, 0, 0],
                     [0, 0, 0, 1, 0],
                     [0, 0, 1, 0, 0],
                     [0, 1, 0, 0, 0],
-                    [0, 0, 0, 0, 0]])
+                    [1, 0, 0, 0, 0]])
     agg = new_agg()
-    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, False, agg)
+    draw_line(x0, y0, x1, y1, 0, True, False, agg)
     np.testing.assert_equal(agg, out)
     agg = new_agg()
-    draw_line(vt, mbounds, x1, y1, x0, y0, 0, True, False, agg)
+    draw_line(x1, y1, x0, y0, 0, True, False, agg)
     np.testing.assert_equal(agg, out)
     # plot_start = False
     agg = new_agg()
-    draw_line(vt, mbounds, x0, y0, x1, y1, 0, False, False, agg)
+    draw_line(x0, y0, x1, y1, 0, False, False, agg)
     out[4, 0] = 0
     np.testing.assert_equal(agg, out)
     agg = new_agg()
-    draw_line(vt, mbounds, x1, y1, x0, y0, 0, False, False, agg)
+    draw_line(x1, y1, x0, y0, 0, False, False, agg)
     out[4, 0] = 1
     out[1, 3] = 0
 
 
 def test_draw_line_same_point():
-    x0, y0 = (0, 0)
-    x1, y1 = (0.1, 0.1)
+    x0, y0 = (3, 3)
+    x1, y1 = (3, 3)
     agg = new_agg()
-    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, False, agg)
+    draw_line(x0, y0, x1, y1, 0, True, False, agg)
     assert agg.sum() == 2
     assert agg[3, 3] == 2
     agg = new_agg()
-    draw_line(vt, mbounds, x0, y0, x1, y1, 0, False, False, agg)
+    draw_line(x0, y0, x1, y1, 0, False, False, agg)
     assert agg.sum() == 1
     assert agg[3, 3] == 1
     agg = new_agg()
-    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, True, agg)
+    draw_line(x0, y0, x1, y1, 0, True, True, agg)
     assert agg.sum() == 1
     assert agg[3, 3] == 1
 
 
 def test_draw_line_vertical_horizontal():
     # Vertical
-    x0, y0 = (0, 0)
-    x1, y1 = (0, -3)
+    x0, y0 = (3, 3)
+    x1, y1 = (3, 0)
     agg = new_agg()
-    draw_line(vt, mbounds, x0, y0, x1, y1, 0, True, False, agg)
+    draw_line(x0, y0, x1, y1, 0, True, False, agg)
     out = new_agg()
     out[:4, 3] = 1
     np.testing.assert_equal(agg, out)
     # Horizontal
     agg = new_agg()
-    draw_line(vt, mbounds, y0, x0, y1, x1, 0, True, False, agg)
+    draw_line(y0, x0, y1, x1, 0, True, False, agg)
     out = new_agg()
     out[3, :4] = 1
     np.testing.assert_equal(agg, out)

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -69,7 +69,7 @@ def test_draw_line():
                     [0, 0, 0, 1, 0],
                     [0, 0, 1, 0, 0],
                     [0, 1, 0, 0, 0],
-                    [1, 0, 0, 0, 0]])
+                    [0, 0, 0, 0, 0]])
     agg = new_agg()
     draw_line(vt, bounds, x0, y0, x1, y1, 0, True, False, agg)
     np.testing.assert_equal(agg, out)

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import pytest
 
-from datashader.glyphs import Point, _build_draw_line, _build_extend_line
+from datashader.glyphs import Point, _build_draw_line, _build_extend_line, _build_map_onto_pixel
 from datashader.utils import ngjit
 
 
@@ -31,7 +31,8 @@ def new_agg():
 
 
 mapper = ngjit(lambda x: x)
-draw_line = _build_draw_line(append, mapper, mapper)
+map_onto_pixel = _build_map_onto_pixel(mapper, mapper)
+draw_line = _build_draw_line(append, map_onto_pixel)
 extend_line = _build_extend_line(draw_line)
 
 bounds = (-3, 1, -3, 1)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -147,7 +147,7 @@ def test_multiple_aggregates():
     assert_eq(agg.i32_count, f(np.array([[5, 5], [5, 5]], dtype='i4')))
 
 
-def test_log_axis():
+def test_log_axis_points():
     # Upper bound for scale/index of x-axis
     x_max_index = 10 ** (1 / (2 / np.log10(11)))
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
@@ -178,3 +178,18 @@ def test_line():
     out = xr.DataArray(sol, coords=[np.arange(-3., 4.), np.arange(-3., 4.)],
                        dims=['y_axis', 'x_axis'])
     assert_eq(agg, out)
+
+
+def test_log_axis_line():
+    # Upper bound for scale/index of x-axis
+    x_max_index = 10 ** (1 / (2 / np.log10(11)))
+    sol = np.array([[5, 5], [5, 5]], dtype='i4')
+    out = xr.DataArray(sol, coords=[np.array([0., 1.]), np.array([1., x_max_index])],
+                       dims=dims)
+    assert_eq(c_logx.line(df, 'log_x', 'y', ds.count('i32')), out)
+    out = xr.DataArray(sol, coords=[np.array([1., x_max_index]), np.array([0., 1.])],
+                       dims=dims)
+    assert_eq(c_logy.line(df, 'x', 'log_y', ds.count('i32')), out)
+    out = xr.DataArray(sol, coords=[np.array([1., x_max_index]), np.array([1., x_max_index])],
+                       dims=dims)
+    assert_eq(c_logxy.line(df, 'log_x', 'log_y', ds.count('i32')), out)


### PR DESCRIPTION
The previous adjustment for the exlusive upper bound failed to account properly for bounds with float values. This caused more pixels than necessary to be clipped.

Instead of performing the upper bound check when we clipped a line segment to the bounding box, we now check at a lower level when we translate a line segment to the actual pixels. This gives us greater control without dealing with float coordinates; at that level we are working with integer coordinates.

One test was updated to match the expected result.

Fix #342