### PR TITLE
Optimize range calculation operations

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -138,23 +138,35 @@ class Canvas(object):
     plot_width, plot_height : int, optional
         Width and height of the output aggregate in pixels.
     x_range, y_range : tuple, optional
-        A tuple representing the bounds inclusive space ``[min, max]`` along
-        the axis.
+        A tuple representing the bounds inclusive space ``[min, max]`` along the
+        axis. These will be calculated and cached by datashader during the first
+        aggregation, if not provided. The cached values may be
+        invalidated/recalculated by providing the ``recalc_ranges`` keyword
+        argument to the ``Canvas.points()`` and/or ``Canvas.line()`` methods.
     x_axis_type, y_axis_type : str, optional
         The type of the axis. Valid options are ``'linear'`` [default], and
         ``'log'``.
+    cache_ranges : bool, optional
+        Whether to cache x_range and y_range variables when they get
+        updated. Default is ``True``. This provides a speedup by relying on the
+        x and y data remaining unchanged between data aggregations. If the x or
+        y data may have changed, one may either set this option to ``False``, or
+        provide the ``recalc_ranges=True`` when calling ``Canvas.points()``
+        and/or ``Canvas.line()``.
     """
     def __init__(self, plot_width=600, plot_height=600,
                  x_range=None, y_range=None,
-                 x_axis_type='linear', y_axis_type='linear'):
+                 x_axis_type='linear', y_axis_type='linear',
+                 cache_ranges=True):
         self.plot_width = plot_width
         self.plot_height = plot_height
-        self.x_range = tuple(x_range) if x_range is not None else x_range
-        self.y_range = tuple(y_range) if y_range is not None else y_range
+        self.x_range = tuple(x_range) if x_range is not None else None
+        self.y_range = tuple(y_range) if y_range is not None else None
         self.x_axis = _axis_lookup[x_axis_type]
         self.y_axis = _axis_lookup[y_axis_type]
+        self.cache_ranges = cache_ranges
 
-    def points(self, source, x, y, agg=None):
+    def points(self, source, x, y, agg=None, recalc_ranges=False):
         """Compute a reduction by pixel, mapping data to pixels as points.
 
         Parameters
@@ -165,14 +177,22 @@ class Canvas(object):
             Column names for the x and y coordinates of each point.
         agg : Reduction, optional
             Reduction to compute. Default is ``count()``.
+        recalc_ranges : bool, optional
+            Recalculate the ranges that datashader calculated/cached during the
+            first aggregation. Default is ``False``. This option should only be
+            used if the dataframe's x or y data was altered after the ``Canvas``
+            was created.
         """
         from .glyphs import Point
         from .reductions import count
+        if not self.cache_ranges or recalc_ranges:
+            self.x_range = None
+            self.y_range = None
         if agg is None:
             agg = count()
         return bypixel(source, self, Point(x, y), agg)
 
-    def line(self, source, x, y, agg=None):
+    def line(self, source, x, y, agg=None, recalc_ranges=False):
         """Compute a reduction by pixel, mapping data to pixels as a line.
 
         For aggregates that take in extra fields, the interpolated bins will
@@ -192,9 +212,17 @@ class Canvas(object):
             Column names for the x and y coordinates of each vertex.
         agg : Reduction, optional
             Reduction to compute. Default is ``any()``.
+        recalc_ranges : bool, optional
+            Recalculate the ranges that datashader calculated/cached during the
+            first aggregation. Default is ``False``. This option should only be
+            used if the dataframe's x or y data was altered after the ``Canvas``
+            was created.
         """
         from .glyphs import Line
         from .reductions import any
+        if not self.cache_ranges or recalc_ranges:
+            self.x_range = None
+            self.y_range = None
         if agg is None:
             agg = any()
         return bypixel(source, self, Line(x, y), agg)

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -25,8 +25,8 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
 
 
 def shape_bounds_st_and_axis(df, canvas, glyph):
-    x_range = canvas.x_range or glyph._compute_x_bounds_hashable(df)
-    y_range = canvas.y_range or glyph._compute_y_bounds_hashable(df)
+    x_range = canvas.x_range or glyph._compute_x_bounds_dask(df)
+    y_range = canvas.y_range or glyph._compute_y_bounds_dask(df)
     x_min, x_max, y_min, y_max = bounds = compute(*(x_range + y_range))
     x_range, y_range = (x_min, x_max), (y_min, y_max)
     width = canvas.plot_width

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -25,8 +25,8 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
 
 
 def shape_bounds_st_and_axis(df, canvas, glyph):
-    x_range = canvas.x_range or glyph._compute_x_bounds(df)
-    y_range = canvas.y_range or glyph._compute_y_bounds(df)
+    x_range = canvas.x_range or glyph._compute_x_bounds_hashable(df)
+    y_range = canvas.y_range or glyph._compute_y_bounds_hashable(df)
     x_min, x_max, y_min, y_max = bounds = compute(*(x_range + y_range))
     x_range, y_range = (x_min, x_max), (y_min, y_max)
     width = canvas.plot_width

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -25,13 +25,8 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
 
 
 def shape_bounds_st_and_axis(df, canvas, glyph):
-    # Cache the x and y ranges during the first aggregation
-    if canvas.x_range is None:
-        canvas.x_range = glyph._compute_x_bounds(df)
-    if canvas.y_range is None:
-        canvas.y_range = glyph._compute_y_bounds(df)
-    x_range = canvas.x_range
-    y_range = canvas.y_range
+    x_range = canvas.x_range or glyph._compute_x_bounds(df)
+    y_range = canvas.y_range or glyph._compute_y_bounds(df)
     x_min, x_max, y_min, y_max = bounds = compute(*(x_range + y_range))
     x_range, y_range = (x_min, x_max), (y_min, y_max)
     width = canvas.plot_width

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -25,8 +25,13 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
 
 
 def shape_bounds_st_and_axis(df, canvas, glyph):
-    x_range = canvas.x_range or glyph._compute_x_bounds(df)
-    y_range = canvas.y_range or glyph._compute_y_bounds(df)
+    # Cache the x and y ranges during the first aggregation
+    if canvas.x_range is None:
+        canvas.x_range = glyph._compute_x_bounds(df)
+    if canvas.y_range is None:
+        canvas.y_range = glyph._compute_y_bounds(df)
+    x_range = canvas.x_range
+    y_range = canvas.y_range
     x_min, x_max, y_min, y_max = bounds = compute(*(x_range + y_range))
     x_range, y_range = (x_min, x_max), (y_min, y_max)
     width = canvas.plot_width

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -34,12 +34,20 @@ class _PointLike(Glyph):
         if len(xs) == 0:
             raise ValueError('x coordinate array is empty.')
         minval = maxval = xs[0]
-        for x in xs:
+        idx = 1
+        while idx < len(xs) and np.isnan(minval) and np.isnan(maxval):
+            x = xs[idx]
             if not np.isnan(x):
-                if np.isnan(minval) or x < minval:
+                minval = maxval = x
+            idx += 1
+        while idx < len(xs):
+            x = xs[idx]
+            if not np.isnan(x):
+                if x < minval:
                     minval = x
-                elif np.isnan(maxval) or x > maxval:
+                elif x > maxval:
                     maxval = x
+            idx += 1
         if np.isnan(minval) or np.isnan(maxval):
             raise ValueError('All x coordinates are NaN.')
         return minval, maxval
@@ -50,12 +58,20 @@ class _PointLike(Glyph):
         if len(ys) == 0:
             raise ValueError('y coordinate array is empty.')
         minval = maxval = ys[0]
-        for y in ys:
+        idx = 1
+        while idx < len(ys) and np.isnan(minval) and np.isnan(maxval):
+            y = ys[idx]
             if not np.isnan(y):
-                if np.isnan(minval) or y < minval:
+                minval = maxval = y
+            idx += 1
+        while idx < len(ys):
+            y = ys[idx]
+            if not np.isnan(y):
+                if y < minval:
                     minval = y
-                elif np.isnan(maxval) or y > maxval:
+                elif y > maxval:
                     maxval = y
+            idx += 1
         if np.isnan(minval) or np.isnan(maxval):
             raise ValueError('All y coordinates are NaN.')
         return minval, maxval

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -29,25 +29,41 @@ class _PointLike(Glyph):
         elif not isreal(in_dshape.measure[self.y]):
             raise ValueError('y must be real')
 
-    def _compute_x_bounds(self, df):
-        xs = df[self.x].values
-        return np.nanmin(xs), np.nanmax(xs)
+    @staticmethod
+    @ngjit
+    def _compute_x_bounds_pandas(xs):
+        minval = maxval = xs[0]
+        for x in xs:
+            if not np.isnan(x):
+                if x < minval:
+                    minval = x
+                elif x > maxval:
+                    maxval = x
+        return minval, maxval
 
-    def _compute_y_bounds(self, df):
-        ys = df[self.y].values
-        return np.nanmin(ys), np.nanmax(ys)
+    @staticmethod
+    @ngjit
+    def _compute_y_bounds_pandas(ys):
+        minval = maxval = ys[0]
+        for y in ys:
+            if not np.isnan(y):
+                if y < minval:
+                    minval = y
+                elif y > maxval:
+                    maxval = y
+        return minval, maxval
 
     @memoize
-    def _compute_x_bounds_hashable(self, df):
-        """Same as ``PointLike._compute_x_bounds``, but memoized because
+    def _compute_x_bounds_dask(self, df):
+        """Like ``PointLike._compute_x_bounds``, but memoized because
         ``df`` is immutable/hashable (a Dask dataframe).
         """
         xs = df[self.x].values
         return np.nanmin(xs), np.nanmax(xs)
 
     @memoize
-    def _compute_y_bounds_hashable(self, df):
-        """Same as ``PointLike._compute_y_bounds``, but memoized because
+    def _compute_y_bounds_dask(self, df):
+        """Like ``PointLike._compute_y_bounds``, but memoized because
         ``df`` is immutable/hashable (a Dask dataframe).
         """
         ys = df[self.y].values

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -31,23 +31,13 @@ class _PointLike(Glyph):
     @staticmethod
     @ngjit
     def _compute_x_bounds(xs):
-        if len(xs) == 0:
-            raise ValueError('x coordinate array is empty.')
         minval = maxval = xs[0]
-        idx = 1
-        while idx < len(xs) and np.isnan(minval) and np.isnan(maxval):
-            x = xs[idx]
+        for x in xs:
             if not np.isnan(x):
-                minval = maxval = x
-            idx += 1
-        while idx < len(xs):
-            x = xs[idx]
-            if not np.isnan(x):
-                if x < minval:
+                if np.isnan(minval) or x < minval:
                     minval = x
-                elif x > maxval:
+                if np.isnan(maxval) or x > maxval:
                     maxval = x
-            idx += 1
         if np.isnan(minval) or np.isnan(maxval):
             raise ValueError('All x coordinates are NaN.')
         return minval, maxval
@@ -55,23 +45,13 @@ class _PointLike(Glyph):
     @staticmethod
     @ngjit
     def _compute_y_bounds(ys):
-        if len(ys) == 0:
-            raise ValueError('y coordinate array is empty.')
         minval = maxval = ys[0]
-        idx = 1
-        while idx < len(ys) and np.isnan(minval) and np.isnan(maxval):
-            y = ys[idx]
+        for y in ys:
             if not np.isnan(y):
-                minval = maxval = y
-            idx += 1
-        while idx < len(ys):
-            y = ys[idx]
-            if not np.isnan(y):
-                if y < minval:
+                if np.isnan(minval) or y < minval:
                     minval = y
-                elif y > maxval:
+                if np.isnan(maxval) or y > maxval:
                     maxval = y
-            idx += 1
         if np.isnan(minval) or np.isnan(maxval):
             raise ValueError('All y coordinates are NaN.')
         return minval, maxval

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -31,7 +31,7 @@ class _PointLike(Glyph):
 
     @staticmethod
     @ngjit
-    def _compute_x_bounds_pandas(xs):
+    def _compute_x_bounds(xs):
         minval = maxval = xs[0]
         for x in xs:
             if not np.isnan(x):
@@ -43,7 +43,7 @@ class _PointLike(Glyph):
 
     @staticmethod
     @ngjit
-    def _compute_y_bounds_pandas(ys):
+    def _compute_y_bounds(ys):
         minval = maxval = ys[0]
         for y in ys:
             if not np.isnan(y):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division
 
 from toolz import memoize
-from dask.dataframe.hashing import hash_pandas_object
 import numpy as np
 
 from .core import Expr
@@ -32,25 +31,33 @@ class _PointLike(Glyph):
     @staticmethod
     @ngjit
     def _compute_x_bounds(xs):
+        if len(xs) == 0:
+            raise ValueError('x coordinate array is empty.')
         minval = maxval = xs[0]
         for x in xs:
             if not np.isnan(x):
-                if x < minval:
+                if np.isnan(minval) or x < minval:
                     minval = x
-                elif x > maxval:
+                elif np.isnan(maxval) x > maxval:
                     maxval = x
+        if np.isnan(minval) or np.isnan(maxval):
+            raise ValueError('All x coordinates are NaN.')
         return minval, maxval
 
     @staticmethod
     @ngjit
     def _compute_y_bounds(ys):
+        if len(ys) == 0:
+            raise ValueError('y coordinate array is empty.')
         minval = maxval = ys[0]
         for y in ys:
             if not np.isnan(y):
-                if y < minval:
+                if np.isnan(minval) or y < minval:
                     minval = y
-                elif y > maxval:
+                elif np.isnan(maxval) or y > maxval:
                     maxval = y
+        if np.isnan(minval) or np.isnan(maxval):
+            raise ValueError('All y coordinates are NaN.')
         return minval, maxval
 
     @memoize

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 
 from toolz import memoize
+from dask.dataframe.hashing import hash_pandas_object
 import numpy as np
 
 from .core import Expr
@@ -28,13 +29,27 @@ class _PointLike(Glyph):
         elif not isreal(in_dshape.measure[self.y]):
             raise ValueError('y must be real')
 
-    @memoize
     def _compute_x_bounds(self, df):
         xs = df[self.x].values
         return np.nanmin(xs), np.nanmax(xs)
 
-    @memoize
     def _compute_y_bounds(self, df):
+        ys = df[self.y].values
+        return np.nanmin(ys), np.nanmax(ys)
+
+    @memoize
+    def _compute_x_bounds_hashable(self, df):
+        """Same as ``PointLike._compute_x_bounds``, but memoized because
+        ``df`` is immutable/hashable (a Dask dataframe).
+        """
+        xs = df[self.x].values
+        return np.nanmin(xs), np.nanmax(xs)
+
+    @memoize
+    def _compute_y_bounds_hashable(self, df):
+        """Same as ``PointLike._compute_y_bounds``, but memoized because
+        ``df`` is immutable/hashable (a Dask dataframe).
+        """
         ys = df[self.y].values
         return np.nanmin(ys), np.nanmax(ys)
 

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -28,10 +28,12 @@ class _PointLike(Glyph):
         elif not isreal(in_dshape.measure[self.y]):
             raise ValueError('y must be real')
 
+    @memoize
     def _compute_x_bounds(self, df):
         xs = df[self.x].values
         return np.nanmin(xs), np.nanmax(xs)
 
+    @memoize
     def _compute_y_bounds(self, df):
         ys = df[self.y].values
         return np.nanmin(ys), np.nanmax(ys)

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -29,10 +29,12 @@ class _PointLike(Glyph):
             raise ValueError('y must be real')
 
     def _compute_x_bounds(self, df):
-        return df[self.x].min(), df[self.x].max()
+        xs = df[self.x].values
+        return xs.min(), xs.max()
 
     def _compute_y_bounds(self, df):
-        return df[self.y].min(), df[self.y].max()
+        ys = df[self.y].values
+        return ys.min(), ys.max()
 
 
 class Point(_PointLike):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -38,7 +38,7 @@ class _PointLike(Glyph):
             if not np.isnan(x):
                 if np.isnan(minval) or x < minval:
                     minval = x
-                elif np.isnan(maxval) x > maxval:
+                elif np.isnan(maxval) or x > maxval:
                     maxval = x
         if np.isnan(minval) or np.isnan(maxval):
             raise ValueError('All x coordinates are NaN.')

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -30,11 +30,11 @@ class _PointLike(Glyph):
 
     def _compute_x_bounds(self, df):
         xs = df[self.x].values
-        return xs.min(), xs.max()
+        return np.nanmin(xs), np.nanmax(xs)
 
     def _compute_y_bounds(self, df):
         ys = df[self.y].values
-        return ys.min(), ys.max()
+        return np.nanmin(ys), np.nanmax(ys)
 
 
 class Point(_PointLike):

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -15,8 +15,8 @@ def pandas_pipeline(df, schema, canvas, glyph, summary):
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
-    x_range = canvas.x_range or glyph._compute_x_bounds_pandas(df[glyph.x].values)
-    y_range = canvas.y_range or glyph._compute_y_bounds_pandas(df[glyph.y].values)
+    x_range = canvas.x_range or glyph._compute_x_bounds(df[glyph.x].values)
+    y_range = canvas.y_range or glyph._compute_y_bounds(df[glyph.y].values)
     width = canvas.plot_width
     height = canvas.plot_height
 

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -15,8 +15,8 @@ def pandas_pipeline(df, schema, canvas, glyph, summary):
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
-    x_range = canvas.x_range or glyph._compute_x_bounds(df)
-    y_range = canvas.y_range or glyph._compute_y_bounds(df)
+    x_range = canvas.x_range or glyph._compute_x_bounds_pandas(df[glyph.x].values)
+    y_range = canvas.y_range or glyph._compute_y_bounds_pandas(df[glyph.y].values)
     width = canvas.plot_width
     height = canvas.plot_height
 

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -15,13 +15,8 @@ def pandas_pipeline(df, schema, canvas, glyph, summary):
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
-    # Cache the x and y ranges during the first aggregation
-    if canvas.x_range is None:
-        canvas.x_range = glyph._compute_x_bounds(df)
-    if canvas.y_range is None:
-        canvas.y_range = glyph._compute_y_bounds(df)
-    x_range = canvas.x_range
-    y_range = canvas.y_range
+    x_range = canvas.x_range or glyph._compute_x_bounds(df)
+    y_range = canvas.y_range or glyph._compute_y_bounds(df)
     width = canvas.plot_width
     height = canvas.plot_height
 

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -15,8 +15,13 @@ def pandas_pipeline(df, schema, canvas, glyph, summary):
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
-    x_range = canvas.x_range or glyph._compute_x_bounds(df)
-    y_range = canvas.y_range or glyph._compute_y_bounds(df)
+    # Cache the x and y ranges during the first aggregation
+    if canvas.x_range is None:
+        canvas.x_range = glyph._compute_x_bounds(df)
+    if canvas.y_range is None:
+        canvas.y_range = glyph._compute_y_bounds(df)
+    x_range = canvas.x_range
+    y_range = canvas.y_range
     width = canvas.plot_width
     height = canvas.plot_height
 

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -10,8 +10,8 @@ from datashader.utils import ngjit
 def test_point_bounds_check():
     df = pd.DataFrame({'x': [1, 2, 3], 'y': [5, 6, 7]})
     p = Point('x', 'y')
-    assert p._compute_x_bounds(df) == (1, 3)
-    assert p._compute_y_bounds(df) == (5, 7)
+    assert p._compute_x_bounds(df['x'].values) == (1, 3)
+    assert p._compute_y_bounds(df['y'].values) == (5, 7)
 
 
 def test_point_validate():

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -232,7 +232,7 @@ def timed_agg(df, filepath, plot_width=int(900), plot_height=int(900*7.0/12), re
     global CACHED_RANGES
     start = time.time()
     cvs = ds.Canvas(plot_width, plot_height, x_range=CACHED_RANGES[0], y_range=CACHED_RANGES[1])
-    agg = cvs.points(df, p.x, p.y, recalc_ranges=recalc_ranges)
+    agg = cvs.points(df, p.x, p.y)
     end = time.time()
     if not recalc_ranges:
         CACHED_RANGES = (cvs.x_range, cvs.y_range)

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -227,11 +227,15 @@ def timed_read(filepath,dftype):
     return df, duration
 
 
-def timed_agg(df, filepath, plot_width=int(900), plot_height=int(900*7.0/12)):
+CACHED_RANGES = (None, None)
+def timed_agg(df, filepath, plot_width=int(900), plot_height=int(900*7.0/12), recalc_ranges=False):
+    global CACHED_RANGES
     start = time.time()
-    cvs = ds.Canvas(plot_width, plot_height)
-    agg = cvs.points(df, p.x, p.y)
+    cvs = ds.Canvas(plot_width, plot_height, x_range=CACHED_RANGES[0], y_range=CACHED_RANGES[1])
+    agg = cvs.points(df, p.x, p.y, recalc_ranges=recalc_ranges)
     end = time.time()
+    if not recalc_ranges:
+        CACHED_RANGES = (cvs.x_range, cvs.y_range)
     img = export_image(tf.shade(agg),filepath,export_path=".")
     return img, end-start
 
@@ -273,6 +277,7 @@ def main(argv):
     parser.add_argument('--debug', action='store_true', help='Enable increased verbosity and DEBUG messages')
     parser.add_argument('--cache', choices=('persist', 'cachey'), default=None, help='Enable caching: "persist" causes Dask dataframes to force loading into memory; "cachey" uses dask.cache.Cache with a cachesize of {}. Caching is disabled by default'.format(int(p.cachesize)))
     parser.add_argument('--distributed', action='store_true', help='Enable the distributed scheduler instead of the threaded, which is the default.')
+    parser.add_argument('--recalc-ranges', action='store_true', help='Tell datashader to recalculate the ranges on each aggregation, instead of caching them (by default).')
     args = parser.parse_args(argv[1:])
 
     if args.cache is None:
@@ -321,7 +326,7 @@ def main(argv):
     if DEBUG:
         print('DEBUG: Memory usage (after read):\t{} MB'.format(get_proc_mem(), flush=True))
 
-    img,aggtime1 = timed_agg(df,filepath,5,5)
+    img,aggtime1 = timed_agg(df,filepath,5,5,recalc_ranges=args.recalc_ranges)
     if DEBUG:
         mem_usage = df.memory_usage(deep=True)
         if p.dftype == 'dask':
@@ -333,7 +338,7 @@ def main(argv):
             print('DEBUG: column "{}" dtype: {}'.format(colname, df[colname].dtype))
         print('DEBUG: Memory usage (after agg1):\t{} MB'.format(get_proc_mem(), flush=True))
 
-    img,aggtime2 = timed_agg(df,filepath)
+    img,aggtime2 = timed_agg(df,filepath,recalc_ranges=args.recalc_ranges)
     if DEBUG:
         print('DEBUG: Memory usage (after agg2):\t{} MB'.format(get_proc_mem(), flush=True))
     

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -228,13 +228,13 @@ def timed_read(filepath,dftype):
 
 
 CACHED_RANGES = (None, None)
-def timed_agg(df, filepath, plot_width=int(900), plot_height=int(900*7.0/12), recalc_ranges=False):
+def timed_agg(df, filepath, plot_width=int(900), plot_height=int(900*7.0/12), cache_ranges=True):
     global CACHED_RANGES
     start = time.time()
     cvs = ds.Canvas(plot_width, plot_height, x_range=CACHED_RANGES[0], y_range=CACHED_RANGES[1])
     agg = cvs.points(df, p.x, p.y)
     end = time.time()
-    if not recalc_ranges:
+    if cache_ranges:
         CACHED_RANGES = (cvs.x_range, cvs.y_range)
     img = export_image(tf.shade(agg),filepath,export_path=".")
     return img, end-start
@@ -326,7 +326,7 @@ def main(argv):
     if DEBUG:
         print('DEBUG: Memory usage (after read):\t{} MB'.format(get_proc_mem(), flush=True))
 
-    img,aggtime1 = timed_agg(df,filepath,5,5,recalc_ranges=args.recalc_ranges)
+    img,aggtime1 = timed_agg(df,filepath,5,5,cache_ranges=(not args.recalc_ranges))
     if DEBUG:
         mem_usage = df.memory_usage(deep=True)
         if p.dftype == 'dask':
@@ -338,7 +338,7 @@ def main(argv):
             print('DEBUG: column "{}" dtype: {}'.format(colname, df[colname].dtype))
         print('DEBUG: Memory usage (after agg1):\t{} MB'.format(get_proc_mem(), flush=True))
 
-    img,aggtime2 = timed_agg(df,filepath,recalc_ranges=args.recalc_ranges)
+    img,aggtime2 = timed_agg(df,filepath,cache_ranges=(not args.recalc_ranges))
     if DEBUG:
         print('DEBUG: Memory usage (after agg2):\t{} MB'.format(get_proc_mem(), flush=True))
     


### PR DESCRIPTION
Optimize the operations that datashader uses to calculate the x_range and y_range variables when the ranges are not provided by the user. Addresses issue https://github.com/bokeh/datashader/issues/336 and some comments that came out of https://github.com/bokeh/datashader/issues/332 . Agg2 now takes the same amount of time with df.persist() as it had previously with cachey.

~~Add a caching feature to Canvas which allows it to avoid recalculating the x_range and y_range when the Canvas object is reused for multiple aggregations. This caching feature can be turned off when instantiating the Canvas object `Canvas(..., cache_ranges=False)`, or be circumvented by calling `cvs.points(..., recalc_ranges=True)` or `cvs.line(..., recalc_ranges=True)`.~~

Update `filetimes.py` to do its own caching of the range variables. Also add a `--recalc-ranges` flag to see timing difference when the range variables are not cached.