### PR TITLE
Support alpha for non-categorical shade

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -92,7 +92,21 @@ def test_interpolate_cmap():
     sol = xr.DataArray(sol, coords=coords, dims=dims)
     assert img.equals(sol)
 
-    with pytest.raises(TypeError):
+
+@pytest.mark.parametrize('cmap', ['black', (0, 0, 0), '#000000'])
+def test_interpolate_cmap_non_categorical_alpha(cmap):
+    img = tf.interpolate(agg.a, how='log', cmap=cmap)
+    sol = np.array([[         0,          0, 1509949440],
+                    [2399141888,          0, 3523215360],
+                    [3925868544, 4278190080,          0]])
+    sol = xr.DataArray(sol, coords=coords, dims=dims)
+    assert img.equals(sol)
+
+
+def test_interpolate_cmap_errors():
+    cmap = ['red', (0, 255, 0), '#0000FF']
+
+    with pytest.raises(ValueError):
         tf.interpolate(agg.a, cmap='foo')
 
     with pytest.raises(ValueError):

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -196,14 +196,24 @@ def _interpolate(agg, cmap, how, alpha, span):
         b = np.interp(data, span, bspan, left=255).astype(np.uint8)
         a = np.where(np.isnan(data), 0, alpha).astype(np.uint8)
         img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
+    elif isinstance(cmap, str) or isinstance(cmap, tuple):
+        color = rgb(cmap)
+        aspan = np.arange(0, alpha+1)
+        rspan, gspan, bspan = np.repeat(list(zip(color)), len(aspan), axis=1)
+        span = np.linspace(span[0], span[1], len(aspan))
+        r = np.interp(data, span, rspan, left=255).astype(np.uint8)
+        g = np.interp(data, span, gspan, left=255).astype(np.uint8)
+        b = np.interp(data, span, bspan, left=255).astype(np.uint8)
+        a = np.interp(data, span, aspan, left=0, right=255).astype(np.uint8)
+        img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
     elif callable(cmap):
         # Assume callable is matplotlib colormap
         img = cmap((data - span[0])/(span[1] - span[0]), bytes=True)
         img[:, :, 3] = np.where(np.isnan(data), 0, alpha).astype(np.uint8)
         img = img.view(np.uint32).reshape(data.shape)
     else:
-        raise TypeError("Expected `cmap` of `matplotlib.colors.Colormap` or "
-                        "`list`, got: '{0}'".format(type(cmap)))
+        raise TypeError("Expected `cmap` of `matplotlib.colors.Colormap`, "
+                        "`list`, `str`, or `tuple`; got: '{0}'".format(type(cmap)))
     return Image(img, coords=agg.coords, dims=agg.dims)
 
 


### PR DESCRIPTION
If the colormap is a string or a tuple, then we map the data over a RGB mask with 256 values using given color as a base while varying alpha from 0 to 255.

Fix #244