### PR TITLE
Add Appveyor CI support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+environment:
+  matrix:
+    - PY: "2.7"
+      PYTHON: "C:\\Python27-x64"
+      CONDA: "C:\\Miniconda-x64"
+    - PY: "3.4"
+      PYTHON: "C:\\Python34-x64"
+      CONDA: "C:\\Miniconda3-x64"
+    - PY: "3.5"
+      PYTHON: "C:\\Python35-x64"
+      CONDA: "C:\\Miniconda35-x64"
+    - PY: "3.6"
+      PYTHON: "C:\\Python36-x64"
+      CONDA: "C:\\Miniconda36-x64"
+
+install:
+  # Install conda
+  - "%CONDA%\\conda config --set always_yes yes --set changeps1 no"
+  - "%CONDA%\\conda update conda"
+
+  # Install dependencies
+  - "%CONDA%\\conda create -n test-environment python=%PY%"
+  - "%CONDA%\\activate test-environment"
+  - "%CONDA%\\conda install dask numba numpy panda pillow pytest toolz xarray datashape odo colorcet rasterio scikit-image"
+
+  # Optional dependencies, for testing only
+  - "%CONDA%\\conda install matplotlib"
+
+  - "%PYTHON%\\python.exe setup.py develop --no-deps"
+
+build: off
+
+test_script:
+  - "%PYTHON%\\Scripts\\pytest.exe -x -v datashader"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,8 @@ install:
   # Install dependencies
   - "conda create -n test-environment python=%PY%"
   - "activate test-environment"
-  - "conda install dask numba numpy pandas pillow pytest toolz xarray datashape odo colorcet rasterio scikit-image"
+  - "conda install dask numba numpy pandas pillow pytest toolz xarray datashape odo colorcet scikit-image"
+  - "conda install rasterio -c conda-forge"
 
   # Optional dependencies, for testing only
   - "conda install matplotlib"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   # Install dependencies
   - "conda create -n test-environment python=%PY%"
   - "activate test-environment"
-  - "conda install dask numba numpy panda pillow pytest toolz xarray datashape odo colorcet rasterio scikit-image"
+  - "conda install dask numba numpy pandas pillow pytest toolz xarray datashape odo colorcet rasterio scikit-image"
 
   # Optional dependencies, for testing only
   - "conda install matplotlib"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,21 +14,24 @@ environment:
       CONDA: "C:\\Miniconda36-x64"
 
 install:
-  # Install conda
-  - "%CONDA%\\conda config --set always_yes yes --set changeps1 no"
-  - "%CONDA%\\conda update conda"
+  # Update path
+  -  "SET PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+
+  # Update conda
+  - "conda config --set always_yes yes --set changeps1 no"
+  - "conda update -q conda"
 
   # Install dependencies
-  - "%CONDA%\\conda create -n test-environment python=%PY%"
-  - "%CONDA%\\activate test-environment"
-  - "%CONDA%\\conda install dask numba numpy panda pillow pytest toolz xarray datashape odo colorcet rasterio scikit-image"
+  - "conda create -n test-environment python=%PY%"
+  - "activate test-environment"
+  - "conda install dask numba numpy panda pillow pytest toolz xarray datashape odo colorcet rasterio scikit-image"
 
   # Optional dependencies, for testing only
-  - "%CONDA%\\conda install matplotlib"
+  - "conda install matplotlib"
 
-  - "%PYTHON%\\python.exe setup.py develop --no-deps"
+  - "python setup.py develop --no-deps"
 
 build: off
 
 test_script:
-  - "%PYTHON%\\Scripts\\pytest.exe -x -v datashader"
+  - "pytest -x -v datashader"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 install:
   # Update path
-  -  "SET PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  -  "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
 
   # Update conda
   - "conda config --set always_yes yes --set changeps1 no"


### PR DESCRIPTION
This adds win-64 build support.

This already uncovered an issue with the rasterio package on the default channel. The package had conflicts with Python 3.5 and 3.6. I switched to the conda-forge channel to resolve it.