### PR TITLE
Added 1-billion point interactive OSM notebook and dashboard

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -118,7 +118,9 @@ Plotting the 2.7 billion GPS coordinates made available by [open street
 map](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). This
 dataset is not provided by the download script, and the notebook is only
 included to demonstrate working with a large dataset. The run notebook can be
-viewed at [anaconda.org](https://anaconda.org/jbednar/osm/notebook).
+viewed at [anaconda.org](https://anaconda.org/jbednar/osm). A 
+[1-billion-point subset](https://anaconda.org/jbednar/osm-1billion) is also 
+available for separate download.
 
 **[Amazon.com center distance](https://anaconda.org/defusco/amz_centers/notebook)**
 
@@ -143,6 +145,8 @@ To start, launch it with one of the supported datasets specified:
 ```
 python dashboard/dashboard.py -c dashboard/nyc_taxi.yml
 python dashboard/dashboard.py -c dashboard/census.yml
+python dashboard/dashboard.py -c dashboard/opensky.yml
+python dashboard/dashboard.py -c dashboard/osm.yml
 ```
 
 The '.yml' configuration file sets up the dashboard to use one of the
@@ -157,4 +161,5 @@ use substantially slower than if sufficient memory were available.
 
 To launch multiple dashboards at once, you'll need to add "-p 5001"
 (etc.) to select a unique port number for the web page to use for
-communicating with the Bokeh server.
+communicating with the Bokeh server.  Otherwise, be sure to kill the
+server process before launching another instance.

--- a/examples/dashboard/dashboard.py
+++ b/examples/dashboard/dashboard.py
@@ -18,12 +18,10 @@ from bokeh.models import (Range1d, ImageSource, WMTSTileSource, TileRenderer, Dy
 
 from bokeh.models import (Select, Slider, CheckboxGroup)
 
-from bokeh.palettes import GnBu9, PuRd9, YlGnBu9, Greys9
-
 import datashader as ds
 import datashader.transfer_functions as tf
 
-from datashader.colors import Hot, viridis
+from colorcet import palette
 
 from datashader.bokeh_ext import HoverLayer, create_categorical_legend, create_ramp_legend
 from datashader.utils import hold
@@ -40,6 +38,13 @@ ds_args = {
     'height': fields.Int(missing=600),
     'select': fields.Str(missing=""),
 }
+
+
+def odict_to_front(odict,key):
+    """Given an OrderedDict, move the item with the given key to the front."""
+    front_item = [(key,odict[key])]
+    other_items = [(k,v) for k,v in odict.items() if k is not key]
+    return OrderedDict(front_item+other_items)
 
 
 class GetDataset(RequestHandler):
@@ -137,16 +142,11 @@ class AppState(object):
         self.spread_size = 0
 
         # color ramps
-        self.color_ramps = OrderedDict()
-        self.color_ramps['Hot'] = Hot
-        self.color_ramps['Hot (reverse)'] = list(reversed(Hot))
-        self.color_ramps['Viridis'] = viridis
-        self.color_ramps['Viridis (reverse)'] = list(reversed(viridis))
-        self.color_ramps['Green-Blue'] = list(reversed(GnBu9))
-        self.color_ramps['Purple-Red'] = list(reversed(PuRd9))
-        self.color_ramps['Yellow-Green-Blue'] = list(reversed(YlGnBu9))
-        self.color_ramps['Grays'] = list(reversed(Greys9))[2:]
-        self.color_ramp = list(self.color_ramps.values())[0]
+        default_palette = "fire"
+        named_palettes = {k:p for k,p in palette.items() if not '_' in k}
+        sorted_palettes = OrderedDict(sorted(named_palettes.items()))
+        self.color_ramps = odict_to_front(sorted_palettes,default_palette)
+        self.color_ramp  = palette[default_palette]
 
         self.hover_layer = None
         self.agg = None

--- a/examples/dashboard/osm.yml
+++ b/examples/dashboard/osm.yml
@@ -1,0 +1,19 @@
+---
+
+file: ../data/osm-1billion.snappy.parq
+
+
+axes: 
+  - name: Open Street Map Locations
+    xaxis: x
+    yaxis: y
+    initial_extent:
+      is_geo: true
+      xmin: -20026376.39
+      ymin: -8010550
+      xmax: 20026376.39
+      ymax: 12015825
+
+summary_fields:
+  - name: Count
+    field: None

--- a/examples/osm-1billion.ipynb
+++ b/examples/osm-1billion.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Datashading a 1-billion-point Open Street Map database\n",
+    "\n",
+    "The [osm.ipynb](https://anaconda.org/jbednar/osm) example shows how to use Dask's out of core support for working with datasets larger than will fit in memory.  Here, we consider the largest dataset that will fit comfortably on a 16GB machine, namely 1 billion x,y points (at 32-bit float resolution).\n",
+    "\n",
+    "The data is taken from Open Street Map's (OSM) [bulk GPS point data](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). The data was collected by OSM contributors' GPS devices, and was provided as a CSV file of `latitude,longitude` coordinates. The data was downloaded from their website, extracted, converted to use positions in Web Mercator format using `datashader.utils.lnglat_to_meters()`, and then stored in a [parquet](https://github.com/dask/fastparquet) file for [faster disk access](https://github.com/bokeh/datashader/issues/129#issuecomment-300515690). As usual, loading it into memory will be the most time-consuming step, by far:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import dask.dataframe as dd\n",
+    "import dask.diagnostics as diag\n",
+    "import dask.distributed as dist\n",
+    "import datashader as ds\n",
+    "import datashader.transfer_functions as tf\n",
+    "\n",
+    "from functools import partial\n",
+    "from colorcet import fire\n",
+    "from datashader.utils import export_image\n",
+    "from datashader.colors import colormap_select"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "df = dd.io.parquet.read_parquet('data/osm-1billion.snappy.parq')\n",
+    "df = df.persist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(df))\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Aggregation\n",
+    "\n",
+    "To visualize this data, we first create a canvas to provide pixel-shaped bins in which points can be aggregated, and then aggregate the data to produce a fixed-size aggregate array. For data already in memory, this aggregation is the only expensive step, because it requires reading every point in the dataset. For interactive use we are most interested in the performance for a *second* aggregation, after all of the components and data are in memory and the user is interacting with a plot dynamically.  So let's first do a dry run, which will be slightly slower, then do the full aggregation to show what performance can be expected during interactive use with a billion datapoints:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "bound = 20026376.39\n",
+    "bounds = dict(x_range = (-bound, bound), y_range = (int(-bound*0.4), int(bound*0.6)))\n",
+    "plot_width = 950\n",
+    "plot_height = int(plot_width*0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "bounds2 = dict(x_range = (-bound/2, bound/2), y_range = (int(-bound*0.2), int(bound*0.3)))\n",
+    "cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height, **bounds2)\n",
+    "agg2=cvs.points(df, 'x', 'y', ds.count())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height, **bounds)\n",
+    "agg = cvs.points(df, 'x', 'y', ds.count())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, once everything has been loaded, aggregating this billion-point dataset takes about a second on a 16GB Macbook laptop.  The remaining steps for display complete in milliseconds, so those times are not shown below.\n",
+    "\n",
+    "\n",
+    "### Transfer Function\n",
+    "\n",
+    "To actually see the data, we need to render an image of the aggregate array.  Let's map small (but nonzero) counts to light blue, the largest counts to dark blue, and interpolate according to a logarithmic function in between:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.shade(agg, cmap=[\"lightblue\", \"darkblue\"], how='log')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There's some odd, low-count, nearly-uniform noise going on in the tropics. It's worth trying to figure out what that could be, but for now we can filter it out quickly from the aggregated data using the `where` method from xarray.  We'll also switch to the parameter-free histogram equalization method for mapping to colors using various colormaps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.shade(agg.where(agg > 15), cmap=[\"lightblue\", \"darkblue\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.set_background(tf.shade(agg.where(agg > 15), cmap=fire),\"black\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result covers the most-populated areas of the globe, with Europe apparently having particularly many OpenStreetMap contributors. The long great-circle paths visible on the white background are presumably flight or boat trips, from devices that log their GPS coordinates more than 15 times during the space of one pixel in this plot (or else they would have been eliminated by the `where` call)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interactive plotting\n",
+    "\n",
+    "As long as the data fits into RAM on your machine, performance should be high enough to explore the data interactively, with only a brief pause after zooming or panning to a new region of the data space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh.plotting import figure, output_notebook\n",
+    "from datashader.bokeh_ext import InteractiveImage\n",
+    "from datashader import transfer_functions as tf\n",
+    "\n",
+    "output_notebook(hide_banner=True)\n",
+    "\n",
+    "def create_image(x_range, y_range, w, h):\n",
+    "    cvs = ds.Canvas(x_range=x_range, y_range=y_range)\n",
+    "    agg = cvs.points(df, 'x', 'y', ds.count())\n",
+    "    return tf.dynspread(tf.shade(agg, cmap=[\"darkblue\", \"lightcyan\"]))\n",
+    "\n",
+    "p = figure(tools='pan,wheel_zoom,box_zoom,reset', background_fill_color=\"black\",\n",
+    "           plot_width=plot_width, plot_height=plot_height, **bounds)\n",
+    "\n",
+    "p.axis.visible = False\n",
+    "p.xgrid.grid_line_color = None\n",
+    "p.ygrid.grid_line_color = None\n",
+    "InteractiveImage(p, create_image)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here the plot will be refreshed only if you are running the notebook with a live Python server; for static notebooks like those at anaconda.org you can zoom in but the plot will never be re-rendered at the higher resolution needed at that zoom level."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:ds]",
+   "language": "python",
+   "name": "conda-env-ds-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  },
+  "widgets": {
+   "state": {},
+   "version": "1.1.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/osm-1billion.ipynb
+++ b/examples/osm-1billion.ipynb
@@ -6,9 +6,10 @@
    "source": [
     "# Datashading a 1-billion-point Open Street Map database\n",
     "\n",
-    "The [osm.ipynb](https://anaconda.org/jbednar/osm) example shows how to use Dask's out of core support for working with datasets larger than will fit in memory.  Here, we consider the largest dataset that will fit comfortably on a 16GB machine, namely 1 billion x,y points (at 32-bit float resolution).\n",
+    "The [osm.ipynb](https://anaconda.org/jbednar/osm) example shows how to use Dask's out of core support for working with datasets larger than will fit in memory.  Here, we consider the largest dataset that will fit comfortably on a 16GB machine, namely 1 billion x,y points (at 32-bit float resolution). You can download it from [our site](http://s3.amazonaws.com/datashader-data/osm-1billion.snappy.parq.zip) and unzip it into the `data/` subdirectory, but because of its size it's not downloaded with the other examples by default, and please try to limit the number of times you download it so that we can continue making it available.\n",
     "\n",
-    "The data is taken from Open Street Map's (OSM) [bulk GPS point data](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). The data was collected by OSM contributors' GPS devices, and was provided as a CSV file of `latitude,longitude` coordinates. The data was downloaded from their website, extracted, converted to use positions in Web Mercator format using `datashader.utils.lnglat_to_meters()`, and then stored in a [parquet](https://github.com/dask/fastparquet) file for [faster disk access](https://github.com/bokeh/datashader/issues/129#issuecomment-300515690). As usual, loading it into memory will be the most time-consuming step, by far:"
+    "The data is taken from Open Street Map's (OSM) [bulk GPS point data](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). The data was collected by OSM contributors' GPS devices, and was provided as a CSV file of `latitude,longitude` coordinates. The data was downloaded from their website, extracted, converted to use positions in Web Mercator format using `datashader.utils.lnglat_to_meters()`, and then stored in a [parquet](https://github.com/dask/fastparquet) file for [faster disk access](https://github.com/bokeh/datashader/issues/129#issuecomment-300515690). As usual, loading it into memory will be the most time-consuming step, by far:\n",
+    "http://s3.amazonaws.com/datashader-data/census.snappy.parq.zip"
    ]
   },
   {
@@ -34,7 +35,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -45,7 +48,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(len(df))\n",
@@ -78,7 +83,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -90,7 +97,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -113,7 +122,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tf.shade(agg, cmap=[\"lightblue\", \"darkblue\"], how='log')"
@@ -129,7 +140,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tf.shade(agg.where(agg > 15), cmap=[\"lightblue\", \"darkblue\"])"
@@ -138,7 +151,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tf.set_background(tf.shade(agg.where(agg > 15), cmap=fire),\"black\")"
@@ -163,7 +178,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from bokeh.plotting import figure, output_notebook\n",

--- a/examples/osm.ipynb
+++ b/examples/osm.ipynb
@@ -4,17 +4,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Visualizing datasets larger than memory using Datashader with Dask\n",
+    "\n",
     "## Datashading a 2.7-billion-point Open Street Map database\n",
     "\n",
-    "Most [datashader](https://github.com/bokeh/datashader) examples use \"medium-sized\" datasets, because they need to be small enough to be distributed over the internet without racking up huge bandwidth charges for the project maintainers.  But given that Datashader supports [Dask](http://dask.pydata.org) dataframes, Datashader can easily be used with truly large datasets.  Such datasets can be much larger than the available amount of physical memory on the machine, either by paging in data on a single machine, or by distributing data across multiple machines. Here we illustrate how to work \"out of core\" on a single machine.\n",
+    "Most [datashader](https://github.com/bokeh/datashader) examples use \"medium-sized\" datasets, because they need to be small enough to be distributed over the internet without racking up huge bandwidth charges for the project maintainers. Even though these datasets can be relatively large (such as the [1-billion point Open Street Map example](https://anaconda.org/jbednar/osm-1billion)), they still fit into memory on a 16GB laptop.\n",
     "\n",
-    "This example will use a 2.7-billion point dataset, which is unfortunately too large to distribute with Datashader (7GB compressed). The data is taken from Open Street Map's (OSM) [bulk GPS point data](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/). The data was collected by OSM contributors' GPS devices, and was provided as a CSV file of `latitude,longitude` coordinates. The data was downloaded from their website, extracted, converted to use positions in Web Mercator format using `datashader.utils.lnglat_to_meters()`, and then stored in a [parquet](https://github.com/dask/fastparquet) file for [faster disk access](https://github.com/bokeh/datashader/issues/129#issuecomment-300515690). To run this notebook, you would need to do the same process yourself to obtain `osm.snappy.parq`.   Once you have it, you can follow the steps below to load and plot the data."
+    "Because Datashader supports [Dask](http://dask.pydata.org) dataframes, it also works well with truly large datasets, much bigger than will fit in any one machine's physical memory. On a single machine, Dask will automatically and efficiently page in the data as needed, and you can also easily distribute the data and computation across multiple machines. Here we illustrate how to work \"out of core\" on a single machine using a 22GB OSM dataset containing 2.7 billion points.\n",
+    "\n",
+    "The data is taken from Open Street Map's (OSM) [bulk GPS point data](https://blog.openstreetmap.org/2012/04/01/bulk-gps-point-data/), and is unfortunately too large to distribute with Datashader (7GB compressed). The data was collected by OSM contributors' GPS devices, and was provided as a CSV file of `latitude,longitude` coordinates. The data was downloaded from their website, extracted, converted to use positions in Web Mercator format using `datashader.utils.lnglat_to_meters()`, and then stored in a [parquet](https://github.com/dask/fastparquet) file for [faster disk access](https://github.com/bokeh/datashader/issues/129#issuecomment-300515690). To run this notebook, you would need to do the same process yourself to obtain `osm.snappy.parq`.   Once you have it, you can follow the steps below to load and plot the data."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import dask.dataframe as dd\n",
@@ -31,7 +37,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "df = dd.io.parquet.read_parquet('data/osm.snappy.parq')\n",
@@ -44,13 +52,15 @@
    "source": [
     "### Aggregation\n",
     "\n",
-    "First, we create a canvas to provide pixel-shaped bins in which points can be aggregated, and then aggregate the data to produce a fixed-size aggregate array."
+    "First, we create a canvas to provide pixel-shaped bins in which points can be aggregated, and then aggregate the data to produce a fixed-size aggregate array.  This process may take up to a minute, so we provide a progress bar using dask:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "bound = 20026376.39\n",
@@ -68,61 +78,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Transfer Function\n",
-    "\n",
-    "Next, we create an image out of the aggregate array, by mapping small (but nonzero) counts to light blue, the largest counts to dark blue, and interpolating according to a logarithmic function in between."
+    "We can now visualize this data very quickly, ignoring low-count noise as described in the [1-billion point OSM version](https://anaconda.org/jbednar/osm-1billion):"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tf.shade(agg, cmap=[\"lightblue\", \"darkblue\"], how='log')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "There's some odd, low-count, nearly-uniform noise going on in the tropics. It's worth trying to figure out what that could be, but for now we can filter it out quickly from the aggregated data using the `where` method, and switch to the parameter-free histogram equalization method for mapping to colors using various colormaps:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "tf.shade(agg.where(agg > 15), cmap=[\"lightblue\", \"darkblue\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "export = partial(export_image, export_path=\"export\", background=\"black\")\n",
-    "\n",
-    "export(tf.shade(agg.where(agg > 15), cmap=[\"darkblue\", \"lightcyan\"]), \"OSM_black_blue\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "export(tf.shade(agg.where(agg > 15), cmap=fire), \"OSM_fire\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The result is a decent map of world population, with Europe apparently having particularly many OpenStreetMap contributors. The long great-circle paths are presumably flight or boat trips, from devices that log their GPS coordinates more than 15 times during the space of one pixel in this plot (or else they would have been elimnated by the `where` call)."
    ]
   },
   {
@@ -137,7 +104,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from bokeh.io import output_notebook\n",
@@ -148,7 +117,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "diag.visualize([prof, rprof])\n",
@@ -164,48 +135,15 @@
     "- Reading time includes not just disk I/O, but decompressing chunks of data\n",
     "- The disk reads don't release the [Global Interpreter Lock](https://wiki.python.org/moin/GlobalInterpreterLock) (GIL), and so CPU usage (see second chart above) drops to only one core during those periods.\n",
     "- During the aggregation steps (the green rectangles), CPU usage on this machine with 8 hyperthreaded cores (4 full cores) spikes to nearly 800%, because the aggregation function is implemented in parallel. \n",
-    "- The data takes up 11 GB of memory when uncompressed, but only a peak of around 6 GB of physical memory is ever used because the data is paged in as needed."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Interactive plotting\n",
-    "\n",
-    "If you have enough RAM to hold the whole dataset (or are very patient), you can uncomment the `InteractiveImage` line below and run the cell to build an interactive plot where you can select a region for zooming. Without enough RAM, computation has to be done out of core, and it could take a half-minute or so to process a pan or zoom event before the plot gets updated."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from bokeh.plotting import figure, output_notebook\n",
-    "from bokeh.io import push_notebook\n",
-    "from datashader.bokeh_ext import InteractiveImage\n",
-    "from datashader import transfer_functions as tf\n",
-    "\n",
-    "def create_image(x_range, y_range, w, h):\n",
-    "    cvs = ds.Canvas(x_range=x_range, y_range=y_range)\n",
-    "    agg = cvs.points(df, 'x', 'y', ds.count())\n",
-    "    return tf.shade(agg.where(agg > 20), cmap=[\"lightcyan\", \"darkblue\"], how=\"log\")\n",
-    "\n",
-    "p = figure(tools='pan,wheel_zoom,box_zoom,reset', plot_width=plot_width, plot_height=plot_height, **bounds)\n",
-    "           \n",
-    "p.axis.visible = False\n",
-    "p.xgrid.grid_line_color = None\n",
-    "p.ygrid.grid_line_color = None\n",
-    "#InteractiveImage(p, create_image)"
+    "- The data takes up 22 GB uncompressed, but only a peak of around 6 GB of physical memory is ever used because the data is paged in as needed."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:ds]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-ds-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
With recent improvements in Datashader/Numba memory handling, 1 billion-point float32 datasets now fit into memory easily on a 16GB machine.  To demonstrate this, split the OSM examples into two separate notebooks illustrating different things -- osm-1billion.ipynb illustrating very fast interactive exploration of in-memory datasets, and osm.ipynb illustrating how to work with out-of-core datasets.  Also added the 1-billion-point OSM to the dashboard, now that it updates quickly enough to be usable.