### PR TITLE
Edge bundling for graphs

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -1,0 +1,217 @@
+from __future__ import absolute_import, division, print_function
+
+from dask import compute, delayed
+from math import ceil
+from skimage.filters import gaussian, sobel_h, sobel_v
+import numba as nb
+import numpy as np
+
+from .utils import ngjit
+
+
+ACCURACY = 500
+
+MIN_SEG = 0.008
+MAX_SEG = 0.016
+TENSION = 0.3
+
+
+@ngjit
+def distance_between(a, b):
+    return (((a[0] - b[0]) ** 2) + ((a[1] - b[1]) ** 2))**(0.5)
+
+
+@ngjit
+def resample_segment(segments, new_segments, min_segment_length=MIN_SEG, max_segment_length=MAX_SEG):
+
+    next_point = np.array([0.0, 0.0])
+    current_point = segments[0]
+
+    pos = 0
+    index = 1
+    while index < len(segments):
+        next_point = segments[index]
+        distance = distance_between(current_point, next_point)
+        if (distance < min_segment_length and 1 < index < (len(segments) - 1)):
+            # Merge points, because they're too close to each other
+            current_point = (current_point + next_point) / 2
+            new_segments[pos] = current_point
+            pos += 1
+            index += 2
+        elif distance > max_segment_length:
+            # If points are too far away from each other, linearly place new points
+            points = ceil(distance / ((max_segment_length + min_segment_length) / 2))
+            for i in range(points):
+                new_segments[pos] = current_point + (i * ((next_point - current_point) / points))
+                pos += 1
+            current_point = next_point
+            index += 1
+        else:
+            # Do nothing, everything is good
+            new_segments[pos] = current_point
+            pos += 1
+            current_point = next_point
+            index += 1
+    new_segments[pos] = next_point
+    return new_segments
+
+
+@ngjit
+def calculate_length(segments, min_segment_length=MIN_SEG, max_segment_length=MAX_SEG):
+
+    next_point = np.array([0.0, 0.0])
+    current_point = segments[0]
+    index = 1
+    total = 0
+    any_change = False
+    while index < len(segments):
+        next_point = segments[index]
+        distance = distance_between(current_point, next_point)
+        if (distance < min_segment_length and 1 < index < (len(segments) - 1)):
+            any_change = True
+            current_point = (current_point + next_point) / 2
+            total += 1
+            index += 2
+        elif distance > max_segment_length:
+            any_change = True
+            # Linear subsample
+            points = ceil(distance / ((max_segment_length + min_segment_length) / 2))
+            total += points
+            current_point = next_point
+            index += 1
+        else:
+            # Do nothing
+            total += 1
+            current_point = next_point
+            index += 1
+    total += 1
+    return any_change, total
+
+
+def resample_edge(segments, min_segment_length=MIN_SEG, max_segment_length=MAX_SEG):
+    change, total_resamples = calculate_length(segments, min_segment_length, max_segment_length)
+    if not change:
+        return segments
+    resampled = np.empty((total_resamples, 2))
+    resample_segment(segments, resampled, min_segment_length, max_segment_length)
+    return resampled
+
+
+@delayed
+def resample_edges(edge_segments, min_segment_length=MIN_SEG, max_segment_length=MAX_SEG):
+    replaced_edges = []
+    for segments in edge_segments:
+        replaced_edges.append(resample_edge(segments, min_segment_length, max_segment_length))
+    return replaced_edges
+
+
+@ngjit
+def smooth_segment(segments, tension):
+    seg_length = len(segments) - 2
+    for i in range(1, seg_length):
+        previous, current, next_point = segments[i - 1], segments[i], segments[i + 1]
+        current[0] = ((1 - tension) * current[0]) + (tension * (previous[0] + next_point[0]) / 2)
+        current[1] = ((1 - tension) * current[1]) + (tension * (previous[1] + next_point[1]) / 2)
+
+
+@nb.jit
+def smooth(edge_segments, tension):
+    for segments in edge_segments:
+        smooth_segment(segments, tension)
+
+
+@ngjit
+def advect_segments(segments, vert, horiz):
+    for i in range(1, len(segments) - 1):
+        x = int(segments[i][0] * ACCURACY)
+        y = int(segments[i][1] * ACCURACY)
+        segments[i][0] = segments[i][0] + horiz[x, y] / ACCURACY
+        segments[i][1] = segments[i][1] + vert[x, y] / ACCURACY
+        segments[i][0] = max(0, min(segments[i][0], 1))
+        segments[i][1] = max(0, min(segments[i][1], 1))
+
+
+def advect_and_resample(vert, horiz, segments, iterations=50):
+    for it in range(iterations):
+        advect_segments(segments, vert, horiz)
+        if it % 2 == 0:
+            segments = resample_edge(segments)
+    return segments
+
+
+@delayed
+def advect_resample_all(gradients, edge_segments):
+    vert, horiz = gradients
+    return [advect_and_resample(vert, horiz, edges) for edges in edge_segments]
+
+
+def batches(l, n):
+    """Yield successive n-sized batches from l."""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
+
+
+@delayed
+def draw_to_surface(edge_segments, bandwidth):
+    img = np.zeros((ACCURACY + 1, ACCURACY + 1))
+    for segments in edge_segments:
+        for point in segments:
+            img[int(point[0] * ACCURACY), int(point[1] * ACCURACY)] += 1
+    return gaussian(img, sigma=bandwidth / 2)
+
+
+@delayed
+def get_gradients(img):
+    img /= np.max(img)
+
+    horiz = sobel_h(img)
+    vert = sobel_v(img)
+
+    magnitude = np.sqrt(horiz**2 + vert**2) + 1e-5
+    vert /= magnitude
+    horiz /= magnitude
+    return (vert, horiz)
+
+
+def bundle(edges, initial_bandwidth=0.05, decay=0.7, iterations=4, batch_size=20000):
+    # This is simply to let the work split out over multiple cores
+    edge_batches = list(batches(edges, batch_size))
+
+    # This gets the edges split into lots of small segments
+    # Doing this inside a delayed function lowers the transmission overhead
+    edge_segments = [resample_edges(batch) for batch in edge_batches]
+
+    for i in range(iterations):
+        # Each step, the size of the 'blur' shrinks
+        bandwidth = initial_bandwidth * decay**(i + 1) * ACCURACY
+
+        # If it's this small, there won't be a change anyway
+        if bandwidth < 2:
+            break
+
+        # Draw the density maps and combine them
+        images = [draw_to_surface(segment, bandwidth) for segment in edge_segments]
+        overall_image = sum(images)
+
+        gradients = get_gradients(overall_image)
+
+        # Move edges along the gradients and resample when necessary
+        # This could include smoothing to adjust the amount a graph can change
+        edge_segments = [advect_resample_all(gradients, segment) for segment in edge_segments]
+
+    # Do a final resample to a smaller size for nicer rendering
+    edge_segments = [resample_edges(segment, MIN_SEG / 2, MAX_SEG / 2) for segment in edge_segments]
+
+    # Finally things can be sent for computation
+    edge_segments = compute(edge_segments)[0]
+
+    # Smooth out the graph
+    for i in range(10):
+        for batch in edge_segments:
+            smooth(batch, TENSION)
+
+    # Flatten things
+    new_segs = []
+    for batch in edge_segments:
+        new_segs.extend(batch)
+    return new_segs

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -209,7 +209,7 @@ def _convert_edge_segments_to_dataframe(edge_segments):
     return df
 
 
-def nop_bundle(nodes, edges, initial_bandwidth=0.05, decay=0.7, iterations=4, batch_size=20000):
+def directly_connect_edges(nodes, edges, initial_bandwidth=0.05, decay=0.7, iterations=4, batch_size=20000):
     # Convert graph into list of edge segments
     edges = _convert_graph_to_edge_segments(nodes, edges)
 

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -217,7 +217,7 @@ def directly_connect_edges(nodes, edges, initial_bandwidth=0.05, decay=0.7, iter
     return _convert_edge_segments_to_dataframe(edges)
 
 
-def bundle(nodes, edges, initial_bandwidth=0.05, decay=0.7, iterations=4, batch_size=20000):
+def hammer_bundle(nodes, edges, initial_bandwidth=0.05, decay=0.7, iterations=4, batch_size=20000):
     # Convert graph into list of edge segments
     edges = _convert_graph_to_edge_segments(nodes, edges)
 

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -174,7 +174,7 @@ def get_gradients(img):
     return (vert, horiz)
 
 
-def _from_pandas(nodes, edges):
+def _convert_graph_to_edge_segments(nodes, edges):
     def minmax_scale(series):
         minimum, maximum = np.min(series), np.max(series)
         return (series - minimum) / (maximum - minimum)
@@ -197,7 +197,7 @@ def _from_pandas(nodes, edges):
     return edge_segments
 
 
-def _to_pandas(edge_segments):
+def _convert_edge_segments_to_dataframe(edge_segments):
     # Need to put a [np.nan, np.nan] between edges
     def edge_iterator():
         for edge in edge_segments:
@@ -210,16 +210,16 @@ def _to_pandas(edge_segments):
 
 
 def nop_bundle(nodes, edges, initial_bandwidth=0.05, decay=0.7, iterations=4, batch_size=20000):
-    # Import from Pandas DataFrame
-    edges = _from_pandas(nodes, edges)
+    # Convert graph into list of edge segments
+    edges = _convert_graph_to_edge_segments(nodes, edges)
 
-    # Convert to Pandas DataFrame
-    return _to_pandas(edges)
+    # Convert list of edge segments to Pandas dataframe
+    return _convert_edge_segments_to_dataframe(edges)
 
 
 def bundle(nodes, edges, initial_bandwidth=0.05, decay=0.7, iterations=4, batch_size=20000):
-    # Import from Pandas DataFrame
-    edges = _from_pandas(nodes, edges)
+    # Convert graph into list of edge segments
+    edges = _convert_graph_to_edge_segments(nodes, edges)
 
     # This is simply to let the work split out over multiple cores
     edge_batches = list(batches(edges, batch_size))
@@ -262,5 +262,5 @@ def bundle(nodes, edges, initial_bandwidth=0.05, decay=0.7, iterations=4, batch_
     for batch in edge_segments:
         new_segs.extend(batch)
 
-    # Convert to Pandas DataFrame
-    return _to_pandas(new_segs)
+    # Convert list of edge segments to Pandas dataframe
+    return _convert_edge_segments_to_dataframe(new_segs)

--- a/examples/datasets.yml
+++ b/examples/datasets.yml
@@ -95,9 +95,9 @@ data:
     files:
       - NSRDB_StationsMeta.csv
 
-  - url: http://s3.amazonaws.com/datashader-data/edge-bundling.snappy.parq.zip
-    title: 'Graph for Edge Bundling'
+  - url: http://s3.amazonaws.com/datashader-data/calvert_uk_research2017.snappy.parq.zip
+    title: 'Graph for Edge Bundling (Calvert UK Research 2017)'
     files:
-      - nodes.snappy.parq
-      - edges.snappy.parq
+      - calvert_uk_research2017_nodes.snappy.parq
+      - calvert_uk_research2017_edges.snappy.parq
 

--- a/examples/datasets.yml
+++ b/examples/datasets.yml
@@ -95,3 +95,9 @@ data:
     files:
       - NSRDB_StationsMeta.csv
 
+  - url: http://s3.amazonaws.com/datashader-data/edge-bundling.snappy.parq.zip
+    title: 'Graph for Edge Bundling'
+    files:
+      - nodes.snappy.parq
+      - edges.snappy.parq
+

--- a/examples/edge_bundling.ipynb
+++ b/examples/edge_bundling.ipynb
@@ -1,0 +1,524 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "from pandas import DataFrame\n",
+    "\n",
+    "import fastparquet as fp\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from datashader.bundling import bundle, nop_bundle\n",
+    "from datashader.colors import inferno, viridis\n",
+    "from datashader.utils import export_image\n",
+    "\n",
+    "import datashader as ds\n",
+    "import datashader.transfer_functions as tf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def render_points(df, width=4000, height=4000, cmap=None, bgcolor=None):\n",
+    "    cvs = ds.Canvas(plot_width=width, plot_height=height, x_range=(0, 1), y_range=(0, 1))\n",
+    "    agg = cvs.points(df, 'x', 'y',  ds.count())\n",
+    "    img = tf.shade(agg, cmap=cmap) if cmap else tf.shade(agg)\n",
+    "    img = tf.spread(img)\n",
+    "    return tf.set_background(img, bgcolor) if bgcolor else img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def render_lines(df, width=4000, height=4000, cmap=None, bgcolor=None):\n",
+    "    cvs = ds.Canvas(plot_width=width, plot_height=height, x_range=(0, 1), y_range=(0, 1))\n",
+    "    agg = cvs.line(df, 'x', 'y',  ds.count())\n",
+    "    img = tf.shade(agg, cmap=cmap) if cmap else tf.shade(agg)\n",
+    "    return tf.set_background(img, bgcolor) if bgcolor else img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "client = Client()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Edge bundling with graph read from Parquet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "nodes_df = fp.ParquetFile('nodes.snappy.parq').to_pandas(index='id')\n",
+    "edges_df = fp.ParquetFile('edges.snappy.parq').to_pandas(index='id')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "nodes_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "edges_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph with only nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_points(nodes_df, width=2000, height=2000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph without edge bundling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "nop_df = nop_bundle(nodes_df, edges_df)\n",
+    "render_lines(nop_df, width=2000, height=2000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph with edge bundling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%time df = bundle(nodes_df, edges_df, 0.05, 0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap='blue')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap='red')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap=viridis, bgcolor='black')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Edge bundling with random graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def generate_nodes(n):\n",
+    "    return pd.DataFrame(np.random.randn(n, 2), columns=['x', 'y'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def generate_edges(n, nodes):\n",
+    "    return pd.DataFrame(np.random.randint(len(nodes), size=(n, 2)), columns=['source', 'target'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def generate_random_graph(nodes, edges):\n",
+    "    ndf = generate_nodes(nodes)\n",
+    "    edf = generate_edges(edges, ndf)\n",
+    "    return ndf, edf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "nodes_df, edges_df = generate_random_graph(10000, 50000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%time df = bundle(nodes_df, edges_df, 0.05, 0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap=viridis, bgcolor='black')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Edge bundling with star graph and circular layout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import networkx as nx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "graph = nx.star_graph(100000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "layout = nx.circular_layout(graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "data = []\n",
+    "for node in graph.nodes_iter():\n",
+    "    x, y = layout[node]\n",
+    "    data.append([node, x, y])\n",
+    "nodes_df = pd.DataFrame(data, columns=['id', 'x', 'y'])\n",
+    "nodes_df.set_index('id', inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "edges_df = pd.DataFrame(graph.edges_iter(), columns=['source', 'target'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%time df = bundle(nodes_df, edges_df, 0.05, 0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Decrease decay for edge bundling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%time df = bundle(nodes_df, edges_df, initial_bandwidth=0.05, decay=0.4) # Decay from 0.7 to 0.4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Increase decay for edge bundling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%time df = bundle(nodes_df, edges_df, initial_bandwidth=0.05, decay=1.0) # Decay from 0.7 to 1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Decrease initial bandwidth for edge bundling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%time df = bundle(nodes_df, edges_df, initial_bandwidth=0.025, decay=0.7) # Initial bandwidth from 0.05 to 0.025"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Increase initial bandwidth for edge bundling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%time df = bundle(nodes_df, edges_df, initial_bandwidth=0.1, decay=0.7) # Initial bandwidth from 0.05 to 0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/edge_bundling.ipynb
+++ b/examples/edge_bundling.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from dask.distributed import Client\n",
@@ -15,8 +13,9 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "from datashader.bundling import bundle, nop_bundle\n",
-    "from datashader.colors import inferno, viridis\n",
+    "from colorcet import fire\n",
+    "\n",
+    "from datashader.bundling import directly_connect_edges, hammer_bundle\n",
     "from datashader.utils import export_image\n",
     "\n",
     "import datashader as ds\n",
@@ -31,10 +30,10 @@
    },
    "outputs": [],
    "source": [
-    "def render_points(df, width=4000, height=4000, cmap=None, bgcolor=None):\n",
+    "def render_points(df, width=4000, height=4000, cmap=[\"lightblue\", \"darkblue\"], bgcolor=None):\n",
     "    cvs = ds.Canvas(plot_width=width, plot_height=height, x_range=(0, 1), y_range=(0, 1))\n",
     "    agg = cvs.points(df, 'x', 'y',  ds.count())\n",
-    "    img = tf.shade(agg, cmap=cmap) if cmap else tf.shade(agg)\n",
+    "    img = tf.shade(agg, cmap=cmap)\n",
     "    img = tf.spread(img)\n",
     "    return tf.set_background(img, bgcolor) if bgcolor else img"
    ]
@@ -47,10 +46,10 @@
    },
    "outputs": [],
    "source": [
-    "def render_lines(df, width=4000, height=4000, cmap=None, bgcolor=None):\n",
+    "def render_lines(df, width=4000, height=4000, cmap=[\"lightblue\", \"darkblue\"], bgcolor=None):\n",
     "    cvs = ds.Canvas(plot_width=width, plot_height=height, x_range=(0, 1), y_range=(0, 1))\n",
     "    agg = cvs.line(df, 'x', 'y',  ds.count())\n",
-    "    img = tf.shade(agg, cmap=cmap) if cmap else tf.shade(agg)\n",
+    "    img = tf.shade(agg, cmap=cmap)\n",
     "    return tf.set_background(img, bgcolor) if bgcolor else img"
    ]
   },
@@ -80,8 +79,26 @@
    },
    "outputs": [],
    "source": [
-    "nodes_df = fp.ParquetFile('nodes.snappy.parq').to_pandas(index='id')\n",
-    "edges_df = fp.ParquetFile('edges.snappy.parq').to_pandas(index='id')"
+    "researchers_nodes_df = fp.ParquetFile('data/calvert_uk_research2017_nodes.snappy.parq').to_pandas(index='id')\n",
+    "researchers_edges_df = fp.ParquetFile('data/calvert_uk_research2017_edges.snappy.parq').to_pandas(index='id')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "researchers_nodes_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "researchers_edges_df.head()"
    ]
   },
   {
@@ -92,18 +109,7 @@
    },
    "outputs": [],
    "source": [
-    "nodes_df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "edges_df.head()"
+    "researchers_direct_df = directly_connect_edges(researchers_nodes_df, researchers_edges_df)"
    ]
   },
   {
@@ -116,12 +122,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "render_points(nodes_df, width=2000, height=2000)"
+    "render_points(researchers_nodes_df, width=2000, height=2000)"
    ]
   },
   {
@@ -134,13 +138,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "nop_df = nop_bundle(nodes_df, edges_df)\n",
-    "render_lines(nop_df, width=2000, height=2000)"
+    "render_lines(researchers_direct_df, width=2000, height=2000)"
    ]
   },
   {
@@ -158,7 +159,7 @@
    },
    "outputs": [],
    "source": [
-    "%time df = bundle(nodes_df, edges_df, 0.05, 0.7)"
+    "%time researchers_df = hammer_bundle(researchers_nodes_df, researchers_edges_df, 0.05, 0.7)"
    ]
   },
   {
@@ -169,40 +170,7 @@
    },
    "outputs": [],
    "source": [
-    "render_lines(df, width=2000, height=2000, cmap='blue')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "render_lines(df, width=2000, height=2000, cmap='red')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "render_lines(df, width=2000, height=2000, cmap=viridis, bgcolor='black')"
+    "render_lines(researchers_df, width=2000, height=2000, cmap=fire, bgcolor='black')"
    ]
   },
   {
@@ -258,29 +226,65 @@
    },
    "outputs": [],
    "source": [
-    "nodes_df, edges_df = generate_random_graph(10000, 50000)"
+    "random_nodes_df, random_edges_df = generate_random_graph(10000, 50000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph with only nodes"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%time df = bundle(nodes_df, edges_df, 0.05, 0.7)"
+    "render_points(random_nodes_df, width=2000, height=2000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph without edge bundling"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "render_lines(df, width=2000, height=2000, cmap=viridis, bgcolor='black')"
+    "random_direct_df = directly_connect_edges(random_nodes_df, random_edges_df)\n",
+    "render_lines(random_direct_df, width=2000, height=2000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph with edge bundling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time random_df = hammer_bundle(random_nodes_df, random_edges_df, 0.05, 0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "render_lines(random_df, width=2000, height=2000, cmap=fire, bgcolor='black')"
    ]
   },
   {
@@ -337,8 +341,8 @@
     "for node in graph.nodes_iter():\n",
     "    x, y = layout[node]\n",
     "    data.append([node, x, y])\n",
-    "nodes_df = pd.DataFrame(data, columns=['id', 'x', 'y'])\n",
-    "nodes_df.set_index('id', inplace=True)"
+    "circular_nodes_df = pd.DataFrame(data, columns=['id', 'x', 'y'])\n",
+    "circular_nodes_df.set_index('id', inplace=True)"
    ]
   },
   {
@@ -349,7 +353,14 @@
    },
    "outputs": [],
    "source": [
-    "edges_df = pd.DataFrame(graph.edges_iter(), columns=['source', 'target'])"
+    "circular_edges_df = pd.DataFrame(graph.edges_iter(), columns=['source', 'target'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph with only nodes"
    ]
   },
   {
@@ -360,7 +371,14 @@
    },
    "outputs": [],
    "source": [
-    "%time df = bundle(nodes_df, edges_df, 0.05, 0.7)"
+    "render_points(circular_nodes_df, width=4000, height=4000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph without edge bundling"
    ]
   },
   {
@@ -371,7 +389,37 @@
    },
    "outputs": [],
    "source": [
-    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+    "circular_direct_df = directly_connect_edges(circular_nodes_df, circular_edges_df)\n",
+    "render_lines(circular_direct_df, width=2000, height=2000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Graph with edge bundling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%time circular_df0 = hammer_bundle(circular_nodes_df, circular_edges_df, 0.05, 0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "render_lines(circular_df0, width=2000, height=2000, cmap=fire, bgcolor='black')"
    ]
   },
   {
@@ -389,7 +437,8 @@
    },
    "outputs": [],
    "source": [
-    "%time df = bundle(nodes_df, edges_df, initial_bandwidth=0.05, decay=0.4) # Decay from 0.7 to 0.4"
+    "# Decay from 0.7 to 0.4\n",
+    "%time circular_df1 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.05, decay=0.4)"
    ]
   },
   {
@@ -400,7 +449,7 @@
    },
    "outputs": [],
    "source": [
-    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+    "render_lines(circular_df1, width=2000, height=2000, cmap=fire, bgcolor='black')"
    ]
   },
   {
@@ -418,7 +467,8 @@
    },
    "outputs": [],
    "source": [
-    "%time df = bundle(nodes_df, edges_df, initial_bandwidth=0.05, decay=1.0) # Decay from 0.7 to 1.0"
+    "# Decay from 0.7 to 1.0\n",
+    "%time circular_df2 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.05, decay=1.0)"
    ]
   },
   {
@@ -429,7 +479,7 @@
    },
    "outputs": [],
    "source": [
-    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+    "render_lines(circular_df2, width=2000, height=2000, cmap=fire, bgcolor='black')"
    ]
   },
   {
@@ -447,7 +497,8 @@
    },
    "outputs": [],
    "source": [
-    "%time df = bundle(nodes_df, edges_df, initial_bandwidth=0.025, decay=0.7) # Initial bandwidth from 0.05 to 0.025"
+    "# Initial bandwidth from 0.05 to 0.025\n",
+    "%time circular_df3 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.025, decay=0.7)"
    ]
   },
   {
@@ -458,7 +509,7 @@
    },
    "outputs": [],
    "source": [
-    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+    "render_lines(circular_df3, width=2000, height=2000, cmap=fire, bgcolor='black')"
    ]
   },
   {
@@ -476,7 +527,8 @@
    },
    "outputs": [],
    "source": [
-    "%time df = bundle(nodes_df, edges_df, initial_bandwidth=0.1, decay=0.7) # Initial bandwidth from 0.05 to 0.1"
+    "# Initial bandwidth from 0.05 to 0.1\n",
+    "%time circular_df4 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.1, decay=0.7)"
    ]
   },
   {
@@ -487,7 +539,7 @@
    },
    "outputs": [],
    "source": [
-    "render_lines(df, width=2000, height=2000, cmap=inferno, bgcolor='black')"
+    "render_lines(circular_df4, width=2000, height=2000, cmap=fire, bgcolor='black')"
    ]
   },
   {


### PR DESCRIPTION
This is the initial import of Ian Calvert's edge bundling implementation. The main structure was preserved with minor updates to fit into Datashader's pipeline.

To use an existing graph, the nodes and edges must be stored separately in a format importable to a Pandas dataframe (for example, fastparquet or CSV). Each node must have an id and a XY point. Each edge must have its own id, the id of the source node, and the id of the target node. A usable dataset is available in `examples/datasets.yml`. A notebook with full examples is also available.

Once the graph data is imported into the respective dataframes, `datashader.bundling.bundle()` takes the two dataframes as input and additional optional parameters control the specifics of edge bundling. The returned dataframe contains all calculated line segments and is structured for input into `Canvas.line`.

The bundling operation assumes that all nodes have a position. A separate layout operation must be run prior to bundling. If you wish to bypass bundling and convert a given graph to a format suitable for the Datashader pipeline, use `datashader.bundling.nop_bundle()`, which takes the same parameters as `bundle()`.

To describe the internal bundling implementation further, the graph dataframes are converted to a list of smaller edge segments represented by NumPy arrays. After processing, the list of edge segments is converted back to a dataframe. A future PR will use a native dataframe (either Pandas or Dask) without the current conversion steps. A weighted graph will also be a future improvement.