### PR TITLE
Parameterized the edge bundling code

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - xarray >=0.7.0
     - toolz >=0.7.4
     - colorcet >=0.9.0
+    - param >=1.5.1,<2.0
 
 test:
   requires:

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -56,7 +56,8 @@ def stack(*imgs, **kwargs):
     if len(imgs) == 1:
         return imgs[0]
     imgs = xr.align(*imgs, copy=False, join='outer')
-    out = tz.reduce(tz.flip(op), [i.data for i in imgs])
+    with np.errstate(divide='ignore', invalid='ignore'):    
+        out = tz.reduce(tz.flip(op), [i.data for i in imgs])
     return Image(out, coords=imgs[0].coords, dims=imgs[0].dims)
 
 

--- a/examples/edge_bundling.ipynb
+++ b/examples/edge_bundling.ipynb
@@ -30,7 +30,7 @@
    },
    "outputs": [],
    "source": [
-    "def render_points(df, width=4000, height=4000, cmap=[\"lightblue\", \"darkblue\"], bgcolor=None):\n",
+    "def render_points(df, width=4000, height=4000, cmap=[\"lightcoral\", \"darkred\"], bgcolor=None):\n",
     "    cvs = ds.Canvas(plot_width=width, plot_height=height, x_range=(0, 1), y_range=(0, 1))\n",
     "    agg = cvs.points(df, 'x', 'y',  ds.count())\n",
     "    img = tf.shade(agg, cmap=cmap)\n",
@@ -56,9 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "client = Client()"
@@ -74,9 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "researchers_nodes_df = fp.ParquetFile('data/calvert_uk_research2017_nodes.snappy.parq').to_pandas(index='id')\n",
@@ -125,7 +121,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "render_points(researchers_nodes_df, width=2000, height=2000)"
+    "nodes_img = tf.spread(render_points(researchers_nodes_df, width=2000, height=2000))\n",
+    "nodes_img"
    ]
   },
   {
@@ -141,7 +138,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "render_lines(researchers_direct_df, width=2000, height=2000)"
+    "lines_img=render_lines(researchers_direct_df, width=2000, height=2000)\n",
+    "lines_img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.stack(lines_img,nodes_img)"
    ]
   },
   {
@@ -154,20 +161,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%time researchers_df = hammer_bundle(researchers_nodes_df, researchers_edges_df, 0.05, 0.7)"
+    "%time researchers_df = hammer_bundle(researchers_nodes_df, researchers_edges_df)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "render_lines(researchers_df, width=2000, height=2000, cmap=fire, bgcolor='black')"
@@ -242,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "render_points(random_nodes_df, width=2000, height=2000)"
+    "tf.spread(render_points(random_nodes_df, width=2000, height=2000))"
    ]
   },
   {
@@ -275,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%time random_df = hammer_bundle(random_nodes_df, random_edges_df, 0.05, 0.7)"
+    "%time random_df = hammer_bundle(random_nodes_df, random_edges_df)"
    ]
   },
   {
@@ -366,12 +369,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "render_points(circular_nodes_df, width=4000, height=4000)"
+    "render_points(circular_nodes_df, width=2000, height=2000)"
    ]
   },
   {
@@ -384,9 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "circular_direct_df = directly_connect_edges(circular_nodes_df, circular_edges_df)\n",
@@ -403,20 +402,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%time circular_df0 = hammer_bundle(circular_nodes_df, circular_edges_df, 0.05, 0.7)"
+    "%time circular_df0 = hammer_bundle(circular_nodes_df, circular_edges_df)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "render_lines(circular_df0, width=2000, height=2000, cmap=fire, bgcolor='black')"
@@ -432,21 +427,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Decay from 0.7 to 0.4\n",
-    "%time circular_df1 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.05, decay=0.4)"
+    "%time circular_df1 = hammer_bundle(circular_nodes_df, circular_edges_df, decay=0.4)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "render_lines(circular_df1, width=2000, height=2000, cmap=fire, bgcolor='black')"
@@ -462,21 +453,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Decay from 0.7 to 1.0\n",
-    "%time circular_df2 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.05, decay=1.0)"
+    "%time circular_df2 = hammer_bundle(circular_nodes_df, circular_edges_df, decay=1.0)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "render_lines(circular_df2, width=2000, height=2000, cmap=fire, bgcolor='black')"
@@ -492,21 +479,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initial bandwidth from 0.05 to 0.025\n",
-    "%time circular_df3 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.025, decay=0.7)"
+    "%time circular_df3 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.025)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "render_lines(circular_df3, width=2000, height=2000, cmap=fire, bgcolor='black')"
@@ -522,41 +505,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Initial bandwidth from 0.05 to 0.1\n",
-    "%time circular_df4 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.1, decay=0.7)"
+    "%time circular_df4 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.1)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "render_lines(circular_df4, width=2000, height=2000, cmap=fire, bgcolor='black')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:ds]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-ds-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
One of the great things about Datashader in general is that there are not normally any "magic" parameters, i.e., arbitrary values that need to be set just so an algorithm can run, with no clear constraints that determine those values.  For better or worse, the new edge bundling code contains multiple such arbitrary values, and it's now crucial to make sure that the values are declared clearly, documented, interpreted consistently, and easily modifiable by the user.  Moreover, in part because of these arbitrary choices, users are likely to need multiple such edge bundling algorithms, each with tradeoffs, and so it's important to be able to bundle up each algorithm into a clearly maintainable chunk.

Accordingly, I have packaged up the two edge bundling algorithms currently provided into classes that can be called just as the old functions were, except that some positional arguments have been made keyword-only arguments for consistency.

Making this change would not normally affect the actual results, but it does in this case, because two of the parameters were *not* previously being respected consistently: MIN_SEG and MAX_SEG.  These parameters were defined as module constants and then passed around divided by 2 in some cases, and defaulting to the module-level value in others.  They should now all be respected consistently, with declared values that can safely be overridden in subclasses if needed.