### PR TITLE
Made alpha scaling respect min_alpha consistently

### DIFF
--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -96,9 +96,9 @@ def test_interpolate_cmap():
 @pytest.mark.parametrize('cmap', ['black', (0, 0, 0), '#000000'])
 def test_interpolate_cmap_non_categorical_alpha(cmap):
     img = tf.interpolate(agg.a, how='log', cmap=cmap)
-    sol = np.array([[         0,          0, 1509949440],
-                    [2399141888,          0, 3523215360],
-                    [3925868544, 4278190080,          0]])
+    sol = np.array([[         0,  671088640, 1946157056],
+                    [2701131776,          0, 3640655872],
+                    [3976200192, 4278190080,          0]])
     sol = xr.DataArray(sol, coords=coords, dims=dims)
     assert img.equals(sol)
 

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -160,10 +160,10 @@ def interpolate(agg, low=None, high=None, cmap=None, how='eq_hist', alpha=255, s
         warnings.simplefilter('always', DeprecationWarning)
         w = DeprecationWarning("`interpolate` is deprecated; use `shade` instead")
         warnings.warn(w)
-    return _interpolate(agg, cmap, how, alpha, span)
+    return _interpolate(agg, cmap, how, alpha, span, 40)
 
 
-def _interpolate(agg, cmap, how, alpha, span):
+def _interpolate(agg, cmap, how, alpha, span, min_alpha):
     if agg.ndim != 2:
         raise ValueError("agg must be 2D")
     interpolater = _normalize_interpolate_how(how)
@@ -208,7 +208,7 @@ def _interpolate(agg, cmap, how, alpha, span):
         img = np.dstack([r, g, b, a]).view(np.uint32).reshape(a.shape)
     elif isinstance(cmap, str) or isinstance(cmap, tuple):
         color = rgb(cmap)
-        aspan = np.arange(0, alpha+1)
+        aspan = np.arange(min_alpha, alpha+1)
         rspan, gspan, bspan = np.repeat(list(zip(color)), len(aspan), axis=1)
         span = np.linspace(span[0], span[1], len(aspan))
         r = np.interp(data, span, rspan, left=255).astype(np.uint8)
@@ -358,7 +358,7 @@ def shade(agg, cmap=["lightblue", "darkblue"], color_key=Sets1to3,
         raise TypeError("agg must be instance of DataArray")
 
     if agg.ndim == 2:
-        return _interpolate(agg, cmap, how, alpha, span)
+        return _interpolate(agg, cmap, how, alpha, span, min_alpha)
     elif agg.ndim == 3:
         return _colorize(agg, color_key, how, min_alpha)
     else:


### PR DESCRIPTION
PR #345 added alpha-based scaling for non-categorical types, based on the support that was already provided for categorical types.  However, it mapped data values into the alpha range 0 to 255, with the result that low data values were completely invisible, which is particularly acute when there are only a few data values total. E.g. if plotting counts where 1000 pixels have count 1 and 2 pixels have count 2, the resulting plot has only two visible pixels, which is highly misleading.  Moreover, such situations are very common when zooming in; at some point just a couple of overlapping points are shown, and the entire dataset is invisible, with it reappearing when zooming in just slightly more to remove that overlap.

The categorical alpha-scaling code already provided a `min_alpha` parameter for this purpose, and this PR now makes the non-categorical alpha-scaling code respect it.