### PR TITLE
Expanded edge_bundling notebook using HoloViews

### DIFF
--- a/examples/datasets.yml
+++ b/examples/datasets.yml
@@ -101,3 +101,7 @@ data:
       - calvert_uk_research2017_nodes.snappy.parq
       - calvert_uk_research2017_edges.snappy.parq
 
+  - url: http://s3.amazonaws.com/datashader-data/calvert_uk_research2017_nodes.zip
+    title: 'Institutions for Edge Bundling (Calvert UK Research 2017)'
+    files:
+      - calvert_uk_research2017_nodes.csv

--- a/examples/edge_bundling.ipynb
+++ b/examples/edge_bundling.ipynb
@@ -1,25 +1,159 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plotting graphs in Datashader with edge bundling\n",
+    "\n",
+    "[Datashader](http://datashader.readthedocs.org) provides general-purpose support for plotting very large collections of points, line segments, and gridded data, using a convenient API provided by [HoloViews](http://holoviews.org) and  an interactive user interface provided by [Bokeh](http://bokeh.pydata.org). While these facilities can be used to plot any sort of data, graph data (networks of nodes connected by edges) presents some special challenges.  At a minimum, the nodes and edges must be mapped into specific locations and shapes in a 2D plane before they can be visualized, which is an [open-ended problem involving a complex set of tradeoffs and complications](http://www.hiveplot.com).\n",
+    "\n",
+    "Here, we will assume that the nodes have already been laid out in 2D, whether because they have such structure inherently (such as connections between geographic locations), or an arbitrary random or geometric layout has been selected manually, or the layout has been determined by an external tool (such as a force-directed algorithm laying out similarly connected nodes in similar locations).\n",
+    "\n",
+    "First, we'll import the packages we are using and set up some defaults."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask.distributed import Client\n",
-    "from pandas import DataFrame\n",
-    "\n",
-    "import fastparquet as fp\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import holoviews as hv\n",
+    "import fastparquet as fp\n",
+    "import datashader as ds\n",
     "\n",
     "from colorcet import fire\n",
-    "\n",
     "from datashader.bundling import directly_connect_edges, hammer_bundle\n",
     "from datashader.utils import export_image\n",
     "\n",
-    "import datashader as ds\n",
-    "import datashader.transfer_functions as tf"
+    "from holoviews.operation.datashader import aggregate, shade, datashade, dynspread\n",
+    "from holoviews.operation import decimate\n",
+    "\n",
+    "from dask.distributed import Client\n",
+    "client = Client()\n",
+    "\n",
+    "hv.notebook_extension('bokeh','matplotlib')\n",
+    "\n",
+    "decimate.max_samples=20000\n",
+    "dynspread.threshold=0.01\n",
+    "datashade.cmap=fire[40:]\n",
+    "sz = dict(width=150,height=150)\n",
+    "\n",
+    "%opts RGB [xaxis=None yaxis=None show_grid=False bgcolor=\"black\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Random graph\n",
+    "\n",
+    "As a first example, let's generate a random graph, with 5000 points normally distributed around the origin and 10000 random connections between them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(0)\n",
+    "\n",
+    "nodes = hv.Points(pd.DataFrame(np.random.randn(5000, 2), columns=['x', 'y']))\n",
+    "nodes.data.tail()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edges = hv.Curve(pd.DataFrame(np.random.randint(len(nodes.data), size=(10000, 2)),\n",
+    "                              columns=['source', 'target']))\n",
+    "edges.data.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here you can see that the nodes list is a columnar dataframe with an index value and an (x,y) location for every node.  The edges list is a columnar dataframe listing the index of the source and target in the nodes dataframe.  \n",
+    "\n",
+    "We can now visualize this data using some graph-specific helper functions in Datashader, with results packaged as HoloViews objects that display using Bokeh:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts RGB [width=400 height=400]\n",
+    "\n",
+    "%time direct  = hv.Curve(directly_connect_edges(nodes.data, edges.data))\n",
+    "%time bundled = hv.Curve(hammer_bundle(nodes.data, edges.data))\n",
+    "\n",
+    "(datashade(direct)  * dynspread(datashade(nodes,cmap=[\"cyan\"]),threshold=0.01)).relabel(\"Directly connected\") + \\\n",
+    "(datashade(bundled) * dynspread(datashade(nodes,cmap=[\"cyan\"]),threshold=0.01)).relabel(\"Bundled\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In these plots, you can select the Bokeh \"wheel zoom\" from the tool palette and zoom or pan on the plot.  On a static site like anaconda.org the image will be rescaled blockily as you zoom in, not revealing any new data, but with a live server it will be dynamically re-rendered to show more detailed structure each time. Here the nodes are shown as cyan-colored dots, and the connections are lines that show up as dark red for a single line and gradually brighter colors as more lines are overlaid.  \n",
+    "\n",
+    "The \"Directly Connected\" plot shows a single line segment per edge, which is very quick (scaling in computational complexity with the number of edges) but has so much overlap that it is difficult to see the underlying structure.\n",
+    "\n",
+    "Conversely, if we render the edges as curves by using an edge bundling algorithm (a variant of [Hurter, Ersoy, & Telea, ECV-2012](http://www.cs.rug.nl/~alext/PAPERS/EuroVis12/kdeeb.pdf)), we can see structure at a local scale.  (Of course, the large-scale structure in this case is random, but this technique magnifies small fluctuations, which in real datasets presumably reflect actual structure of the data.)\n",
+    "\n",
+    "The specific patterns that develop in the bundling process depend on the bundling parameters, particularly the initial bandwidth over which grouping is done, and the rate of decay of this bandwidth:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nodes_ds = dynspread(datashade(nodes,cmap=[\"cyan\"]),threshold=0.01)\n",
+    "\n",
+    "%time bundled         = hv.Curve(hammer_bundle(nodes.data, edges.data))\n",
+    "%time bundled_decay04 = hv.Curve(hammer_bundle(nodes.data, edges.data, decay=0.4))\n",
+    "%time bundled_decay10 = hv.Curve(hammer_bundle(nodes.data, edges.data, decay=1.0))\n",
+    "%time bundled_bw01    = hv.Curve(hammer_bundle(nodes.data, edges.data, initial_bandwidth=0.01))\n",
+    "%time bundled_bw30    = hv.Curve(hammer_bundle(nodes.data, edges.data, initial_bandwidth=0.30))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts RGB [width=250 height=250] {+framewise}\n",
+    "\n",
+    "((datashade(bundled_bw01,**sz)    * nodes_ds).relabel(\"Bundled with bw=0.01\") + \\\n",
+    " (datashade(bundled,**sz)         * nodes_ds).relabel(\"Bundled with bw=0.05\") + \\\n",
+    " (datashade(bundled_bw30,**sz)    * nodes_ds).relabel(\"Bundled with bw=0.30\") + \\\n",
+    " (datashade(bundled_decay04,**sz) * nodes_ds).relabel(\"Bundled with decay=0.1\") + \\\n",
+    " (datashade(bundled,**sz)         * nodes_ds).relabel(\"Bundled with decay=0.7\") + \\\n",
+    " (datashade(bundled_decay10,**sz) * nodes_ds).relabel(\"Bundled with decay=1.0\")).cols(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# Other standard graph types using NetworkX\n",
+    "\n",
+    "The separate [NetworkX](https://networkx.readthedocs.io) package can be used to create a variety of standard [graph structures](https://networkx.readthedocs.io/en/stable/reference/generators.html), so that you can see how bundling works across different graph types.  Here, we lay each of them out in a circular pattern using NetworkX, but note as always that results will differ dramatically depending on the layout, so it is important to choose a good layout first."
    ]
   },
   {
@@ -30,27 +164,26 @@
    },
    "outputs": [],
    "source": [
-    "def render_points(df, width=4000, height=4000, cmap=[\"lightcoral\", \"darkred\"], bgcolor=None):\n",
-    "    cvs = ds.Canvas(plot_width=width, plot_height=height, x_range=(0, 1), y_range=(0, 1))\n",
-    "    agg = cvs.points(df, 'x', 'y',  ds.count())\n",
-    "    img = tf.shade(agg, cmap=cmap)\n",
-    "    img = tf.spread(img)\n",
-    "    return tf.set_background(img, bgcolor) if bgcolor else img"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "def render_lines(df, width=4000, height=4000, cmap=[\"lightblue\", \"darkblue\"], bgcolor=None):\n",
-    "    cvs = ds.Canvas(plot_width=width, plot_height=height, x_range=(0, 1), y_range=(0, 1))\n",
-    "    agg = cvs.line(df, 'x', 'y',  ds.count())\n",
-    "    img = tf.shade(agg, cmap=cmap)\n",
-    "    return tf.set_background(img, bgcolor) if bgcolor else img"
+    "import networkx as nx\n",
+    "\n",
+    "def nx_plot(graph):\n",
+    "    print(graph.name, len(graph.edges()))\n",
+    "    layout = nx.circular_layout(graph)\n",
+    "    data = [[node, *layout[node]] for node in graph.nodes_iter()]\n",
+    "\n",
+    "    nodes_df = pd.DataFrame(data, columns=['id', 'x', 'y'])\n",
+    "    nodes_df.set_index('id', inplace=True)\n",
+    "    nodes = hv.Points(nodes_df)\n",
+    "\n",
+    "    edges = hv.Points(pd.DataFrame(graph.edges_iter(), columns=['source', 'target']))\n",
+    "    direct = hv.Curve(directly_connect_edges(nodes.data, edges.data))\n",
+    "\n",
+    "    bundled_bw005 = hv.Curve(hammer_bundle(nodes.data, edges.data))\n",
+    "    bundled_bw030 = hv.Curve(hammer_bundle(nodes.data, edges.data, initial_bandwidth=0.30))\n",
+    "\n",
+    "    return (datashade(direct, **sz)        * nodes).relabel(graph.name) + \\\n",
+    "           (datashade(bundled_bw005, **sz) * nodes).relabel(\"Bundled bw=0.05\") + \\\n",
+    "           (datashade(bundled_bw030, **sz) * nodes).relabel(\"Bundled bw=0.30\")"
    ]
   },
   {
@@ -59,60 +192,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client = Client()"
+    "%%time\n",
+    "%%opts RGB [width=200 height=200] {+framewise}\n",
+    "n=100\n",
+    "\n",
+    "hv.Layout([nx_plot(g) for g in\n",
+    "           [nx.complete_graph(n), nx.lollipop_graph(n, 5),     nx.barbell_graph(n,2),\n",
+    "            nx.ladder_graph(n),   nx.circular_ladder_graph(n), nx.star_graph(n),\n",
+    "            nx.cycle_graph(n)]]).cols(3)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Edge bundling with graph read from Parquet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "researchers_nodes_df = fp.ParquetFile('data/calvert_uk_research2017_nodes.snappy.parq').to_pandas(index='id')\n",
-    "researchers_edges_df = fp.ParquetFile('data/calvert_uk_research2017_edges.snappy.parq').to_pandas(index='id')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "researchers_nodes_df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "researchers_edges_df.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "researchers_direct_df = directly_connect_edges(researchers_nodes_df, researchers_edges_df)"
+    "As you can see, both bundled and unbundled representations reflect important aspects of the graph structure, but the bundling results do depend on the parameters chosen.  Bundling is also very computationally expensive, with unbundled plots much less expensive to prepare."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Graph with only nodes"
+    "# UK research collaboration example\n",
+    "\n",
+    "The above examples use artificial datasets, but each real-world dataset will have its own specific properties. Here, let's look at one example dataset of 600,000 collaborations between 15000 UK research institutions, previously laid out using a force-directed algorithm by [Ian Calvert](https://www.digital-science.com/people/ian-calvert):"
    ]
   },
   {
@@ -121,15 +224,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nodes_img = tf.spread(render_points(researchers_nodes_df, width=2000, height=2000))\n",
-    "nodes_img"
+    "r_nodes_file = 'data/calvert_uk_research2017_nodes.snappy.parq'\n",
+    "r_edges_file = 'data/calvert_uk_research2017_edges.snappy.parq'\n",
+    "\n",
+    "r_nodes = hv.Points(fp.ParquetFile(r_nodes_file).to_pandas(index='id'), label=\"Nodes\")\n",
+    "r_edges = hv.Curve( fp.ParquetFile(r_edges_file).to_pandas(index='id'), label=\"Edges\")\n",
+    "len(r_nodes),len(r_edges)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Graph without edge bundling"
+    "We can render each collaboration as a single-line direct connection, but the result is a dense tangle:"
    ]
   },
   {
@@ -138,24 +245,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lines_img=render_lines(researchers_direct_df, width=2000, height=2000)\n",
-    "lines_img"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tf.stack(lines_img,nodes_img)"
+    "%%opts RGB [tools=[\"hover\"] width=400 height=400] \n",
+    "\n",
+    "%time r_direct = hv.Curve(directly_connect_edges(r_nodes.data, r_edges.data),label=\"Direct\")\n",
+    "\n",
+    "dynspread(datashade(r_nodes,cmap=[\"cyan\"])) + \\\n",
+    "datashade(r_direct)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Graph with edge bundling"
+    "Detailed substructure of this graph becomes visible after bundling, which takes several minutes even using multiple cores with Dask:"
    ]
   },
   {
@@ -164,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%time researchers_df = hammer_bundle(researchers_nodes_df, researchers_edges_df)"
+    "%time r_bundled = hv.Curve(hammer_bundle(r_nodes.data, r_edges.data),label=\"Bundled\")"
    ]
   },
   {
@@ -173,70 +275,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "render_lines(researchers_df, width=2000, height=2000, cmap=fire, bgcolor='black')"
+    "%%opts RGB [tools=[\"hover\"] width=400 height=400] \n",
+    "\n",
+    "dynspread(datashade(r_nodes,cmap=[\"cyan\"])) + datashade(r_bundled)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Edge bundling with random graph"
+    "Zooming into these plots reveals interesting patterns, but immediately one then wants to ask what the various groupings of nodes might represent. With a small number of nodes or a small number of categories one could color-code the dots (using datashader's categorical color coding support), but here we just have thousands of indistinguishable dots. Instead, let's use hover information so the viewer can see the identity of each node.  \n",
+    "\n",
+    "To give something useful to hover, let's load the names of each institution in the researcher list and merge that with our existing layout data:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "def generate_nodes(n):\n",
-    "    return pd.DataFrame(np.random.randn(n, 2), columns=['x', 'y'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "def generate_edges(n, nodes):\n",
-    "    return pd.DataFrame(np.random.randint(len(nodes), size=(n, 2)), columns=['source', 'target'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "def generate_random_graph(nodes, edges):\n",
-    "    ndf = generate_nodes(nodes)\n",
-    "    edf = generate_edges(edges, ndf)\n",
-    "    return ndf, edf"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "random_nodes_df, random_edges_df = generate_random_graph(10000, 50000)"
+    "node_names = pd.read_csv(\"data/calvert_uk_research2017_nodes.csv\", index_col=\"node_id\", usecols=[\"node_id\",\"name\"])\n",
+    "node_names = node_names.rename(columns={\"name\": \"Institution\"})\n",
+    "node_names\n",
+    "\n",
+    "r_nodes_named = pd.merge(r_nodes.data, node_names, left_index=True, right_index=True)\n",
+    "r_nodes_named.tail()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Graph with only nodes"
+    "We can now overlay a set of points on top of the datashaded edges, which will provide hover information for each node.  Here, the entire set of 15000 nodes would be reasonably feasible to plot, but to show how to work with larger datasets we wrap the `hv.Points()` call with `decimate` so that only a finite subset of the points will be shown at any one time. If a node of interest is not visible in a particular zoom, then you can simply zoom in on that region; at some point the number of visible points will be below the specified decimate limit and the required point should be revealed."
    ]
   },
   {
@@ -245,288 +316,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tf.spread(render_points(random_nodes_df, width=2000, height=2000))"
+    "%%opts Points (color=\"cyan\") [tools=[\"hover\"] width=900 height=650] \n",
+    "datashade(r_bundled, width=900, height=650) * decimate(hv.Points(r_nodes_named),max_samples=2000)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Graph without edge bundling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "random_direct_df = directly_connect_edges(random_nodes_df, random_edges_df)\n",
-    "render_lines(random_direct_df, width=2000, height=2000)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Graph with edge bundling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%time random_df = hammer_bundle(random_nodes_df, random_edges_df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "render_lines(random_df, width=2000, height=2000, cmap=fire, bgcolor='black')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "### Edge bundling with star graph and circular layout"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "import networkx as nx"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "graph = nx.star_graph(100000)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "layout = nx.circular_layout(graph)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "data = []\n",
-    "for node in graph.nodes_iter():\n",
-    "    x, y = layout[node]\n",
-    "    data.append([node, x, y])\n",
-    "circular_nodes_df = pd.DataFrame(data, columns=['id', 'x', 'y'])\n",
-    "circular_nodes_df.set_index('id', inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "circular_edges_df = pd.DataFrame(graph.edges_iter(), columns=['source', 'target'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Graph with only nodes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "render_points(circular_nodes_df, width=2000, height=2000)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Graph without edge bundling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "circular_direct_df = directly_connect_edges(circular_nodes_df, circular_edges_df)\n",
-    "render_lines(circular_direct_df, width=2000, height=2000)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Graph with edge bundling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%time circular_df0 = hammer_bundle(circular_nodes_df, circular_edges_df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "render_lines(circular_df0, width=2000, height=2000, cmap=fire, bgcolor='black')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Decrease decay for edge bundling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Decay from 0.7 to 0.4\n",
-    "%time circular_df1 = hammer_bundle(circular_nodes_df, circular_edges_df, decay=0.4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "render_lines(circular_df1, width=2000, height=2000, cmap=fire, bgcolor='black')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Increase decay for edge bundling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Decay from 0.7 to 1.0\n",
-    "%time circular_df2 = hammer_bundle(circular_nodes_df, circular_edges_df, decay=1.0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "render_lines(circular_df2, width=2000, height=2000, cmap=fire, bgcolor='black')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Decrease initial bandwidth for edge bundling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Initial bandwidth from 0.05 to 0.025\n",
-    "%time circular_df3 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.025)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "render_lines(circular_df3, width=2000, height=2000, cmap=fire, bgcolor='black')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Increase initial bandwidth for edge bundling"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Initial bandwidth from 0.05 to 0.1\n",
-    "%time circular_df4 = hammer_bundle(circular_nodes_df, circular_edges_df, initial_bandwidth=0.1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "render_lines(circular_df4, width=2000, height=2000, cmap=fire, bgcolor='black')"
+    "If you click around and hover, you should see interesting groups of nodes, and can then set up further interactive tools using [HoloViews' stream support](http://holoviews.org/Tutorials/Streams.html) to reveal aspects relevant to your research interests or questions.\n",
+    "\n",
+    "As you can see, datashader lets you work with very large graph datasets, though there are a number of decisions to make by trial and error, you do have to be careful when doing computationally expensive operations like edge bundling, and interactive information will only be available for a limited subset of the data at any one time."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:ds]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-ds-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/edge_bundling.ipynb
+++ b/examples/edge_bundling.ipynb
@@ -19,6 +19,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import math\n",
+    "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import holoviews as hv\n",
@@ -49,9 +51,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Random graph\n",
+    "## Random graph\n",
     "\n",
-    "As a first example, let's generate a random graph, with 5000 points normally distributed around the origin and 10000 random connections between them:"
+    "As a first example, let's generate a random graph, with 5000 points normally distributed around the origin and 20000 random connections between them:"
    ]
   },
   {
@@ -72,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edges = hv.Curve(pd.DataFrame(np.random.randint(len(nodes.data), size=(10000, 2)),\n",
+    "edges = hv.Curve(pd.DataFrame(np.random.randint(len(nodes.data), size=(20000, 2)),\n",
     "                              columns=['source', 'target']))\n",
     "edges.data.tail()"
    ]
@@ -109,9 +111,18 @@
     "\n",
     "The \"Directly Connected\" plot shows a single line segment per edge, which is very quick (scaling in computational complexity with the number of edges) but has so much overlap that it is difficult to see the underlying structure.\n",
     "\n",
-    "Conversely, if we render the edges as curves by using an edge bundling algorithm (a variant of [Hurter, Ersoy, & Telea, ECV-2012](http://www.cs.rug.nl/~alext/PAPERS/EuroVis12/kdeeb.pdf)), we can see structure at a local scale.  (Of course, the large-scale structure in this case is random, but this technique magnifies small fluctuations, which in real datasets presumably reflect actual structure of the data.)\n",
+    "Conversely, if we render the edges as curves by using an edge bundling algorithm (a variant of [Hurter, Ersoy, & Telea, ECV-2012](http://www.cs.rug.nl/~alext/PAPERS/EuroVis12/kdeeb.pdf)), we can more easily see the structure of groups of connections, but here there is very little structure to see, given the overall randomness.  Other graphs will have more interesting structure, as shown below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bundling example using a star graph\n",
     "\n",
-    "The specific patterns that develop in the bundling process depend on the bundling parameters, particularly the initial bandwidth over which grouping is done, and the rate of decay of this bandwidth:"
+    "As a simple example with clear structure, let's put one node at the center, and select some random points on a circle around it that connect to the central node (a star graph topology):\n",
+    "\n",
+    "<!-- def circle(r,n): return [(math.cos(2*math.pi/n*x)*r,math.sin(2*math.pi/n*x)*r) for x in range(0,n)] -->"
    ]
   },
   {
@@ -120,13 +131,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nodes_ds = dynspread(datashade(nodes,cmap=[\"cyan\"]),threshold=0.01)\n",
+    "n = 75\n",
+    "np.random.seed(0)\n",
+    "x = np.random.random(n)\n",
     "\n",
-    "%time bundled         = hv.Curve(hammer_bundle(nodes.data, edges.data))\n",
-    "%time bundled_decay04 = hv.Curve(hammer_bundle(nodes.data, edges.data, decay=0.4))\n",
-    "%time bundled_decay10 = hv.Curve(hammer_bundle(nodes.data, edges.data, decay=1.0))\n",
-    "%time bundled_bw01    = hv.Curve(hammer_bundle(nodes.data, edges.data, initial_bandwidth=0.01))\n",
-    "%time bundled_bw30    = hv.Curve(hammer_bundle(nodes.data, edges.data, initial_bandwidth=0.30))"
+    "nodes = hv.Points(pd.DataFrame(np.stack((np.cos(2*math.pi*x),np.sin(2*math.pi*x))).T, columns=['x', 'y']))\n",
+    "nodes.data.ix[0]=(0.0,0.0)\n",
+    "edges = hv.Curve(pd.DataFrame(list(zip((range(1,n+1)),[0]*n)),columns=['source', 'target']))"
    ]
   },
   {
@@ -135,14 +146,64 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts RGB [width=250 height=250] {+framewise}\n",
+    "%%opts RGB [width=400 height=400]\n",
     "\n",
-    "((datashade(bundled_bw01,**sz)    * nodes_ds).relabel(\"Bundled with bw=0.01\") + \\\n",
-    " (datashade(bundled,**sz)         * nodes_ds).relabel(\"Bundled with bw=0.05\") + \\\n",
-    " (datashade(bundled_bw30,**sz)    * nodes_ds).relabel(\"Bundled with bw=0.30\") + \\\n",
-    " (datashade(bundled_decay04,**sz) * nodes_ds).relabel(\"Bundled with decay=0.1\") + \\\n",
-    " (datashade(bundled,**sz)         * nodes_ds).relabel(\"Bundled with decay=0.7\") + \\\n",
-    " (datashade(bundled_decay10,**sz) * nodes_ds).relabel(\"Bundled with decay=1.0\")).cols(3)"
+    "direct  = hv.Curve(directly_connect_edges(nodes.data, edges.data))\n",
+    "bundled = hv.Curve(hammer_bundle(nodes.data, edges.data))\n",
+    "\n",
+    "(datashade(direct)  * dynspread(datashade(nodes,cmap=[\"cyan\"]))).relabel(\"Directly connected\") + \\\n",
+    "(datashade(bundled) * dynspread(datashade(nodes,cmap=[\"cyan\"]))).relabel(\"Bundled\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here you can see the bundling algorithm forms groups of nearby connnections, which helps make the structure at a particular scale clear.  The scale of this structure, i.e., how much bundling is done, is determined by an effective \"bandwidth\", which is a combination of an `initial_bandwidth` parameter and a `decay` time constant for annealing this bandwidth over time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time  grid = hv.GridSpace({(bw, decay): hv.Curve(hammer_bundle(nodes.data, edges.data, iterations=5, \\\n",
+    "                                                         decay=decay, initial_bandwidth=bw)) \\\n",
+    "                              for decay in [0.1, 0.25, 0.5, 0.9] for bw in [0.1, 0.2, 0.5, 1]}, \\\n",
+    "                           kdims=['Initial bandwidth', 'Decay'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts RGB [width=150 height=150] {+framewise +axiswise}\n",
+    "datashade(grid, **sz).map(lambda edges_ds: edges_ds * nodes, hv.DynamicMap)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Starting from the bottom left and moving diagonally to the upper right, the scale of the bundling increases along a diagonal to the upper right, with higher initial bandwidth and higher decay time constants leading to larger-scale bundling.  For the largest decay time constant, the algorithm has failed to converge for large initial bandwidths (the bw 0.5 and 1.0 plots on the top row), because the algorithm stops at a specified maximum `iterations`, rather than reaching a fully organized state.\n",
+    "\n",
+    "Of course, even when the algorithm does converge, larger amounts of bundling can magnify small amounts of clumping over large scales, which may or may not be relevant to the questions being asked of this data, so it is important to set these parameters appropriately for the types of structures of interest.\n",
+    "\n",
+    "<!--\n",
+    "max_iterations=10\n",
+    "hmap = hv.HoloMap({(it, bw, decay): hv.Curve(hammer_bundle(nodes.data, edges.data,\n",
+    "                         decay=decay, initial_bandwidth=bw, iterations=it))\n",
+    "                     for decay in [0.1, 0.25, 0.5, 1, 2] \n",
+    "                     for bw in [0.1, 0.2, 0.5, 1] \n",
+    "                     for it in range(max_iterations)},\n",
+    "                   kdims=['Iteration', 'Initial bandwidth', 'Decay'])\n",
+    "    \n",
+    "nodes_ds = datashade(nodes,cmap=[\"cyan\"])\n",
+    "datashade(hmap.grid(['Initial bandwidth', 'Decay']), **sz).map(lambda e_ds: e_ds * nodes, hv.DynamicMap)\n",
+    "-->"
    ]
   },
   {
@@ -151,9 +212,9 @@
     "collapsed": true
    },
    "source": [
-    "# Other standard graph types using NetworkX\n",
+    "## Using graphs from NetworkX\n",
     "\n",
-    "The separate [NetworkX](https://networkx.readthedocs.io) package can be used to create a variety of standard [graph structures](https://networkx.readthedocs.io/en/stable/reference/generators.html), so that you can see how bundling works across different graph types.  Here, we lay each of them out in a circular pattern using NetworkX, but note as always that results will differ dramatically depending on the layout, so it is important to choose a good layout first."
+    "The above examples constructed networks by hand.  A convenient way to get access to a large number of  [graph types](https://networkx.readthedocs.io/en/stable/reference/generators.html) is the separate [NetworkX](https://networkx.readthedocs.io) package.  Here, we will select several standard graph structures, lay them each out in the same fixed circular shape using NetworkX, and then show how they will appear without bundling, with moderate levels of bundling, and with high amounts of bundling."
    ]
   },
   {
@@ -166,8 +227,7 @@
    "source": [
     "import networkx as nx\n",
     "\n",
-    "def nx_plot(graph):\n",
-    "    print(graph.name, len(graph.edges()))\n",
+    "def nx_layout(graph):\n",
     "    layout = nx.circular_layout(graph)\n",
     "    data = [[node, *layout[node]] for node in graph.nodes_iter()]\n",
     "\n",
@@ -176,8 +236,13 @@
     "    nodes = hv.Points(nodes_df)\n",
     "\n",
     "    edges = hv.Points(pd.DataFrame(graph.edges_iter(), columns=['source', 'target']))\n",
-    "    direct = hv.Curve(directly_connect_edges(nodes.data, edges.data))\n",
+    "    return nodes, edges\n",
     "\n",
+    "def nx_plot(graph):\n",
+    "    print(graph.name, len(graph.edges()))\n",
+    "    nodes, edges = nx_layout(graph)\n",
+    "    \n",
+    "    direct = hv.Curve(directly_connect_edges(nodes.data, edges.data))\n",
     "    bundled_bw005 = hv.Curve(hammer_bundle(nodes.data, edges.data))\n",
     "    bundled_bw030 = hv.Curve(hammer_bundle(nodes.data, edges.data, initial_bandwidth=0.30))\n",
     "\n",
@@ -194,6 +259,7 @@
    "source": [
     "%%time\n",
     "%%opts RGB [width=200 height=200] {+framewise}\n",
+    "\n",
     "n=100\n",
     "\n",
     "hv.Layout([nx_plot(g) for g in\n",
@@ -206,14 +272,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, both bundled and unbundled representations reflect important aspects of the graph structure, but the bundling results do depend on the parameters chosen.  Bundling is also very computationally expensive, with unbundled plots much less expensive to prepare."
+    "As you can see, both bundled and unbundled representations reflect important aspects of the graph structure, but the bundling results do depend on the parameters chosen.  Bundling is also very computationally expensive; nearly all of the time taken to render these plots is for the bundling step.\n",
+    "\n",
+    "Note that the `star_graph` example above differs from the one in the previous section, in that all nodes here connect to a node on the outer circle instead of one in the center, which shows clearly how the layout can affect the resulting visualization."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# UK research collaboration example\n",
+    "## UK research collaboration example\n",
     "\n",
     "The above examples use artificial datasets, but each real-world dataset will have its own specific properties. Here, let's look at one example dataset of 600,000 collaborations between 15000 UK research institutions, previously laid out using a force-directed algorithm by [Ian Calvert](https://www.digital-science.com/people/ian-calvert):"
    ]
@@ -284,9 +352,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Zooming into these plots reveals interesting patterns, but immediately one then wants to ask what the various groupings of nodes might represent. With a small number of nodes or a small number of categories one could color-code the dots (using datashader's categorical color coding support), but here we just have thousands of indistinguishable dots. Instead, let's use hover information so the viewer can see the identity of each node.  \n",
+    "Zooming into these plots reveals interesting patterns, but immediately one then wants to ask what the various groupings of nodes might represent. With a small number of nodes or a small number of categories one could color-code the dots (using datashader's categorical color coding support), but here we just have thousands of indistinguishable dots. Instead, let's use hover information so the viewer can at least see the identity of each node on inspection.  \n",
     "\n",
-    "To give something useful to hover, let's load the names of each institution in the researcher list and merge that with our existing layout data:"
+    "To do that, we'll first need to pull in something useful to hover, so let's load the names of each institution in the researcher list and merge that with our existing layout data:"
    ]
   },
   {
@@ -317,7 +385,8 @@
    "outputs": [],
    "source": [
     "%%opts Points (color=\"cyan\") [tools=[\"hover\"] width=900 height=650] \n",
-    "datashade(r_bundled, width=900, height=650) * decimate(hv.Points(r_nodes_named),max_samples=2000)"
+    "datashade(r_bundled, width=900, height=650) * \\\n",
+    "decimate( hv.Points(r_nodes_named),max_samples=2000)"
    ]
   },
   {
@@ -326,15 +395,15 @@
    "source": [
     "If you click around and hover, you should see interesting groups of nodes, and can then set up further interactive tools using [HoloViews' stream support](http://holoviews.org/Tutorials/Streams.html) to reveal aspects relevant to your research interests or questions.\n",
     "\n",
-    "As you can see, datashader lets you work with very large graph datasets, though there are a number of decisions to make by trial and error, you do have to be careful when doing computationally expensive operations like edge bundling, and interactive information will only be available for a limited subset of the data at any one time."
+    "As you can see, datashader lets you work with very large graph datasets, though there are a number of decisions to make by trial and error, you do have to be careful when doing computationally expensive operations like edge bundling, and interactive information will only be available for a limited subset of the data at any one time due to data-size limitations of current web browsers."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:ds]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-ds-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Working with graph data requires both zooming and being able to overlay node and graph data easily, a combination that is not possible with Datashader's PIL support or with its InteractiveImage class.  These things are simple with HoloViews, though, and this new notebook replaces the previous one to tell a story about how to work with graph data.  The rendered notebook is at: https://anaconda.org/jbednar/edge_bundling 

![image](https://user-images.githubusercontent.com/1695496/26995543-e15d632c-4d32-11e7-8f89-8888aad43caa.png)

This PR is marked WIP not because it's not complete, but to make it possible for anyone with suggestions to push to it before it is merged.  Improvements that could be made:

- [ ] The "force directed algorithm" for layout should be described more fully, with a link to the specific code used or at least a better description.
- [ ] The code for testing the various bw and decay values could probably be simplified, perhaps using NDLayout?  Not sure how to do that when it's not a full cross product of the parameter values (which seems too expensive).  Perhaps a GridMatrix would be a better approach, with smaller images (and maybe a smaller network) but a better exploration of the full space of parameter values.
- [ ] The hover information should show id,institution, rather than the current x,y,institution.  Not sure how to get access to the id for hovering, but x,y should be suppressable if using a custom HoverTool specification.
- [ ] It would be nice to be able to select a node and then show all nodes that have connections to it (@Philipp?).