### PR TITLE
Replace rasterio with xarray, skimage with gridtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ target/
 
 #Editor files
 *~
+
+# Example output, notes
+examples/times
+examples/data
+examples/export
+**.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ python:
     - "3.5"
     - "3.6"
 
+matrix:
+  fast_finish: True
+  # Allow py3.4 to fail; conda-forge no longer supports it
+  allow_failures:
+    - python: "3.4"
+
 install:
   # Install conda
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
 test:
   requires:
     - pytest >=2.8.5
+    - rasterio >=1.0
+
   imports:
     - datashader
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - numpy >=1.7
     - pandas >=0.15.0
     - pillow >=3.1.1
-    - xarray >=0.7.0
+    - xarray >=0.9.6
     - toolz >=0.7.4
     - colorcet >=0.9.0
     - param >=1.5.1,<2.0

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -212,7 +212,7 @@ class Canvas(object):
         Parameters
         ----------
         source : xarray.DataArray
-            input datasource most likely obtain from `xarray.open_rasterio()`.
+            input datasource most likely obtained from `xarray.open_rasterio()`.
         band : int
             source band number : optional default=1
         resample_method : str, optional default=bilinear

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -253,8 +253,8 @@ class Canvas(object):
         width_ratio = (xmax - xmin) / (self.x_range[1] - self.x_range[0])
         height_ratio = (ymax - ymin) / (self.y_range[1] - self.y_range[0])
 
-        w = int(np.ceil(self.plot_width * width_ratio))
-        h = int(np.ceil(self.plot_height * height_ratio))
+        w = max(int(np.ceil(self.plot_width * width_ratio)), self.plot_width)
+        h = max(int(np.ceil(self.plot_height * height_ratio)), self.plot_height)
 
         data = resize(source.data[0],
                       (h, w),

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -5,7 +5,7 @@ from datashape.predicates import istabular
 from odo import discover
 from xarray import DataArray
 
-from .utils import Dispatcher, ngjit, calc_bbox
+from .utils import Dispatcher, ngjit, calc_res, calc_bbox
 
 
 class Expr(object):
@@ -241,7 +241,7 @@ class Canvas(object):
         if resample_method not in resample_methods.keys():
             raise ValueError('Invalid resample method: options include {}'.format(list(resample_methods.keys())))
 
-        res = source._file_obj.res
+        res = calc_res(source)
         left, bottom, right, top = calc_bbox(source.x.values, source.y.values, res)
 
         # window coodinates

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -252,8 +252,11 @@ class Canvas(object):
         width_ratio = (xmax - xmin) / (self.x_range[1] - self.x_range[0])
         height_ratio = (ymax - ymin) / (self.y_range[1] - self.y_range[0])
 
-        w = max(int(np.ceil(self.plot_width * width_ratio)), self.plot_width)
-        h = max(int(np.ceil(self.plot_height * height_ratio)), self.plot_height)
+        if np.isclose(width_ratio, 0) or np.isclose(height_ratio, 0):
+            raise ValueError('Canvas x_range or y_range values do not match closely-enough with the data source to be able to accurately rasterize. Please provide ranges that are more accurate.')
+
+        w = int(np.ceil(self.plot_width * width_ratio))
+        h = int(np.ceil(self.plot_height * height_ratio))
 
         data = resize(source.data[0],
                       (h, w),

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -205,7 +205,7 @@ class Canvas(object):
                resample_method='bilinear',
                use_overviews=True):
         """Sample a raster dataset by canvas size and bounds. Note: requires
-        `rasterio`, and `gridtools`.  Missing values (those having the value
+        `rasterio`, and `scikit-image`.  Missing values (those having the value
         indicated by the "nodata" attribute of the raster) are replaced with
         `NaN` if floats, and 0 if int.
 
@@ -227,14 +227,13 @@ class Canvas(object):
 
         Notes
         -------
-        requires `rasterio` and `gridtools`.
+        requires `rasterio` and `scikit-image`.
         """
         try:
             import rasterio as rio
             from skimage.transform import resize
-            #import gridtools.resampling as gtr
         except ImportError:
-            raise ImportError('install rasterio and gridtools to use this feature')
+            raise ImportError('install rasterio and scikit-image to use this feature')
 
         resample_methods = dict(nearest=0, bilinear=1)
 

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -1,0 +1,493 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+from .utils import ngjit
+
+#: Interpolation method for upsampling: Take nearest source grid cell, even if it is invalid.
+US_NEAREST = 10
+#: Interpolation method for upsampling: Bi-linear interpolation between the 4 nearest source grid cells.
+US_LINEAR = 11
+
+#: Aggregation method for downsampling: Take first valid source grid cell, ignore contribution areas.
+DS_FIRST = 50
+#: Aggregation method for downsampling: Take last valid source grid cell, ignore contribution areas.
+DS_LAST = 51
+# DS_MIN = 52
+# DS_MAX = 53
+#: Aggregation method for downsampling: Compute average of all valid source grid cells,
+#: with weights given by contribution area.
+DS_MEAN = 54
+# DS_MEDIAN = 55
+#: Aggregation method for downsampling: Compute most frequently seen valid source grid cell,
+#: with frequency given by contribution area. Note that this mode can use an additional keyword argument
+#: *mode_rank* which can be used to generate the n-th mode. See :py:function:`downsample_2d`.
+DS_MODE = 56
+#: Aggregation method for downsampling: Compute the biased weighted estimator of variance
+#: (see https://en.wikipedia.org/wiki/Mean_square_weighted_deviation), with weights given by contribution area.
+DS_VAR = 57
+#: Aggregation method for downsampling: Compute the corresponding standard deviation to the biased weighted estimator
+#: of variance
+#: (see https://en.wikipedia.org/wiki/Mean_square_weighted_deviation), with weights given by contribution area.
+DS_STD = 58
+
+#: Constant indicating an empty 2-D mask
+_NOMASK2D = np.ma.getmaskarray(np.ma.array([[0]], mask=[[0]]))
+
+_EPS = 1e-10
+
+
+def resample_2d(src, w, h, ds_method=DS_MEAN, us_method=US_LINEAR, fill_value=None, mode_rank=1, out=None):
+    """
+    Resample a 2-D grid to a new resolution.
+
+    :param src: 2-D *ndarray*
+    :param w: *int*
+        New grid width
+    :param h:  *int*
+        New grid height
+    :param ds_method: one of the *DS_* constants, optional
+        Grid cell aggregation method for a possible downsampling
+    :param us_method: one of the *US_* constants, optional
+        Grid cell interpolation method for a possible upsampling
+    :param fill_value: *scalar*, optional
+        If ``None``, it is taken from **src** if it is a masked array,
+        otherwise from *out* if it is a masked array,
+        otherwise numpy's default value is used.
+    :param mode_rank: *scalar*, optional
+        The rank of the frequency determined by the *ds_method* ``DS_MODE``. One (the default) means
+        most frequent value, zwo means second most frequent value, and so forth.
+    :param out: 2-D *ndarray*, optional
+        Alternate output array in which to place the result. The default is *None*; if provided, it must have the same
+        shape as the expected output.
+    :return: An resampled version of the *src* array.
+    """
+    out = _get_out(out, src, (h, w))
+    if out is None:
+        return src
+    mask, use_mask = _get_mask(src)
+    fill_value = _get_fill_value(fill_value, src, out)
+    return _mask_or_not(_resample_2d(src, mask, use_mask, ds_method, us_method, fill_value, mode_rank, out),
+                        src, fill_value)
+
+
+def upsample_2d(src, w, h, method=US_LINEAR, fill_value=None, out=None):
+    """
+    Upsample a 2-D grid to a higher resolution by interpolating original grid cells.
+
+    :param src: 2-D *ndarray*
+    :param w: *int*
+        Grid width, which must be greater than or equal to *src.shape[-1]*
+    :param h:  *int*
+        Grid height, which must be greater than or equal to *src.shape[-2]*
+    :param method: one of the *US_* constants, optional
+        Grid cell interpolation method
+    :param fill_value: *scalar*, optional
+        If ``None``, it is taken from **src** if it is a masked array,
+        otherwise from *out* if it is a masked array,
+        otherwise numpy's default value is used.
+    :param out: 2-D *ndarray*, optional
+        Alternate output array in which to place the result. The default is *None*; if provided, it must have the same
+        shape as the expected output.
+    :return: An upsampled version of the *src* array.
+    """
+    out = _get_out(out, src, (h, w))
+    if out is None:
+        return src
+    mask, use_mask = _get_mask(src)
+    fill_value = _get_fill_value(fill_value, src, out)
+    return _mask_or_not(_upsample_2d(src, mask, use_mask, method, fill_value, out), src, fill_value)
+
+
+def downsample_2d(src, w, h, method=DS_MEAN, fill_value=None, mode_rank=1, out=None):
+    """
+    Downsample a 2-D grid to a lower resolution by aggregating original grid cells.
+
+    :param src: 2-D *ndarray*
+    :param w: *int*
+        Grid width, which must be less than or equal to *src.shape[-1]*
+    :param h:  *int*
+        Grid height, which must be less than or equal to *src.shape[-2]*
+    :param method: one of the *DS_* constants, optional
+        Grid cell aggregation method
+    :param fill_value: *scalar*, optional
+        If ``None``, it is taken from **src** if it is a masked array,
+        otherwise from *out* if it is a masked array,
+        otherwise numpy's default value is used.
+    :param mode_rank: *scalar*, optional
+        The rank of the frequency determined by the *method* ``DS_MODE``. One (the default) means
+        most frequent value, zwo means second most frequent value, and so forth.
+    :param out: 2-D *ndarray*, optional
+        Alternate output array in which to place the result. The default is *None*; if provided, it must have the same
+        shape as the expected output.
+    :return: A downsampled version of the *src* array.
+    """
+    if method == DS_MODE and mode_rank < 1:
+        raise ValueError('mode_rank must be >= 1')
+    out = _get_out(out, src, (h, w))
+    if out is None:
+        return src
+    mask, use_mask = _get_mask(src)
+    fill_value = _get_fill_value(fill_value, src, out)
+    return _mask_or_not(_downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out), src, fill_value)
+
+
+def _get_out(out, src, shape):
+    if out is None:
+        return np.zeros(shape, dtype=src.dtype)
+    else:
+        if out.shape != shape:
+            raise ValueError("'shape' and 'out' are incompatible")
+        if out.shape == src.shape:
+            return None
+        return out
+
+
+def _get_mask(src):
+    if isinstance(src, np.ma.MaskedArray):
+        mask = np.ma.getmask(src)
+        if mask is not np.ma.nomask:
+            return mask, True
+    return _NOMASK2D, False
+
+
+def _mask_or_not(out, src, fill_value):
+    if isinstance(src, np.ma.MaskedArray):
+        if not isinstance(out, np.ma.MaskedArray):
+            if np.isfinite(fill_value):
+                masked = np.ma.masked_equal(out, fill_value, copy=False)
+            else:
+                masked = np.ma.masked_invalid(out, copy=False)
+            masked.set_fill_value(fill_value)
+            return masked
+    return out
+
+
+def _get_fill_value(fill_value, src, out):
+    if fill_value is None:
+        if isinstance(src, np.ma.MaskedArray):
+            fill_value = src.fill_value
+        elif isinstance(out, np.ma.MaskedArray):
+            fill_value = out.fill_value
+        else:
+            # use numpy's default fill_value
+            fill_value = np.ma.array([0], mask=[False], dtype=src.dtype).fill_value
+    return fill_value
+
+
+@ngjit
+def _resample_2d(src, mask, use_mask, ds_method, us_method, fill_value, mode_rank, out):
+    src_w = src.shape[-1]
+    src_h = src.shape[-2]
+    out_w = out.shape[-1]
+    out_h = out.shape[-2]
+
+    if out_w < src_w and out_h < src_h:
+        return _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
+    elif out_w < src_w:
+        if out_h > src_h:
+            temp = np.zeros((src_h, out_w), dtype=src.dtype)
+            temp = _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, temp)
+            # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
+            return _upsample_2d(temp, mask, use_mask, us_method, fill_value, out)
+        else:
+            return _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
+    elif out_h < src_h:
+        if out_w > src_w:
+            temp = np.zeros((out_h, src_w), dtype=src.dtype)
+            temp = _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, temp)
+            # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
+            return _upsample_2d(temp, mask, use_mask, us_method, fill_value, out)
+        else:
+            return _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
+    elif out_w > src_w or out_h > src_h:
+        return _upsample_2d(src, mask, use_mask, us_method, fill_value, out)
+    return src
+
+
+@ngjit
+def _upsample_2d(src, mask, use_mask, method, fill_value, out):
+    src_w = src.shape[-1]
+    src_h = src.shape[-2]
+    out_w = out.shape[-1]
+    out_h = out.shape[-2]
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w < src_w or out_h < src_h:
+        raise ValueError("invalid target size")
+
+    if method == US_NEAREST:
+        scale_x = src_w / out_w
+        scale_y = src_h / out_h
+        for out_y in range(out_h):
+            src_y = int(scale_y * out_y)
+            for out_x in range(out_w):
+                src_x = int(scale_x * out_x)
+                value = src[src_y, src_x]
+                if np.isfinite(value) and not (use_mask and mask[src_y, src_x]):
+                    out[out_y, out_x] = value
+                else:
+                    out[out_y, out_x] = fill_value
+
+    elif method == US_LINEAR:
+        scale_x = (src_w - 1.0) / ((out_w - 1.0) if out_w > 1 else 1.0)
+        scale_y = (src_h - 1.0) / ((out_h - 1.0) if out_h > 1 else 1.0)
+        for out_y in range(out_h):
+            src_yf = scale_y * out_y
+            src_y0 = int(src_yf)
+            wy = src_yf - src_y0
+            src_y1 = src_y0 + 1
+            if src_y1 >= src_h:
+                src_y1 = src_y0
+            for out_x in range(out_w):
+                src_xf = scale_x * out_x
+                src_x0 = int(src_xf)
+                wx = src_xf - src_x0
+                src_x1 = src_x0 + 1
+                if src_x1 >= src_w:
+                    src_x1 = src_x0
+                v00 = src[src_y0, src_x0]
+                v01 = src[src_y0, src_x1]
+                v10 = src[src_y1, src_x0]
+                v11 = src[src_y1, src_x1]
+                if use_mask:
+                    v00_ok = np.isfinite(v00) and not mask[src_y0, src_x0]
+                    v01_ok = np.isfinite(v01) and not mask[src_y0, src_x1]
+                    v10_ok = np.isfinite(v10) and not mask[src_y1, src_x0]
+                    v11_ok = np.isfinite(v11) and not mask[src_y1, src_x1]
+                else:
+                    v00_ok = np.isfinite(v00)
+                    v01_ok = np.isfinite(v01)
+                    v10_ok = np.isfinite(v10)
+                    v11_ok = np.isfinite(v11)
+                if v00_ok and v01_ok and v10_ok and v11_ok:
+                    ok = True
+                    v0 = v00 + wx * (v01 - v00)
+                    v1 = v10 + wx * (v11 - v10)
+                    value = v0 + wy * (v1 - v0)
+                elif wx < 0.5:
+                    # NEAREST according to weight
+                    if wy < 0.5:
+                        ok = v00_ok
+                        value = v00
+                    else:
+                        ok = v10_ok
+                        value = v10
+                else:
+                    # NEAREST according to weight
+                    if wy < 0.5:
+                        ok = v01_ok
+                        value = v01
+                    else:
+                        ok = v11_ok
+                        value = v11
+                if ok:
+                    out[out_y, out_x] = value
+                else:
+                    out[out_y, out_x] = fill_value
+
+    else:
+        raise ValueError('invalid upsampling method')
+
+    return out
+
+
+@ngjit
+def _downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out):
+    src_w = src.shape[-1]
+    src_h = src.shape[-2]
+    out_w = out.shape[-1]
+    out_h = out.shape[-2]
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w > src_w or out_h > src_h:
+        raise ValueError("invalid target size")
+
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+
+    if method == DS_FIRST or method == DS_LAST:
+        for out_y in range(out_h):
+            src_yf0 = scale_y * out_y
+            src_yf1 = src_yf0 + scale_y
+            src_y0 = int(src_yf0)
+            src_y1 = int(src_yf1)
+            if src_y1 == src_yf1 and src_y1 > src_y0:
+                src_y1 -= 1
+            for out_x in range(out_w):
+                src_xf0 = scale_x * out_x
+                src_xf1 = src_xf0 + scale_x
+                src_x0 = int(src_xf0)
+                src_x1 = int(src_xf1)
+                if src_x1 == src_xf1 and src_x1 > src_x0:
+                    src_x1 -= 1
+                done = False
+                value = fill_value
+                for src_y in range(src_y0, src_y1 + 1):
+                    for src_x in range(src_x0, src_x1 + 1):
+                        v = src[src_y, src_x]
+                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                            value = v
+                            if method == DS_FIRST:
+                                done = True
+                                break
+                    if done:
+                        break
+                out[out_y, out_x] = value
+
+    elif method == DS_MODE:
+        max_value_count = int(scale_x + 1) * int(scale_y + 1)
+        values = np.zeros((max_value_count,), dtype=src.dtype)
+        frequencies = np.zeros((max_value_count,), dtype=np.uint32)
+        for out_y in range(out_h):
+            src_yf0 = scale_y * out_y
+            src_yf1 = src_yf0 + scale_y
+            src_y0 = int(src_yf0)
+            src_y1 = int(src_yf1)
+            wy0 = 1.0 - (src_yf0 - src_y0)
+            wy1 = src_yf1 - src_y1
+            if wy1 < _EPS:
+                wy1 = 1.0
+                if src_y1 > src_y0:
+                    src_y1 -= 1
+            for out_x in range(out_w):
+                src_xf0 = scale_x * out_x
+                src_xf1 = src_xf0 + scale_x
+                src_x0 = int(src_xf0)
+                src_x1 = int(src_xf1)
+                wx0 = 1.0 - (src_xf0 - src_x0)
+                wx1 = src_xf1 - src_x1
+                if wx1 < _EPS:
+                    wx1 = 1.0
+                    if src_x1 > src_x0:
+                        src_x1 -= 1
+                value_count = 0
+                for src_y in range(src_y0, src_y1 + 1):
+                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                    for src_x in range(src_x0, src_x1 + 1):
+                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                        v = src[src_y, src_x]
+                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                            w = wx * wy
+                            found = False
+                            for i in range(value_count):
+                                if v == values[i]:
+                                    frequencies[i] += w
+                                    found = True
+                                    break
+                            if not found:
+                                values[value_count] = v
+                                frequencies[value_count] = w
+                                value_count += 1
+                w_max = -1.
+                value = fill_value
+                if mode_rank == 1:
+                    for i in range(value_count):
+                        w = frequencies[i]
+                        if w > w_max:
+                            w_max = w
+                            value = values[i]
+                elif mode_rank <= max_value_count:
+                    max_frequencies = np.full(mode_rank, -1.0, dtype=np.float64)
+                    indices = np.zeros(mode_rank, dtype=np.int64)
+                    for i in range(value_count):
+                        w = frequencies[i]
+                        for j in range(mode_rank):
+                            if w > max_frequencies[j]:
+                                max_frequencies[j] = w
+                                indices[j] = i
+                                break
+                    value = values[indices[mode_rank - 1]]
+
+                out[out_y, out_x] = value
+
+    elif method == DS_MEAN:
+        for out_y in range(out_h):
+            src_yf0 = scale_y * out_y
+            src_yf1 = src_yf0 + scale_y
+            src_y0 = int(src_yf0)
+            src_y1 = int(src_yf1)
+            wy0 = 1.0 - (src_yf0 - src_y0)
+            wy1 = src_yf1 - src_y1
+            if wy1 < _EPS:
+                wy1 = 1.0
+                if src_y1 > src_y0:
+                    src_y1 -= 1
+            for out_x in range(out_w):
+                src_xf0 = scale_x * out_x
+                src_xf1 = src_xf0 + scale_x
+                src_x0 = int(src_xf0)
+                src_x1 = int(src_xf1)
+                wx0 = 1.0 - (src_xf0 - src_x0)
+                wx1 = src_xf1 - src_x1
+                if wx1 < _EPS:
+                    wx1 = 1.0
+                    if src_x1 > src_x0:
+                        src_x1 -= 1
+                v_sum = 0.0
+                w_sum = 0.0
+                for src_y in range(src_y0, src_y1 + 1):
+                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                    for src_x in range(src_x0, src_x1 + 1):
+                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                        v = src[src_y, src_x]
+                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                            w = wx * wy
+                            v_sum += w * v
+                            w_sum += w
+                if w_sum < _EPS:
+                    out[out_y, out_x] = fill_value
+                else:
+                    out[out_y, out_x] = v_sum / w_sum
+
+    elif method == DS_VAR or method == DS_STD:
+        for out_y in range(out_h):
+            src_yf0 = scale_y * out_y
+            src_yf1 = src_yf0 + scale_y
+            src_y0 = int(src_yf0)
+            src_y1 = int(src_yf1)
+            wy0 = 1.0 - (src_yf0 - src_y0)
+            wy1 = src_yf1 - src_y1
+            if wy1 < _EPS:
+                wy1 = 1.0
+                if src_y1 > src_y0:
+                    src_y1 -= 1
+            for out_x in range(out_w):
+                src_xf0 = scale_x * out_x
+                src_xf1 = src_xf0 + scale_x
+                src_x0 = int(src_xf0)
+                src_x1 = int(src_xf1)
+                wx0 = 1.0 - (src_xf0 - src_x0)
+                wx1 = src_xf1 - src_x1
+                if wx1 < _EPS:
+                    wx1 = 1.0
+                    if src_x1 > src_x0:
+                        src_x1 -= 1
+                v_sum = 0.0
+                w_sum = 0.0
+                wv_sum = 0.0
+                wvv_sum = 0.0
+                for src_y in range(src_y0, src_y1 + 1):
+                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                    for src_x in range(src_x0, src_x1 + 1):
+                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                        v = src[src_y, src_x]
+                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                            w = wx * wy
+                            v_sum += v
+                            w_sum += w
+                            wv_sum += w * v
+                            wvv_sum += w * v * v
+                if w_sum < _EPS:
+                    out[out_y, out_x] = fill_value
+                else:
+                    out[out_y, out_x] = (wvv_sum * w_sum - wv_sum * wv_sum) / w_sum / w_sum
+        if method == DS_STD:
+            out = np.sqrt(out)
+    else:
+        raise ValueError('invalid upsampling method')
+
+    return out

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -2,15 +2,15 @@ from os import path
 
 import pytest
 import datashader as ds
-import rasterio as rio
+import xarray as xr
 
 BASE_PATH = path.split(__file__)[0]
 DATA_PATH = path.abspath(path.join(BASE_PATH, 'data'))
 TEST_RASTER_PATH = path.join(DATA_PATH, 'world.rgb.tif')
 
-with rio.open(TEST_RASTER_PATH) as src:
-    x_range = (src.bounds.left, src.bounds.right)
-    y_range = (src.bounds.bottom, src.bounds.top)
+with xr.open_rasterio(TEST_RASTER_PATH) as src:
+    x_range = (src._file_obj.bounds.left, src._file_obj.bounds.right)
+    y_range = (src._file_obj.bounds.bottom, src._file_obj.bounds.top)
     cvs = ds.Canvas(plot_width=2,
                     plot_height=2,
                     x_range=x_range,
@@ -18,31 +18,31 @@ with rio.open(TEST_RASTER_PATH) as src:
 
 
 def test_raster_aggregate_default():
-    with rio.open(TEST_RASTER_PATH) as src:
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
         agg = cvs.raster(src)
         assert agg is not None
 
 
 def test_raster_aggregate_nearest():
-    with rio.open(TEST_RASTER_PATH) as src:
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
         agg = cvs.raster(src, resample_method='nearest')
         assert agg is not None
 
 
 def test_raster_aggregate_with_overviews():
-    with rio.open(TEST_RASTER_PATH) as src:
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
         agg = cvs.raster(src, use_overviews=True)
         assert agg is not None
 
 
 def test_raster_aggregate_without_overviews():
-    with rio.open(TEST_RASTER_PATH) as src:
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
         agg = cvs.raster(src, use_overviews=False)
         assert agg is not None
 
 
 def test_out_of_bounds_return_correct_size():
-    with rio.open(TEST_RASTER_PATH) as src:
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
         cvs = ds.Canvas(plot_width=2,
                         plot_height=2,
                         x_range=[1e10, 1e20],
@@ -53,13 +53,13 @@ def test_out_of_bounds_return_correct_size():
 
 
 def test_partial_extent_returns_correct_size():
-    with rio.open(TEST_RASTER_PATH) as src:
-        half_width = (src.bounds.right - src.bounds.left) / 2
-        half_height = (src.bounds.top - src.bounds.bottom) / 2
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
+        half_width = (src._file_obj.bounds.right - src._file_obj.bounds.left) / 2
+        half_height = (src._file_obj.bounds.top - src._file_obj.bounds.bottom) / 2
         cvs = ds.Canvas(plot_width=512,
                         plot_height=256,
-                        x_range=[src.bounds.left-half_width, src.bounds.left+half_width],
-                        y_range=[src.bounds.bottom-half_height, src.bounds.bottom+half_height])
+                        x_range=[src._file_obj.bounds.left-half_width, src._file_obj.bounds.left+half_width],
+                        y_range=[src._file_obj.bounds.bottom-half_height, src._file_obj.bounds.bottom+half_height])
         agg = cvs.raster(src)
         assert agg.shape == (256, 512)
         assert agg is not None

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -3,6 +3,7 @@ from os import path
 import pytest
 import datashader as ds
 import xarray as xr
+import numpy as np
 
 BASE_PATH = path.split(__file__)[0]
 DATA_PATH = path.abspath(path.join(BASE_PATH, 'data'))
@@ -63,3 +64,28 @@ def test_partial_extent_returns_correct_size():
         agg = cvs.raster(src)
         assert agg.shape == (256, 512)
         assert agg is not None
+
+
+def test_calc_res():
+    """Assert that resolution is calculated correctly when using the xarray
+    rasterio backend.
+    """
+    import rasterio
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
+        xr_res = ds.utils.calc_res(src)
+    with rasterio.open(TEST_RASTER_PATH) as src:
+        rio_res = src.res
+    assert np.allclose(xr_res, rio_res)
+
+
+def test_calc_bbox():
+    """Assert that bounding boxes are calculated correctly when using the xarray
+    rasterio backend.
+    """
+    import rasterio
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
+        xr_res = ds.utils.calc_res(src)
+        xr_bounds = ds.utils.calc_bbox(src.x.values, src.y.values, xr_res)
+    with rasterio.open(TEST_RASTER_PATH) as src:
+        rio_bounds = src.bounds
+    assert np.allclose(xr_bounds, rio_bounds)

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -26,16 +26,18 @@ def test_raster_aggregate_default():
 
 def test_raster_aggregate_nearest():
     with xr.open_rasterio(TEST_RASTER_PATH) as src:
-        agg = cvs.raster(src, resample_method='nearest')
+        agg = cvs.raster(src, upsample_method='nearest')
         assert agg is not None
 
 
+@pytest.mark.skip('use_overviews opt no longer supported; may be re-implemented in the future')
 def test_raster_aggregate_with_overviews():
     with xr.open_rasterio(TEST_RASTER_PATH) as src:
         agg = cvs.raster(src, use_overviews=True)
         assert agg is not None
 
 
+@pytest.mark.skip('use_overviews opt no longer supported; may be re-implemented in the future')
 def test_raster_aggregate_without_overviews():
     with xr.open_rasterio(TEST_RASTER_PATH) as src:
         agg = cvs.raster(src, use_overviews=False)
@@ -94,3 +96,30 @@ def test_calc_bbox():
     with rasterio.open(TEST_RASTER_PATH) as src:
         rio_bounds = src.bounds
     assert np.allclose(xr_bounds, rio_bounds)
+
+
+def test_resample_methods():
+    """Assert that an error is raised when incorrect upsample and/or downsample
+    methods are provided to cvs.raster().
+    """
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
+        try:
+            agg = cvs.raster(src, upsample_method='santaclaus', downsample_method='toothfairy')
+        except ValueError:
+            pass
+        else:
+            assert False
+
+        try:
+            agg = cvs.raster(src, upsample_method='honestlawyer')
+        except ValueError:
+            pass
+        else:
+            assert False
+
+        try:
+            agg = cvs.raster(src, downsample_method='tenantfriendlylease')
+        except ValueError:
+            pass
+        else:
+            assert False

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -48,9 +48,12 @@ def test_out_of_bounds_return_correct_size():
                         plot_height=2,
                         x_range=[1e10, 1e20],
                         y_range=[1e10, 1e20])
-        agg = cvs.raster(src)
-        assert agg.shape == (2, 2)
-        assert agg is not None
+        try:
+            agg = cvs.raster(src)
+        except ValueError:
+            pass
+        else:
+            assert False
 
 
 def test_partial_extent_returns_correct_size():

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -64,6 +64,16 @@ def isreal(dt):
     return isinstance(dt, Unit) and dt in real
 
 
+def calc_res(raster):
+    """Calculate the resolution of xarray.DataArray raster and return it as the
+    two-tuple (xres, yres).
+    """
+    w, h = raster.shape[2], raster.shape[1]
+    xres = (raster.x.values[w-1] - raster.x.values[0]) / (w - 1)
+    yres = (raster.y.values[0] - raster.y.values[h-1]) / (h - 1)
+    return xres, yres
+
+
 def calc_bbox(xs, ys, res):
     """Calculate the bounding-box of a raster, and return it in a four-element
     tuple: (xmin, ymin, xmax, ymax). This assumes a flat-earth crs to do an

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -38,7 +38,7 @@ dependencies:
  - shapely
  - statsmodels
  - tblib
- - xarray
+ - xarray>=0.9.6 # For xarray.open_rasterio()
  - yaml
  - fastparquet
  - snappy

--- a/examples/lidar.ipynb
+++ b/examples/lidar.ipynb
@@ -63,6 +63,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -84,14 +85,15 @@
     "import holoviews as hv\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import rasterio as rio\n",
     "client = Client()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "if not os.path.exists('data'):\n",
@@ -182,6 +184,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -212,7 +215,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "hv.notebook_extension('bokeh', width=95)\n",
@@ -237,6 +242,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],

--- a/examples/race_elevation.ipynb
+++ b/examples/race_elevation.ipynb
@@ -17,170 +17,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "    <div class=\"bk-root\">\n",
-       "        <a href=\"http://bokeh.pydata.org\" target=\"_blank\" class=\"bk-logo bk-logo-small bk-logo-notebook\"></a>\n",
-       "        <span id=\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\">Loading BokehJS ...</span>\n",
-       "    </div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "(function(global) {\n",
-       "  function now() {\n",
-       "    return new Date();\n",
-       "  }\n",
-       "\n",
-       "  var force = true;\n",
-       "\n",
-       "  if (typeof (window._bokeh_onload_callbacks) === \"undefined\" || force === true) {\n",
-       "    window._bokeh_onload_callbacks = [];\n",
-       "    window._bokeh_is_loading = undefined;\n",
-       "  }\n",
-       "\n",
-       "\n",
-       "  \n",
-       "  if (typeof (window._bokeh_timeout) === \"undefined\" || force === true) {\n",
-       "    window._bokeh_timeout = Date.now() + 5000;\n",
-       "    window._bokeh_failed_load = false;\n",
-       "  }\n",
-       "\n",
-       "  var NB_LOAD_WARNING = {'data': {'text/html':\n",
-       "     \"<div style='background-color: #fdd'>\\n\"+\n",
-       "     \"<p>\\n\"+\n",
-       "     \"BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \\n\"+\n",
-       "     \"may be due to a slow or bad network connection. Possible fixes:\\n\"+\n",
-       "     \"</p>\\n\"+\n",
-       "     \"<ul>\\n\"+\n",
-       "     \"<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\\n\"+\n",
-       "     \"<li>use INLINE resources instead, as so:</li>\\n\"+\n",
-       "     \"</ul>\\n\"+\n",
-       "     \"<code>\\n\"+\n",
-       "     \"from bokeh.resources import INLINE\\n\"+\n",
-       "     \"output_notebook(resources=INLINE)\\n\"+\n",
-       "     \"</code>\\n\"+\n",
-       "     \"</div>\"}};\n",
-       "\n",
-       "  function display_loaded() {\n",
-       "    if (window.Bokeh !== undefined) {\n",
-       "      var el = document.getElementById(\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\");\n",
-       "      el.textContent = \"BokehJS \" + Bokeh.version + \" successfully loaded.\";\n",
-       "    } else if (Date.now() < window._bokeh_timeout) {\n",
-       "      setTimeout(display_loaded, 100)\n",
-       "    }\n",
-       "  }\n",
-       "\n",
-       "  function run_callbacks() {\n",
-       "    window._bokeh_onload_callbacks.forEach(function(callback) { callback() });\n",
-       "    delete window._bokeh_onload_callbacks\n",
-       "    console.info(\"Bokeh: all callbacks have finished\");\n",
-       "  }\n",
-       "\n",
-       "  function load_libs(js_urls, callback) {\n",
-       "    window._bokeh_onload_callbacks.push(callback);\n",
-       "    if (window._bokeh_is_loading > 0) {\n",
-       "      console.log(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n",
-       "      return null;\n",
-       "    }\n",
-       "    if (js_urls == null || js_urls.length === 0) {\n",
-       "      run_callbacks();\n",
-       "      return null;\n",
-       "    }\n",
-       "    console.log(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n",
-       "    window._bokeh_is_loading = js_urls.length;\n",
-       "    for (var i = 0; i < js_urls.length; i++) {\n",
-       "      var url = js_urls[i];\n",
-       "      var s = document.createElement('script');\n",
-       "      s.src = url;\n",
-       "      s.async = false;\n",
-       "      s.onreadystatechange = s.onload = function() {\n",
-       "        window._bokeh_is_loading--;\n",
-       "        if (window._bokeh_is_loading === 0) {\n",
-       "          console.log(\"Bokeh: all BokehJS libraries loaded\");\n",
-       "          run_callbacks()\n",
-       "        }\n",
-       "      };\n",
-       "      s.onerror = function() {\n",
-       "        console.warn(\"failed to load library \" + url);\n",
-       "      };\n",
-       "      console.log(\"Bokeh: injecting script tag for BokehJS library: \", url);\n",
-       "      document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
-       "    }\n",
-       "  };var element = document.getElementById(\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\");\n",
-       "  if (element == null) {\n",
-       "    console.log(\"Bokeh: ERROR: autoload.js configured with elementid '91ca63dd-1a80-44c7-a78b-04d821bc09c8' but no matching script tag was found. \")\n",
-       "    return false;\n",
-       "  }\n",
-       "\n",
-       "  var js_urls = [\"https://cdn.pydata.org/bokeh/dev/bokeh-0.12.6rc3.min.js\", \"https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.6rc3.min.js\"];\n",
-       "\n",
-       "  var inline_js = [\n",
-       "    function(Bokeh) {\n",
-       "      Bokeh.set_log_level(\"info\");\n",
-       "    },\n",
-       "    \n",
-       "    function(Bokeh) {\n",
-       "      \n",
-       "    },\n",
-       "    \n",
-       "    function(Bokeh) {\n",
-       "      \n",
-       "      document.getElementById(\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\").textContent = \"BokehJS is loading...\";\n",
-       "    },\n",
-       "    function(Bokeh) {\n",
-       "      console.log(\"Bokeh: injecting CSS: https://cdn.pydata.org/bokeh/dev/bokeh-0.12.6rc3.min.css\");\n",
-       "      Bokeh.embed.inject_css(\"https://cdn.pydata.org/bokeh/dev/bokeh-0.12.6rc3.min.css\");\n",
-       "      console.log(\"Bokeh: injecting CSS: https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.6rc3.min.css\");\n",
-       "      Bokeh.embed.inject_css(\"https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.6rc3.min.css\");\n",
-       "    }\n",
-       "  ];\n",
-       "\n",
-       "  function run_inline_js() {\n",
-       "    \n",
-       "    if ((window.Bokeh !== undefined) || (force === true)) {\n",
-       "      for (var i = 0; i < inline_js.length; i++) {\n",
-       "        inline_js[i](window.Bokeh);\n",
-       "      }if (force === true) {\n",
-       "        display_loaded();\n",
-       "      }} else if (Date.now() < window._bokeh_timeout) {\n",
-       "      setTimeout(run_inline_js, 100);\n",
-       "    } else if (!window._bokeh_failed_load) {\n",
-       "      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n",
-       "      window._bokeh_failed_load = true;\n",
-       "    } else if (force !== true) {\n",
-       "      var cell = $(document.getElementById(\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\")).parents('.cell').data().cell;\n",
-       "      cell.output_area.append_execute_result(NB_LOAD_WARNING)\n",
-       "    }\n",
-       "\n",
-       "  }\n",
-       "\n",
-       "  if (window._bokeh_is_loading === 0) {\n",
-       "    console.log(\"Bokeh: BokehJS loaded, going straight to plotting\");\n",
-       "    run_inline_js();\n",
-       "  } else {\n",
-       "    load_libs(js_urls, function() {\n",
-       "      console.log(\"Bokeh: BokehJS plotting callback run at\", now());\n",
-       "      run_inline_js();\n",
-       "    });\n",
-       "  }\n",
-       "}(this));"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from os import path\n",
     "\n",
@@ -211,8 +50,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# load austin elevation data\n",
@@ -229,8 +70,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "census_df = dd.io.parquet.read_parquet('data/census.snappy.parq')\n",
@@ -239,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -259,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -271,21 +114,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "AttributeError",
-     "evalue": "module 'datashader.utils' has no attribute 'calc_res'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-17-e2ca4ae08ab7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalc_res\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0melevation_data\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mxmin\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mymin\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mxmax\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mymax\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalc_bbox\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0melevation_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0melevation_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0my\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mres\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: module 'datashader.utils' has no attribute 'calc_res'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "res = ds.utils.calc_res(elevation_data)\n",
     "xmin, ymin, xmax, ymax = ds.utils.calc_bbox(elevation_data.x.values, elevation_data.y.values, res)"
@@ -308,7 +139,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "elevation_agg = cvs.raster(elevation_data)"
@@ -328,7 +161,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "xs, ys = np.meshgrid(people.x_axis, people.y_axis)\n",
@@ -347,7 +182,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def update_image(x_range, y_range, w, h):\n",

--- a/examples/race_elevation.ipynb
+++ b/examples/race_elevation.ipynb
@@ -17,17 +17,176 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <div class=\"bk-root\">\n",
+       "        <a href=\"http://bokeh.pydata.org\" target=\"_blank\" class=\"bk-logo bk-logo-small bk-logo-notebook\"></a>\n",
+       "        <span id=\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\">Loading BokehJS ...</span>\n",
+       "    </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "(function(global) {\n",
+       "  function now() {\n",
+       "    return new Date();\n",
+       "  }\n",
+       "\n",
+       "  var force = true;\n",
+       "\n",
+       "  if (typeof (window._bokeh_onload_callbacks) === \"undefined\" || force === true) {\n",
+       "    window._bokeh_onload_callbacks = [];\n",
+       "    window._bokeh_is_loading = undefined;\n",
+       "  }\n",
+       "\n",
+       "\n",
+       "  \n",
+       "  if (typeof (window._bokeh_timeout) === \"undefined\" || force === true) {\n",
+       "    window._bokeh_timeout = Date.now() + 5000;\n",
+       "    window._bokeh_failed_load = false;\n",
+       "  }\n",
+       "\n",
+       "  var NB_LOAD_WARNING = {'data': {'text/html':\n",
+       "     \"<div style='background-color: #fdd'>\\n\"+\n",
+       "     \"<p>\\n\"+\n",
+       "     \"BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \\n\"+\n",
+       "     \"may be due to a slow or bad network connection. Possible fixes:\\n\"+\n",
+       "     \"</p>\\n\"+\n",
+       "     \"<ul>\\n\"+\n",
+       "     \"<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\\n\"+\n",
+       "     \"<li>use INLINE resources instead, as so:</li>\\n\"+\n",
+       "     \"</ul>\\n\"+\n",
+       "     \"<code>\\n\"+\n",
+       "     \"from bokeh.resources import INLINE\\n\"+\n",
+       "     \"output_notebook(resources=INLINE)\\n\"+\n",
+       "     \"</code>\\n\"+\n",
+       "     \"</div>\"}};\n",
+       "\n",
+       "  function display_loaded() {\n",
+       "    if (window.Bokeh !== undefined) {\n",
+       "      var el = document.getElementById(\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\");\n",
+       "      el.textContent = \"BokehJS \" + Bokeh.version + \" successfully loaded.\";\n",
+       "    } else if (Date.now() < window._bokeh_timeout) {\n",
+       "      setTimeout(display_loaded, 100)\n",
+       "    }\n",
+       "  }\n",
+       "\n",
+       "  function run_callbacks() {\n",
+       "    window._bokeh_onload_callbacks.forEach(function(callback) { callback() });\n",
+       "    delete window._bokeh_onload_callbacks\n",
+       "    console.info(\"Bokeh: all callbacks have finished\");\n",
+       "  }\n",
+       "\n",
+       "  function load_libs(js_urls, callback) {\n",
+       "    window._bokeh_onload_callbacks.push(callback);\n",
+       "    if (window._bokeh_is_loading > 0) {\n",
+       "      console.log(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n",
+       "      return null;\n",
+       "    }\n",
+       "    if (js_urls == null || js_urls.length === 0) {\n",
+       "      run_callbacks();\n",
+       "      return null;\n",
+       "    }\n",
+       "    console.log(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n",
+       "    window._bokeh_is_loading = js_urls.length;\n",
+       "    for (var i = 0; i < js_urls.length; i++) {\n",
+       "      var url = js_urls[i];\n",
+       "      var s = document.createElement('script');\n",
+       "      s.src = url;\n",
+       "      s.async = false;\n",
+       "      s.onreadystatechange = s.onload = function() {\n",
+       "        window._bokeh_is_loading--;\n",
+       "        if (window._bokeh_is_loading === 0) {\n",
+       "          console.log(\"Bokeh: all BokehJS libraries loaded\");\n",
+       "          run_callbacks()\n",
+       "        }\n",
+       "      };\n",
+       "      s.onerror = function() {\n",
+       "        console.warn(\"failed to load library \" + url);\n",
+       "      };\n",
+       "      console.log(\"Bokeh: injecting script tag for BokehJS library: \", url);\n",
+       "      document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "    }\n",
+       "  };var element = document.getElementById(\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\");\n",
+       "  if (element == null) {\n",
+       "    console.log(\"Bokeh: ERROR: autoload.js configured with elementid '91ca63dd-1a80-44c7-a78b-04d821bc09c8' but no matching script tag was found. \")\n",
+       "    return false;\n",
+       "  }\n",
+       "\n",
+       "  var js_urls = [\"https://cdn.pydata.org/bokeh/dev/bokeh-0.12.6rc3.min.js\", \"https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.6rc3.min.js\"];\n",
+       "\n",
+       "  var inline_js = [\n",
+       "    function(Bokeh) {\n",
+       "      Bokeh.set_log_level(\"info\");\n",
+       "    },\n",
+       "    \n",
+       "    function(Bokeh) {\n",
+       "      \n",
+       "    },\n",
+       "    \n",
+       "    function(Bokeh) {\n",
+       "      \n",
+       "      document.getElementById(\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\").textContent = \"BokehJS is loading...\";\n",
+       "    },\n",
+       "    function(Bokeh) {\n",
+       "      console.log(\"Bokeh: injecting CSS: https://cdn.pydata.org/bokeh/dev/bokeh-0.12.6rc3.min.css\");\n",
+       "      Bokeh.embed.inject_css(\"https://cdn.pydata.org/bokeh/dev/bokeh-0.12.6rc3.min.css\");\n",
+       "      console.log(\"Bokeh: injecting CSS: https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.6rc3.min.css\");\n",
+       "      Bokeh.embed.inject_css(\"https://cdn.pydata.org/bokeh/dev/bokeh-widgets-0.12.6rc3.min.css\");\n",
+       "    }\n",
+       "  ];\n",
+       "\n",
+       "  function run_inline_js() {\n",
+       "    \n",
+       "    if ((window.Bokeh !== undefined) || (force === true)) {\n",
+       "      for (var i = 0; i < inline_js.length; i++) {\n",
+       "        inline_js[i](window.Bokeh);\n",
+       "      }if (force === true) {\n",
+       "        display_loaded();\n",
+       "      }} else if (Date.now() < window._bokeh_timeout) {\n",
+       "      setTimeout(run_inline_js, 100);\n",
+       "    } else if (!window._bokeh_failed_load) {\n",
+       "      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n",
+       "      window._bokeh_failed_load = true;\n",
+       "    } else if (force !== true) {\n",
+       "      var cell = $(document.getElementById(\"91ca63dd-1a80-44c7-a78b-04d821bc09c8\")).parents('.cell').data().cell;\n",
+       "      cell.output_area.append_execute_result(NB_LOAD_WARNING)\n",
+       "    }\n",
+       "\n",
+       "  }\n",
+       "\n",
+       "  if (window._bokeh_is_loading === 0) {\n",
+       "    console.log(\"Bokeh: BokehJS loaded, going straight to plotting\");\n",
+       "    run_inline_js();\n",
+       "  } else {\n",
+       "    load_libs(js_urls, function() {\n",
+       "      console.log(\"Bokeh: BokehJS plotting callback run at\", now());\n",
+       "      run_inline_js();\n",
+       "    });\n",
+       "  }\n",
+       "}(this));"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from os import path\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import rasterio as rio\n",
+    "import xarray as xr\n",
     "import datashader as ds\n",
     "import datashader.transfer_functions as tf\n",
     "\n",
@@ -52,15 +211,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# load austin elevation data\n",
     "path = './data/austin_dem.tif'\n",
-    "elevation_data = rio.open(path)"
+    "elevation_data = xr.open_rasterio(path)"
    ]
   },
   {
@@ -72,19 +229,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 14,
+   "metadata": {},
    "outputs": [],
    "source": [
     "census_df = dd.io.parquet.read_parquet('data/census.snappy.parq')\n",
-    "census_df.persist()"
+    "census_df = census_df.persist()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "collapsed": true
    },
@@ -104,28 +259,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "w = int(np.ceil(elevation_data.width / 8.0))\n",
-    "h = int(np.ceil(elevation_data.height / 8.0))"
+    "w = int(np.ceil(elevation_data.shape[2] / 8.0))\n",
+    "h = int(np.ceil(elevation_data.shape[1] / 8.0))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "module 'datashader.utils' has no attribute 'calc_res'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-17-e2ca4ae08ab7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalc_res\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0melevation_data\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mxmin\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mymin\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mxmax\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mymax\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcalc_bbox\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0melevation_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0melevation_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0my\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mres\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: module 'datashader.utils' has no attribute 'calc_res'"
+     ]
+    }
+   ],
    "source": [
-    "xmin = elevation_data.bounds.left\n",
-    "ymin = elevation_data.bounds.bottom\n",
-    "xmax = elevation_data.bounds.right\n",
-    "ymax = elevation_data.bounds.top"
+    "res = ds.utils.calc_res(elevation_data)\n",
+    "xmin, ymin, xmax, ymax = ds.utils.calc_bbox(elevation_data.x.values, elevation_data.y.values, res)"
    ]
   },
   {
@@ -145,9 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "elevation_agg = cvs.raster(elevation_data)"
@@ -167,9 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "xs, ys = np.meshgrid(people.x_axis, people.y_axis)\n",
@@ -188,9 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def update_image(x_range, y_range, w, h):\n",
@@ -242,21 +399,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
   },
   "widgets": {
    "state": {},
@@ -264,5 +421,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/solar.ipynb
+++ b/examples/solar.ipynb
@@ -30,7 +30,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from collections import OrderedDict\n",
@@ -54,7 +56,6 @@
     "import holoviews as hv\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import rasterio as rio\n",
     "import xarray as xr\n",
     "import numpy as np\n",
     "import holoviews as hv\n",
@@ -133,7 +134,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "meta_df.loc[list(STATION_COMBOS)]"
@@ -189,7 +192,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "df.head()"
@@ -198,7 +203,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "df.describe()"
@@ -207,7 +214,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "desc = df.date.describe()\n",
@@ -225,6 +234,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -297,7 +307,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "julian_summary = get_station_quantiles(station=example_usaf, grouper='julian_hr',)\n",
@@ -318,7 +330,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "julian_summary.columns"
@@ -374,7 +388,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "hour_of_year = plot_gen(station=example_usaf)"
@@ -396,7 +412,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "list(hour_of_year)"
@@ -406,6 +424,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -419,6 +438,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -451,6 +471,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],
@@ -471,6 +492,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": false
    },
    "outputs": [],


### PR DESCRIPTION
Datashader no longer requires _rasterio_ as a hard dependency - in favor of the new [xarray rasterio backend](http://xarray.pydata.org/en/stable/generated/xarray.open_rasterio.html) - however _rasterio_ will be required for running some of the notebooks and executing the unit tests. Also, the `cvs.raster()` method no longer relies on `skimage.transform.resize` for resampling; we are now using [datashader/resampling.py]() which came out of gridtools.

A few functions were also added to [datashader/utils.py](datashader/utils.py), which we should consider offering to _xarray_ at some point:
* *calc_res*: Replaces _rasterio.Dataset.res_ attribute. This is not (yet?) being exposed by the _rasterio_ backend in _xarray_, so it needs to be re-calculated from the data
* *calc_bbox*: Replaces _rasterio.Dataset.bounds()_ method. Simply calculating max and min on xarr.x and xarr.y yields incorrect results - more details can be found [here](https://github.com/mapbox/rasterio/issues/556) - as _rasterio_ relies on _gdal_ (through the _affine_ library) to perform affine transformation on the points based on the source raster's crs. As a substitute for this functionality I implemented an affine transform based on the "Augmented Matrix" approach described [here](https://en.wikipedia.org/wiki/Affine_transformation#Augmented_matrix). It assumes the flat-earth model, and does not currently perform reprojection - although theoretically we could add reprojection capabilities to it in the future.

This PR is still a work in progress. I'd like to wrap up the following items before merging:
- [x] Test `cvs.rasterize()` on a file using the EPSG:32616 crs. It's been tested so far (and verified as working) with EPSG:3857, but there may be subtle issues e.g. with the affine transformation matrix
- [x] Fix a unit test (which broke after a recent change) that is testing when the Canvas object's x_range and/or y_range exceeds the plot_width/plot_height
- [x] Clean up the notebooks so they no longer depend on _rasterio_ directly. They can use _xarray_'s rasterio backend instead, which indirectly depends on _rasterio_
- [x] Replace our usage of _skimage.transform.resize_ with gridtools _resample2d_. ~~Although we initially wanted _gridtools_ to be part of the replacement for _rasterio_, it turns out that it would actually be replacing [skimage.transform.resize](http://scikit-image.org/docs/dev/api/skimage.transform.html#skimage.transform.resize). I made a rudimentary attempt to replace `resize()` with it, but it oesn't seem to like floats, and will require some effort to become conda-installable (it's not available on OSX). @philippjfr may be able to confirm these details. Do we want gridtools as a conda package?~~