### PR TITLE
Various fixes for canvas.raster regridding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install dask numba numpy pandas pillow pytest toolz xarray datashape odo colorcet rasterio scikit-image param
+  - conda install -c gbrener xarray # remove this line when xarray >= 0.9.7
 
   # Optional dependencies, for testing only
   - conda install matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install dask numba numpy pandas pillow pytest toolz xarray datashape odo colorcet rasterio scikit-image param
-  - conda install -c gbrener xarray # remove this line when xarray >= 0.9.7
+  - conda install -c gbrener -c conda-forge xarray # remove this line when xarray >= 0.9.7
 
   # Optional dependencies, for testing only
   - conda install matplotlib

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ directory.
 
 ## Learning more
 
-After working through the examples, you can find additional resources linked from the
-[datashader documentation](http://datashader.readthedocs.org), including
-API documentation and papers and talks about the approach.
+After working through the examples, you can find additional resources linked
+from the [datashader documentation](http://datashader.readthedocs.org),
+including API documentation and papers and talks about the approach.
 
 ## Screenshots
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,6 +5,7 @@ package:
 extra:
   channels:
     - numba
+    - gbrener
 
 requirements:
   build:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -6,6 +6,7 @@ extra:
   channels:
     - numba
     - gbrener
+    - conda-forge
 
 requirements:
   build:

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -209,6 +209,10 @@ class Canvas(object):
                downsample_method='mean'):
         """Sample a raster dataset by canvas size and bounds.
 
+        Handles 2D or 3D xarray DataArrays, assuming that the last two
+        array dimensions are the y- and x-axis that are to be
+        resampled.
+
         Missing values (those having the value indicated by the
         "nodata" attribute of the raster) are replaced with `NaN` if
         floats, and 0 if int.
@@ -247,7 +251,7 @@ class Canvas(object):
             raise ValueError('Invalid downsample method: options include {}'.format(list(downsample_methods.keys())))
 
         res = calc_res(source)
-        ydim, xdim = source.dims if source.ndim == 2 else source.dims[1:]
+        ydim, xdim = source.dims[-2:]
         left, bottom, right, top = calc_bbox(source[xdim].values, source[ydim].values, res)
         array = orient_array(source, res, band)
         dtype = array.dtype

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -71,6 +71,21 @@ def test_partial_extent_returns_correct_size():
                         x_range=[left-half_width, left+half_width],
                         y_range=[bottom-half_height, bottom+half_height])
         agg = cvs.raster(src)
+        assert agg.shape == (3, 256, 512)
+        assert agg is not None
+
+
+def test_partial_extent_with_band_returns_correct_size():
+    with xr.open_rasterio(TEST_RASTER_PATH) as src:
+        res = ds.utils.calc_res(src)
+        left, bottom, right, top = ds.utils.calc_bbox(src.x.values, src.y.values, res)
+        half_width = (right - left) / 2
+        half_height = (top - bottom) / 2
+        cvs = ds.Canvas(plot_width=512,
+                        plot_height=256,
+                        x_range=[left-half_width, left+half_width],
+                        y_range=[bottom-half_height, bottom+half_height])
+        agg = cvs.raster(src, band=1)
         assert agg.shape == (256, 512)
         assert agg is not None
 

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -75,7 +75,7 @@ def test_partial_extent_returns_correct_size():
         assert agg is not None
 
 
-def test_partial_extent_with_band_returns_correct_size():
+def test_partial_extent_with_layer_returns_correct_size():
     with xr.open_rasterio(TEST_RASTER_PATH) as src:
         res = ds.utils.calc_res(src)
         left, bottom, right, top = ds.utils.calc_bbox(src.x.values, src.y.values, res)
@@ -85,7 +85,7 @@ def test_partial_extent_with_band_returns_correct_size():
                         plot_height=256,
                         x_range=[left-half_width, left+half_width],
                         y_range=[bottom-half_height, bottom+half_height])
-        agg = cvs.raster(src, band=1)
+        agg = cvs.raster(src, layer=1)
         assert agg.shape == (256, 512)
         assert agg is not None
 

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -113,6 +113,70 @@ def test_calc_bbox():
     assert np.allclose(xr_bounds, rio_bounds)
 
 
+def test_raster_both_ascending():
+    """
+    Assert raster with ascending x- and y-coordinates is aggregated correctly.
+    """
+    xs = np.arange(10)
+    ys = np.arange(5)
+    arr = xs*ys[np.newaxis].T
+    xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
+    cvs = ds.Canvas(10, 5, x_range=(-.5, 9.5), y_range=(-.5, 4.5))
+    agg = cvs.raster(xarr)
+
+    assert np.allclose(agg.data, arr)
+    assert np.allclose(agg.X.values, xs)
+    assert np.allclose(agg.Y.values, ys)
+
+
+def test_raster_both_descending():
+    """
+    Assert raster with ascending x- and y-coordinates is aggregated correctly.
+    """
+    xs = np.arange(10)[::-1]
+    ys = np.arange(5)[::-1]
+    arr = xs*ys[np.newaxis].T
+    xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
+    cvs = ds.Canvas(10, 5, x_range=(-.5, 9.5), y_range=(-.5, 4.5))
+    agg = cvs.raster(xarr)
+
+    assert np.allclose(agg.data, arr)
+    assert np.allclose(agg.X.values, xs)
+    assert np.allclose(agg.Y.values, ys)
+
+
+def test_raster_x_ascending_y_descending():
+    """
+    Assert raster with ascending x- and descending y-coordinates is aggregated correctly.
+    """
+    xs = np.arange(10)
+    ys = np.arange(5)[::-1]
+    arr = xs*ys[np.newaxis].T
+    xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
+    cvs = ds.Canvas(10, 5, x_range=(-.5, 9.5), y_range=(-.5, 4.5))
+    agg = cvs.raster(xarr)
+
+    assert np.allclose(agg.data, arr)
+    assert np.allclose(agg.X.values, xs)
+    assert np.allclose(agg.Y.values, ys)
+
+
+def test_raster_x_descending_y_ascending():
+    """
+    Assert raster with descending x- and ascending y-coordinates is aggregated correctly.
+    """
+    xs = np.arange(10)[::-1]
+    ys = np.arange(5)
+    arr = xs*ys[np.newaxis].T
+    xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
+    cvs = ds.Canvas(10, 5, x_range=(-.5, 9.5), y_range=(-.5, 4.5))
+    agg = cvs.raster(xarr)
+
+    assert np.allclose(agg.data, arr)
+    assert np.allclose(agg.X.values, xs)
+    assert np.allclose(agg.Y.values, ys)
+
+
 def test_resample_methods():
     """Assert that an error is raised when incorrect upsample and/or downsample
     methods are provided to cvs.raster().

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -68,14 +68,8 @@ def calc_res(raster):
     """Calculate the resolution of xarray.DataArray raster and return it as the
     two-tuple (xres, yres).
     """
-    if raster.ndim == 2:
-        h, w = raster.shape
-        ydim, xdim = raster.dims
-    elif raster.ndim == 3:
-        h, w = raster.shape[1:]
-        ydim, xdim = raster.dims[1:]
-    else:
-        raise ValueError("Could not determine dimensionality of the raster")
+    h, w = raster.shape[-2:]
+    ydim, xdim = raster.dims[-2:]
     xcoords = raster[xdim].values
     ycoords = raster[ydim].values
     xres = (xcoords[-1] - xcoords[0]) / (w - 1)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -160,7 +160,7 @@ def get_indices(x, y, xs, ys, res):
     return int(x_), int(y_)
 
 
-def orient_array(raster, res, band):
+def orient_array(raster, res, layer):
     """
     Reorients the array to a canonical orientation depending on
     whether the x and y-resolution values are positive or negative.
@@ -172,8 +172,8 @@ def orient_array(raster, res, band):
     res : tuple
         Two-tuple (int, int) which includes x and y resolutions (aka "grid/cell
         sizes"), respectively.
-    band : int
-        Index of the raster band to be reoriented (optional)
+    layer : int
+        Index of the raster layer to be reoriented (optional)
 
     Returns
     -------
@@ -185,7 +185,7 @@ def orient_array(raster, res, band):
         if res[0] < 0: array = array[:, ::-1]
         if res[1] > 0: array = array[::-1]
     else:
-        if band is not None: array = array[band-1]
+        if layer is not None: array = array[layer-1]
         if res[0] < 0: array = array[:, :, ::-1]
         if res[1] > 0: array = array[:, ::-1]
     return array

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -104,8 +104,8 @@ def calc_bbox(xs, ys, res):
         Two-tuple (int, int) which includes x and y resolutions (aka "grid/cell
         sizes"), respectively.
     """
-    ybound = ys.min() if res[1] < 0 else ys.max()
     xbound = xs.max() if res[0] < 0 else xs.min()
+    ybound = ys.min() if res[1] < 0 else ys.max()
 
     xmin = ymin = np.inf
     xmax = ymax = -np.inf
@@ -114,18 +114,12 @@ def calc_bbox(xs, ys, res):
                    [0.,      0.,      1.]])
     for x_, y_ in [(0, 0), (0, len(ys)), (len(xs), 0), (len(xs), len(ys))]:
         x, y, _ = np.dot(Ab, np.array([x_, y_, 1.]))
-        if x < xmin:
-            xmin = x
-        if x > xmax:
-            xmax = x
-        if y < ymin:
-            ymin = y
-        if y > ymax:
-            ymax = y
-    xpad, ypad = abs(res[0])/2., abs(res[1])/2.
-    if res[0] < 0 and res[1] > 0:
-        xpad, ypad = -xpad, -ypad
-    return xmin-xpad, ymin-ypad, xmax-xpad, ymax-ypad
+        if x < xmin: xmin = x
+        if x > xmax: xmax = x
+        if y < ymin: ymin = y
+        if y > ymax: ymax = y
+    xpad, ypad = res[0]/2., res[1]/2.
+    return xmin-xpad, ymin+ypad, xmax-xpad, ymax+ypad
 
 
 def get_indices(x, y, xs, ys, res):

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -38,7 +38,7 @@ dependencies:
  - shapely
  - statsmodels
  - tblib
- - xarray>=0.9.6 # For xarray.open_rasterio()
+ - gbrener::xarray>=0.9.6 # For xarray.open_rasterio()
  - yaml
  - fastparquet
 #- fastcache # Only required for Python2, for the dashboard/


### PR DESCRIPTION
Fixe for issues mentioned in https://github.com/bokeh/datashader/issues/380

Handles several issues:

* Handles ascending/descending x-/y-coordinates correctly (assuming they are always aligned at the center)
* Handles both 2D and 3D arrays assuming that the last two DataArray.dims are the y- and x-axis respectively
* Handles non rasterio input without ``xarr._file_data.nodata`` metadata.
* Adds coordinates to returned DataArray
* Keeps coordinate names

Further issues:

*  ~~Still always assumes bin edges as both input and output~~
* ~~Does not address issue slicing the input image according to the canvas x_range and y_range~~

You can find a notebook with further details here: https://anaconda.org/philippjfr/regridding/notebook