### PR TITLE
Add slicing based on canvas bounds

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -264,8 +264,8 @@ class Canvas(object):
         w = int(np.ceil(self.plot_width * width_ratio))
         h = int(np.ceil(self.plot_height * height_ratio))
 
-        rmin, cmin = get_indices(xmin, ymin, source.x.values, source.y.values, res)
-        rmax, cmax = get_indices(xmax, ymax, source.x.values, source.y.values, res)
+        cmin, rmin = get_indices(xmin, ymin, source.x.values, source.y.values, res)
+        cmax, rmax = get_indices(xmax, ymax, source.x.values, source.y.values, res)
         source_window = source[:, rmin:rmax, cmin:cmax]
 
         data = resample_2d(source_window.values[0].astype(np.float32),

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -75,9 +75,9 @@ def calc_res(raster):
 
 def calc_bbox(xs, ys, res):
     """Calculate the bounding-box of a raster, and return it in a four-element
-    tuple: (xmin, ymin, xmax, ymax). This assumes a flat-earth crs to do an
-    Affine transformation with the "Augmented Matrix" approach (does not handle
-    reprojections):
+    tuple: (xmin, ymin, xmax, ymax). This assumes a flat-earth coordinate 
+    reference system, to do an affine transformation with the
+    "Augmented Matrix" approach (does not handle reprojections):
     https://en.wikipedia.org/wiki/Affine_transformation#Augmented_matrix
     
     Parameters
@@ -114,10 +114,10 @@ def calc_bbox(xs, ys, res):
 
 def get_indices(x, y, xs, ys, res):
     """Return indices corresponding to transformed coordinates (x, y).
-    This assumes that a flat-earth crs to perform an inverse Affine
-    transformation, as described here:
-    https://en.wikipedia.org/wiki/Affine_transformation#Groups
-    It also assumes that the Affine transformation matrix is invertible.
+    This assumes that a flat-earth coordinate reference system, to
+    perform an inverse affine transformation, as described here:
+    https://en.wikipedia.org/wiki/Affine_transformation#Groups 
+    It also assumes that the affine transformation matrix is invertible.
     
     Parameters
     ----------
@@ -147,8 +147,8 @@ def get_indices(x, y, xs, ys, res):
     A_ = np.vstack([A_inv, np.zeros(A_inv.shape[1])])
     neg__Ainv__dot__b = -np.dot(A_inv, b)
     b_ = np.hstack([neg__Ainv__dot__b, [1]]).reshape(neg__Ainv__dot__b.shape[0]+1, 1)
-    Affine_inv = np.hstack([A_, b_])
-    x_, y_, _ = np.dot(Affine_inv, np.array([x, y, 1.]))
+    affine_inv = np.hstack([A_, b_])
+    x_, y_, _ = np.dot(affine_inv, np.array([x, y, 1.]))
     return int(x_), int(y_)
 
 

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -73,11 +73,10 @@ def calc_res(raster):
     yres = (raster.y.values[0] - raster.y.values[h-1]) / (h - 1)
     return xres, yres
 
-
 def calc_bbox(xs, ys, res):
     """Calculate the bounding-box of a raster, and return it in a four-element
     tuple: (xmin, ymin, xmax, ymax). This assumes a flat-earth crs to do an
-    affine transformation with the "Augmented Matrix" approach (does not handle
+    Affine transformation with the "Augmented Matrix" approach (does not handle
     reprojections):
     https://en.wikipedia.org/wiki/Affine_transformation#Augmented_matrix
     
@@ -111,6 +110,46 @@ def calc_bbox(xs, ys, res):
         if y > ymax:
             ymax = y
     return xmin, ymin, xmax, ymax
+
+
+def get_indices(x, y, xs, ys, res):
+    """Return indices corresponding to transformed coordinates (x, y).
+    This assumes that a flat-earth crs to perform an inverse Affine
+    transformation, as described here:
+    https://en.wikipedia.org/wiki/Affine_transformation#Groups
+    It also assumes that the Affine transformation matrix is invertible.
+    
+    Parameters
+    ----------
+    x : float
+        x-coordinate of the transformed point.
+    y : float
+        y-coordinate of the transformed point.
+    xs : numpy.array
+        1D NumPy array of floats representing the x-values of a raster. This
+        likely originated from an xarray.DataArray or xarray.Dataset object
+        (xr.open_rasterio).
+    ys : numpy.array
+        1D NumPy array of floats representing the y-values of a raster. This
+        likely originated from an xarray.DataArray or xarray.Dataset object
+        (xr.open_rasterio).
+    res : tuple
+        Two-tuple (int, int) which includes x and y resolutions (aka "grid/cell
+        sizes"), respectively.
+    """
+    Ab = np.array([[res[0], 0.,      xs.min()],
+                   [0.,     -res[1], ys.max()],
+                   [0.,     0.,      1.]])
+    nrows, ncols = Ab.shape
+    A = Ab[:nrows-1, :ncols-1]
+    b = Ab[:, ncols-1][:nrows-1]
+    A_inv = np.linalg.inv(A)
+    A_ = np.vstack([A_inv, np.zeros(A_inv.shape[1])])
+    neg__Ainv__dot__b = -np.dot(A_inv, b)
+    b_ = np.hstack([neg__Ainv__dot__b, [1]]).reshape(neg__Ainv__dot__b.shape[0]+1, 1)
+    Affine_inv = np.hstack([A_, b_])
+    x_, y_, _ = np.dot(Affine_inv, np.array([x, y, 1.]))
+    return int(x_), int(y_)
 
 
 def downsample_aggregate(aggregate, factor, how='mean'):

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -74,10 +74,11 @@ def calc_res(raster):
     return xres, yres
 
 def calc_bbox(xs, ys, res):
-    """Calculate the bounding-box of a raster, and return it in a four-element
-    tuple: (xmin, ymin, xmax, ymax). This assumes a flat-earth coordinate 
-    reference system, to do an affine transformation with the
-    "Augmented Matrix" approach (does not handle reprojections):
+    """Calculate the bounding box of a raster, and return it in a four-element
+    tuple: (xmin, ymin, xmax, ymax). This calculation assumes the raster is
+    uniformly sampled (equivalent to a flat-earth assumption, for geographic
+    data) so that an affine transform (using the "Augmented Matrix" approach) 
+    suffices:
     https://en.wikipedia.org/wiki/Affine_transformation#Augmented_matrix
     
     Parameters
@@ -114,10 +115,11 @@ def calc_bbox(xs, ys, res):
 
 def get_indices(x, y, xs, ys, res):
     """Return indices corresponding to transformed coordinates (x, y).
-    This assumes that a flat-earth coordinate reference system, to
-    perform an inverse affine transformation, as described here:
+    This calculation assumes the raster is uniformly sampled
+    (equivalent to a flat-earth assumption, for geographic data) with
+    an invertible affine transformation matrix, so that an inverse
+    affine transform can be used:
     https://en.wikipedia.org/wiki/Affine_transformation#Groups 
-    It also assumes that the affine transformation matrix is invertible.
     
     Parameters
     ----------


### PR DESCRIPTION
Add slicing for the source data array based on user-defined canvas boundaries. This should address the final bullet point in Issue #380 .