### PR TITLE
Travis: lint check Python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 
 script:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then py.test datashader --doctest-modules --doctest-ignore-import-errors --verbose; else py.test datashader --verbose; fi
+    - flake8 --ignore E,W datashader examples
     # lint checking of example notebooks (ugly)
     - for NB in examples/*.ipynb; do sed -e 's/"[ ]*%/"#%/' "$NB" > "${NB}~"; done && jupyter nbconvert examples/*.ipynb~ --to script --output-dir examples/lint && flake8 --ignore=E,W examples/lint/*.py
 

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -9,9 +9,9 @@ from .glyphs import Point                                # noqa (API import)
 from .pipeline import Pipeline                           # noqa (API import)
 from . import transfer_functions as tf                   # noqa (API import)
 
-from .pandas import *                        # noqa (build backend dispatch)
+from . import pandas                         # noqa (build backend dispatch)
 try:
-    from .dask import *                      # noqa (build backend dispatch)
+    from . import dask                       # noqa (build backend dispatch)
 except ImportError:
     pass
 

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -2,17 +2,16 @@ from __future__ import absolute_import
 
 __version__ = '0.6.0dev3'
 
-from .core import Canvas
-from .reductions import (count, any, sum, min, max, mean, std, var, count_cat,
-                         summary)
-from .glyphs import Point
-from .pipeline import Pipeline
-from . import transfer_functions as tf
+from .core import Canvas                                 # noqa (API import)
+from .reductions import (count, any, sum, min, max,      # noqa (API import)
+                         mean, std, var, count_cat, summary)
+from .glyphs import Point                                # noqa (API import)
+from .pipeline import Pipeline                           # noqa (API import)
+from . import transfer_functions as tf                   # noqa (API import)
 
-# Needed to build the backend dispatch
-from .pandas import *
+from .pandas import *                        # noqa (build backend dispatch)
 try:
-    from .dask import *
+    from .dask import *                      # noqa (build backend dispatch)
 except ImportError:
     pass
 

--- a/datashader/tests/test_compatibility.py
+++ b/datashader/tests/test_compatibility.py
@@ -6,9 +6,8 @@ from datashader.compatibility import apply, _exec
 def test__exec():
     c = "def foo(a):\n    return bar(a) + 1"
     namespace = {'bar': lambda a: a + 1}
-    # Define a different local ``bar`` to ensure that names are pulled from
-    # namespace, not locals
-    bar = lambda a: a - 1
+    bar = lambda a: a - 1  # noqa (define a different local ``bar`` to ensure
+                           # that names are pulled from namespace, not locals)
     _exec(c, namespace)
     foo = namespace['foo']
     assert foo(1) == 3

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -7,8 +7,6 @@ import xarray as xr
 
 import datashader as ds
 
-import pytest
-
 set_options(get=get_sync)
 
 df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -4,7 +4,6 @@ import xarray as xr
 
 import datashader as ds
 
-import pytest
 
 
 df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -53,7 +53,7 @@ def test_out_of_bounds_return_correct_size():
                         x_range=[1e10, 1e20],
                         y_range=[1e10, 1e20])
         try:
-            agg = cvs.raster(src)
+            cvs.raster(src)
         except ValueError:
             pass
         else:
@@ -104,21 +104,21 @@ def test_resample_methods():
     """
     with xr.open_rasterio(TEST_RASTER_PATH) as src:
         try:
-            agg = cvs.raster(src, upsample_method='santaclaus', downsample_method='toothfairy')
+            cvs.raster(src, upsample_method='santaclaus', downsample_method='toothfairy')
         except ValueError:
             pass
         else:
             assert False
 
         try:
-            agg = cvs.raster(src, upsample_method='honestlawyer')
+            cvs.raster(src, upsample_method='honestlawyer')
         except ValueError:
             pass
         else:
             assert False
 
         try:
-            agg = cvs.raster(src, downsample_method='tenantfriendlylease')
+            cvs.raster(src, downsample_method='tenantfriendlylease')
         except ValueError:
             pass
         else:

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-import warnings
 from collections import Iterator
 from io import BytesIO
 

--- a/examples/download_sample_data.py
+++ b/examples/download_sample_data.py
@@ -28,7 +28,6 @@ from collections import OrderedDict
 from os import path
 import glob
 import os
-import subprocess
 import sys
 import tarfile
 import time
@@ -229,7 +228,7 @@ def _process_dataset(dataset, output_dir, here):
     if not path.exists(output_dir):
         os.makedirs(output_dir)
 
-    with DirectoryContext(output_dir) as d:
+    with DirectoryContext(output_dir):
         requires_download = False
         for f in dataset.get('files', []):
             if not path.exists(f):
@@ -268,7 +267,7 @@ def _process_dataset(dataset, output_dir, here):
 
 def main():
     '''Download each dataset specified by datasets.yml in this directory'''
-    here = contrib_dir = path.abspath(path.join(path.split(__file__)[0]))
+    here = path.abspath(path.join(path.split(__file__)[0]))
     info_file = path.join(here, 'datasets.yml')
     with open(info_file) as f:
         info = ordered_load(f.read())

--- a/examples/filetimes.py
+++ b/examples/filetimes.py
@@ -11,14 +11,13 @@ Test files may be generated starting from any file format supported by Pandas:
 import time
 global_start = time.time()
 
-import io, os, os.path, sys, shutil, glob, argparse, resource, multiprocessing
+import os, os.path, sys, glob, argparse, resource, multiprocessing
 import pandas as pd
 import dask.dataframe as dd
 import numpy as np
 import datashader as ds
 import bcolz
 import feather
-import dask
 import fastparquet as fp
 
 from datashader.utils import export_image


### PR DESCRIPTION
Not sure if lint checking the python code is something we want to do because we'd need to suppress various deliberate things.

Anyway, this PR shows the list of things flake8 complains about, so we could decide either it's worth it to fix/suppress those things, or otherwise close this PR and ignore.

From the output of ``flake8 --ignore E,W datashader examples`` on travis:

```
datashader/__init__.py:5:1: F401 '.core.Canvas' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.count' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.any' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.sum' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.min' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.max' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.mean' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.std' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.var' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.count_cat' imported but unused
datashader/__init__.py:6:1: F401 '.reductions.summary' imported but unused
datashader/__init__.py:8:1: F401 '.glyphs.Point' imported but unused
datashader/__init__.py:9:1: F401 '.pipeline.Pipeline' imported but unused
datashader/__init__.py:10:1: F401 '.transfer_functions as tf' imported but unused
datashader/__init__.py:13:1: F403 'from .pandas import *' used; unable to detect undefined names
datashader/__init__.py:15:5: F403 'from .dask import *' used; unable to detect undefined names
datashader/__init__.py:40:32: F405 '__path__' may be undefined, or defined from star imports: .dask, .pandas
datashader/__init__.py:41:32: F405 '__path__' may be undefined, or defined from star imports: .dask, .pandas
datashader/tests/test_compatibility.py:11:5: F841 local variable 'bar' is assigned to but never used
datashader/tests/test_raster.py:56:13: F841 local variable 'agg' is assigned to but never used
datashader/tests/test_raster.py:121:13: F841 local variable 'agg' is assigned to but never used
examples/download_sample_data.py:31:1: F401 'subprocess' imported but unused
examples/download_sample_data.py:232:42: F841 local variable 'd' is assigned to but never used
examples/download_sample_data.py:271:12: F841 local variable 'contrib_dir' is assigned to but never used
```