### PR TITLE
Fix conversion from graph to sparse matrix

### DIFF
--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -98,14 +98,20 @@ def _extract_points_from_nodes(nodes):
     return points
 
 
-def _convert_edges_to_sparse_matrix(edges):
-    if 'weight' in edges:
-        weights = edges['weight']
-    else:
-        weights = np.ones(len(edges))
+def _convert_graph_to_sparse_matrix(nodes, edges, dtype=None, format='csr'):
+    nlen = len(nodes)
+    index = dict(zip(nodes['id'].values, range(nlen)))
 
-    A = sp.sparse.coo_matrix((weights, (edges['source'], edges['target'])))
-    return A.tolil()
+    if 'weight' not in edges:
+        edges = edges.copy()
+        edges['weight'] = np.ones(len(edges))
+
+    rows, cols, data = zip(*((index[src], index[dst], weight)
+                             for src, dst, weight in [tuple(edge) for edge in edges.values]
+                             if src in index and dst in index))
+
+    M = sp.sparse.coo_matrix((data, (rows, cols)), shape=(nlen, nlen), dtype=dtype)
+    return M.asformat(format)
 
 
 def _merge_points_with_nodes(nodes, points):
@@ -132,7 +138,7 @@ def cooling(matrix, points, temperature, params):
             distance = np.where(distance < 0.01, 0.01, distance)
 
             # the adjacency matrix row
-            ai = np.asarray(matrix.getrowview(i).toarray())
+            ai = matrix[i].toarray()
 
             # displacement "force"
             dist = params.k * params.k / distance ** 2
@@ -197,7 +203,7 @@ class forceatlas2_layout(LayoutAlgorithm):
 
         # Convert graph into sparse adjacency matrix and array of points
         points = _extract_points_from_nodes(nodes)
-        matrix = _convert_edges_to_sparse_matrix(edges)
+        matrix = _convert_graph_to_sparse_matrix(nodes, edges)
 
         if p.k is None:
             p.k = np.sqrt(1.0 / len(points))

--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -100,7 +100,10 @@ def _extract_points_from_nodes(nodes):
 
 def _convert_graph_to_sparse_matrix(nodes, edges, dtype=None, format='csr'):
     nlen = len(nodes)
-    index = dict(zip(nodes['id'].values, range(nlen)))
+    if 'id' in nodes:
+        index = dict(zip(nodes['id'].values, range(nlen)))
+    else:
+        index = dict(zip(nodes.index.values, range(nlen)))
 
     if 'weight' not in edges:
         edges = edges.copy()

--- a/datashader/tests/test_layout.py
+++ b/datashader/tests/test_layout.py
@@ -45,12 +45,14 @@ def weighted_edges():
 
 def test_forceatlas2_positioned_nodes_with_unweighted_edges(nodes, edges):
     df = forceatlas2_layout(nodes, edges)
-    assert df.equals(nodes)
+    assert len(nodes) == len(df)
+    assert not df.equals(nodes)
 
 
 def test_forceatlas2_positioned_nodes_with_weighted_edges(nodes, weighted_edges):
     df = forceatlas2_layout(nodes, weighted_edges)
-    assert df.equals(nodes)
+    assert len(nodes) == len(df)
+    assert not df.equals(nodes)
 
 
 def test_forceatlas2_unpositioned_nodes_with_unweighted_edges(nodes_without_positions, edges):


### PR DESCRIPTION
When converting to a sparse matrix, if the nodes dataframe has IDs with high integer values, the generated sparse matrix would take on a shape with a range of (0, max), where max is the highest node ID. This would cause high memory usage even if only a relatively few nodes existed.

Fixes #417