### PR TITLE
Ensure DataArray retains specified column names

### DIFF
--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -68,7 +68,7 @@ def default(glyph, df, schema, canvas, summary):
     keys2 = [(name, i) for i in range(len(keys))]
     dsk = dict((k2, (chunk, k)) for (k2, k) in zip(keys2, keys))
     dsk[name] = (apply, finalize, [(combine, keys2)],
-                 dict(coords=axis, dims=['y_axis', 'x_axis']))
+                 dict(coords=axis, dims=[glyph.y, glyph.x]))
     return dsk, name
 
 
@@ -99,5 +99,5 @@ def line(glyph, df, schema, canvas, summary):
         dsk[(name, i)] = (chunk, (old_name, i - 1), (old_name, i))
     keys2 = [(name, i) for i in range(df.npartitions)]
     dsk[name] = (apply, finalize, [(combine, keys2)],
-                 dict(coords=axis, dims=['y_axis', 'x_axis']))
+                 dict(coords=axis, dims=[glyph.y, glyph.x]))
     return dsk, name

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -29,4 +29,4 @@ def pandas_pipeline(df, schema, canvas, glyph, summary):
     bases = create((height, width))
     extend(bases, df, x_st + y_st, x_range + y_range)
 
-    return finalize(bases, coords=[y_axis, x_axis], dims=['y_axis', 'x_axis'])
+    return finalize(bases, coords=[y_axis, x_axis], dims=[glyph.y, glyph.x])

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -34,7 +34,7 @@ c_logxy = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 11),
                     y_range=(1, 11), x_axis_type='log', y_axis_type='log')
 
 coords = [np.arange(2, dtype='f8')+0.5, np.arange(2, dtype='f8')+0.5]
-dims = ['y_axis', 'x_axis']
+dims = ['y', 'x']
 
 
 def assert_eq(agg, b):
@@ -160,13 +160,13 @@ def test_log_axis_points():
     logcoords = 10**((px-t)/s)
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
     out = xr.DataArray(sol, coords=[np.array([0.5, 1.5]), logcoords],
-                       dims=dims)
+                       dims=['y', 'log_x'])
     assert_eq(c_logx.points(ddf, 'log_x', 'y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, np.array([0.5, 1.5])],
-                       dims=dims)
+                       dims=['log_y', 'x'])
     assert_eq(c_logy.points(ddf, 'x', 'log_y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, logcoords],
-                       dims=dims)
+                       dims=['log_y', 'log_x'])
     assert_eq(c_logxy.points(ddf, 'log_x', 'log_y', ds.count('i32')), out)
 
 
@@ -185,7 +185,7 @@ def test_line():
                     [0, 2, 0, 0, 0, 1, 0],
                     [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
     out = xr.DataArray(sol, coords=[np.arange(-3., 4.)+0.5, np.arange(-3., 4.)+0.5],
-                       dims=['y_axis', 'x_axis'])
+                       dims=['y', 'x'])
     assert_eq(agg, out)
 
 
@@ -198,11 +198,11 @@ def test_log_axis_line():
     logcoords = 10**((px-t)/s)
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
     out = xr.DataArray(sol, coords=[np.array([0.5, 1.5]), logcoords],
-                       dims=dims)
+                       dims=['y', 'log_x'])
     assert_eq(c_logx.line(ddf, 'log_x', 'y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, np.array([0.5, 1.5])],
-                       dims=dims)
+                       dims=['log_y', 'x'])
     assert_eq(c_logy.line(ddf, 'x', 'log_y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, logcoords],
-                       dims=dims)
+                       dims=['log_y', 'log_x'])
     assert_eq(c_logxy.line(ddf, 'log_x', 'log_y', ds.count('i32')), out)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -29,7 +29,7 @@ c_logxy = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 11),
                     y_range=(1, 11), x_axis_type='log', y_axis_type='log')
 
 coords = [np.arange(2, dtype='f8')+0.5, np.arange(2, dtype='f8')+0.5]
-dims = ['y_axis', 'x_axis']
+dims = ['y', 'x']
 
 
 def assert_eq(agg, b):
@@ -155,13 +155,13 @@ def test_log_axis_points():
     logcoords = 10**((px-t)/s)
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
     out = xr.DataArray(sol, coords=[np.array([0.5, 1.5]), logcoords],
-                       dims=dims)
+                       dims=['y', 'log_x'])
     assert_eq(c_logx.points(df, 'log_x', 'y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, np.array([0.5, 1.5])],
-                       dims=dims)
+                       dims=['log_y', 'x'])
     assert_eq(c_logy.points(df, 'x', 'log_y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, logcoords],
-                       dims=dims)
+                       dims=['log_y', 'log_x'])
     assert_eq(c_logxy.points(df, 'log_x', 'log_y', ds.count('i32')), out)
 
 
@@ -179,7 +179,7 @@ def test_line():
                     [0, 2, 0, 0, 0, 1, 0],
                     [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
     out = xr.DataArray(sol, coords=[np.arange(-3., 4.)+0.5, np.arange(-3., 4.)+0.5],
-                       dims=['y_axis', 'x_axis'])
+                       dims=['y', 'x'])
     assert_eq(agg, out)
 
 
@@ -192,11 +192,11 @@ def test_log_axis_line():
     logcoords = 10**((px-t)/s)
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
     out = xr.DataArray(sol, coords=[np.array([0.5, 1.5]), logcoords],
-                       dims=dims)
+                       dims=['y', 'log_x'])
     assert_eq(c_logx.line(df, 'log_x', 'y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, np.array([0.5, 1.5])],
-                       dims=dims)
+                       dims=['log_y', 'x'])
     assert_eq(c_logy.line(df, 'x', 'log_y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, logcoords],
-                       dims=dims)
+                       dims=['log_y', 'log_x'])
     assert_eq(c_logxy.line(df, 'log_x', 'log_y', ds.count('i32')), out)


### PR DESCRIPTION
Follows on from #422 and should wait until that PR is merged. This PR simply ensures that the specified x and y column labels are inherited by the xarray DataArray returned by the canvas.points and canvas.points methods.