### PR TITLE
Parameterized resampling

### DIFF
--- a/datashader/_resampling.py
+++ b/datashader/_resampling.py
@@ -4,13 +4,144 @@ interface and documentation.
 """
 from __future__ import absolute_import, division
 
+# Differences from gridtools.resampling:
+#
+# * removed upsample_2d, downsample_2d, resample_2d interface fns
+#
+# * removed _resample_2d (why was that jit'd?) - should test
+#   performance now
+#
+# * ngjit rather than jit
+#
+# * swapped parameters of _downsample_2d() around to allow rank to be
+#   optional and added assertion that rank >= 1 in _downsample_2d (and
+#   renamed mode_rank to rank)
+#
+# * _get_out(), _get_mask(), _mask_or_not(), _get_fill_value() moved
+#   out to resampling.py
+
 import numpy as np
 
 from .utils import ngjit
 
+#: Interpolation method for upsampling: Take nearest source grid cell, even if it is invalid.
+US_NEAREST = 10
+#: Interpolation method for upsampling: Bi-linear interpolation between the 4 nearest source grid cells.
+US_LINEAR = 11
+
+#: Aggregation method for downsampling: Take first valid source grid cell, ignore contribution areas.
+DS_FIRST = 50
+#: Aggregation method for downsampling: Take last valid source grid cell, ignore contribution areas.
+DS_LAST = 51
+# DS_MIN = 52
+# DS_MAX = 53
+#: Aggregation method for downsampling: Compute average of all valid source grid cells,
+#: with weights given by contribution area.
+DS_MEAN = 54
+# DS_MEDIAN = 55
+#: Aggregation method for downsampling: Compute most frequently seen valid source grid cell,
+#: with frequency given by contribution area. Note that this mode can use an additional keyword argument
+#: *mode_rank* which can be used to generate the n-th mode. See :py:function:`downsample_2d`.
+DS_MODE = 56
+#: Aggregation method for downsampling: Compute the biased weighted estimator of variance
+#: (see https://en.wikipedia.org/wiki/Mean_square_weighted_deviation), with weights given by contribution area.
+DS_VAR = 57
+#: Aggregation method for downsampling: Compute the corresponding standard deviation to the biased weighted estimator
+#: of variance
+#: (see https://en.wikipedia.org/wiki/Mean_square_weighted_deviation), with weights given by contribution area.
+DS_STD = 58
+
+
 _EPS = 1e-10
 
-# TODO: haven't properly dealt with rank yet; default of -1 should not be left.
+@ngjit
+def _upsample_2d(src, mask, use_mask, method, fill_value, out):
+    src_w = src.shape[-1]
+    src_h = src.shape[-2]
+    out_w = out.shape[-1]
+    out_h = out.shape[-2]
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w < src_w or out_h < src_h:
+        raise ValueError("invalid target size")
+
+    if method == US_NEAREST:
+        scale_x = src_w / out_w
+        scale_y = src_h / out_h
+        for out_y in range(out_h):
+            src_y = int(scale_y * out_y)
+            for out_x in range(out_w):
+                src_x = int(scale_x * out_x)
+                value = src[src_y, src_x]
+                if np.isfinite(value) and not (use_mask and mask[src_y, src_x]):
+                    out[out_y, out_x] = value
+                else:
+                    out[out_y, out_x] = fill_value
+
+    elif method == US_LINEAR:
+        scale_x = (src_w - 1.0) / ((out_w - 1.0) if out_w > 1 else 1.0)
+        scale_y = (src_h - 1.0) / ((out_h - 1.0) if out_h > 1 else 1.0)
+        for out_y in range(out_h):
+            src_yf = scale_y * out_y
+            src_y0 = int(src_yf)
+            wy = src_yf - src_y0
+            src_y1 = src_y0 + 1
+            if src_y1 >= src_h:
+                src_y1 = src_y0
+            for out_x in range(out_w):
+                src_xf = scale_x * out_x
+                src_x0 = int(src_xf)
+                wx = src_xf - src_x0
+                src_x1 = src_x0 + 1
+                if src_x1 >= src_w:
+                    src_x1 = src_x0
+                v00 = src[src_y0, src_x0]
+                v01 = src[src_y0, src_x1]
+                v10 = src[src_y1, src_x0]
+                v11 = src[src_y1, src_x1]
+                if use_mask:
+                    v00_ok = np.isfinite(v00) and not mask[src_y0, src_x0]
+                    v01_ok = np.isfinite(v01) and not mask[src_y0, src_x1]
+                    v10_ok = np.isfinite(v10) and not mask[src_y1, src_x0]
+                    v11_ok = np.isfinite(v11) and not mask[src_y1, src_x1]
+                else:
+                    v00_ok = np.isfinite(v00)
+                    v01_ok = np.isfinite(v01)
+                    v10_ok = np.isfinite(v10)
+                    v11_ok = np.isfinite(v11)
+                if v00_ok and v01_ok and v10_ok and v11_ok:
+                    ok = True
+                    v0 = v00 + wx * (v01 - v00)
+                    v1 = v10 + wx * (v11 - v10)
+                    value = v0 + wy * (v1 - v0)
+                elif wx < 0.5:
+                    # NEAREST according to weight
+                    if wy < 0.5:
+                        ok = v00_ok
+                        value = v00
+                    else:
+                        ok = v10_ok
+                        value = v10
+                else:
+                    # NEAREST according to weight
+                    if wy < 0.5:
+                        ok = v01_ok
+                        value = v01
+                    else:
+                        ok = v11_ok
+                        value = v11
+                if ok:
+                    out[out_y, out_x] = value
+                else:
+                    out[out_y, out_x] = fill_value
+
+    else:
+        raise ValueError('invalid upsampling method')
+
+    return out
+
 @ngjit
 def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=-1):
     src_w = src.shape[-1]
@@ -27,7 +158,7 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=-1):
     scale_x = src_w / out_w
     scale_y = src_h / out_h
 
-    if method == 50 or method==51:
+    if method == DS_FIRST or method == DS_LAST:
         for out_y in range(out_h):
             src_yf0 = scale_y * out_y
             src_yf1 = src_yf0 + scale_y
@@ -49,14 +180,14 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=-1):
                         v = src[src_y, src_x]
                         if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
                             value = v
-                            if method == 50:    
+                            if method == DS_FIRST:    
                                 done = True
                                 break
                     if done:
                         break
                 out[out_y, out_x] = value
 
-    elif method == 56:
+    elif method == DS_MODE:
         if rank < 1:
             raise ValueError
         max_value_count = int(scale_x + 1) * int(scale_y + 1)
@@ -124,7 +255,7 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=-1):
 
                 out[out_y, out_x] = value
 
-    elif method == 54:
+    elif method == DS_MEAN:
         for out_y in range(out_h):
             src_yf0 = scale_y * out_y
             src_yf1 = src_yf0 + scale_y
@@ -163,7 +294,7 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=-1):
                 else:
                     out[out_y, out_x] = v_sum / w_sum
 
-    elif method == 57 or method == 58:
+    elif method == DS_VAR or method == DS_STD:
         for out_y in range(out_h):
             src_yf0 = scale_y * out_y
             src_yf1 = src_yf0 + scale_y
@@ -205,7 +336,7 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=-1):
                     out[out_y, out_x] = fill_value
                 else:
                     out[out_y, out_x] = (wvv_sum * w_sum - wv_sum * wv_sum) / w_sum / w_sum
-        if method == 58:
+        if method == DS_STD:
             out = np.sqrt(out)
     else:
         raise ValueError('invalid upsampling method')
@@ -214,92 +345,5 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=-1):
 
 
 
-@ngjit
-def _upsample_2d(src, mask, use_mask, method, fill_value, out):
-    src_w = src.shape[-1]
-    src_h = src.shape[-2]
-    out_w = out.shape[-1]
-    out_h = out.shape[-2]
-
-    if src_w == out_w and src_h == out_h:
-        return src
-
-    if out_w < src_w or out_h < src_h:
-        raise ValueError("invalid target size")
-
-    if method == 10:
-        scale_x = src_w / out_w
-        scale_y = src_h / out_h
-        for out_y in range(out_h):
-            src_y = int(scale_y * out_y)
-            for out_x in range(out_w):
-                src_x = int(scale_x * out_x)
-                value = src[src_y, src_x]
-                if np.isfinite(value) and not (use_mask and mask[src_y, src_x]):
-                    out[out_y, out_x] = value
-                else:
-                    out[out_y, out_x] = fill_value
-
-    elif method == 11:
-        scale_x = (src_w - 1.0) / ((out_w - 1.0) if out_w > 1 else 1.0)
-        scale_y = (src_h - 1.0) / ((out_h - 1.0) if out_h > 1 else 1.0)
-        for out_y in range(out_h):
-            src_yf = scale_y * out_y
-            src_y0 = int(src_yf)
-            wy = src_yf - src_y0
-            src_y1 = src_y0 + 1
-            if src_y1 >= src_h:
-                src_y1 = src_y0
-            for out_x in range(out_w):
-                src_xf = scale_x * out_x
-                src_x0 = int(src_xf)
-                wx = src_xf - src_x0
-                src_x1 = src_x0 + 1
-                if src_x1 >= src_w:
-                    src_x1 = src_x0
-                v00 = src[src_y0, src_x0]
-                v01 = src[src_y0, src_x1]
-                v10 = src[src_y1, src_x0]
-                v11 = src[src_y1, src_x1]
-                if use_mask:
-                    v00_ok = np.isfinite(v00) and not mask[src_y0, src_x0]
-                    v01_ok = np.isfinite(v01) and not mask[src_y0, src_x1]
-                    v10_ok = np.isfinite(v10) and not mask[src_y1, src_x0]
-                    v11_ok = np.isfinite(v11) and not mask[src_y1, src_x1]
-                else:
-                    v00_ok = np.isfinite(v00)
-                    v01_ok = np.isfinite(v01)
-                    v10_ok = np.isfinite(v10)
-                    v11_ok = np.isfinite(v11)
-                if v00_ok and v01_ok and v10_ok and v11_ok:
-                    ok = True
-                    v0 = v00 + wx * (v01 - v00)
-                    v1 = v10 + wx * (v11 - v10)
-                    value = v0 + wy * (v1 - v0)
-                elif wx < 0.5:
-                    # NEAREST according to weight
-                    if wy < 0.5:
-                        ok = v00_ok
-                        value = v00
-                    else:
-                        ok = v10_ok
-                        value = v10
-                else:
-                    # NEAREST according to weight
-                    if wy < 0.5:
-                        ok = v01_ok
-                        value = v01
-                    else:
-                        ok = v11_ok
-                        value = v11
-                if ok:
-                    out[out_y, out_x] = value
-                else:
-                    out[out_y, out_x] = fill_value
-
-    else:
-        raise ValueError('invalid upsampling method')
-
-    return out
 
     

--- a/datashader/_resampling.py
+++ b/datashader/_resampling.py
@@ -1,0 +1,305 @@
+"""
+Functions to provide resampling capabilities; see resampling.py for
+interface and documentation.
+"""
+from __future__ import absolute_import, division
+
+import numpy as np
+
+from .utils import ngjit
+
+_EPS = 1e-10
+
+# TODO: haven't properly dealt with rank yet; default of -1 should not be left.
+@ngjit
+def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=-1):
+    src_w = src.shape[-1]
+    src_h = src.shape[-2]
+    out_w = out.shape[-1]
+    out_h = out.shape[-2]
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w > src_w or out_h > src_h:
+        raise ValueError("invalid target size")
+
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+
+    if method == 50 or method==51:
+        for out_y in range(out_h):
+            src_yf0 = scale_y * out_y
+            src_yf1 = src_yf0 + scale_y
+            src_y0 = int(src_yf0)
+            src_y1 = int(src_yf1)
+            if src_y1 == src_yf1 and src_y1 > src_y0:
+                src_y1 -= 1
+            for out_x in range(out_w):
+                src_xf0 = scale_x * out_x
+                src_xf1 = src_xf0 + scale_x
+                src_x0 = int(src_xf0)
+                src_x1 = int(src_xf1)
+                if src_x1 == src_xf1 and src_x1 > src_x0:
+                    src_x1 -= 1
+                done = False
+                value = fill_value
+                for src_y in range(src_y0, src_y1 + 1):
+                    for src_x in range(src_x0, src_x1 + 1):
+                        v = src[src_y, src_x]
+                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                            value = v
+                            if method == 50:    
+                                done = True
+                                break
+                    if done:
+                        break
+                out[out_y, out_x] = value
+
+    elif method == 56:
+        if rank < 1:
+            raise ValueError
+        max_value_count = int(scale_x + 1) * int(scale_y + 1)
+        values = np.zeros((max_value_count,), dtype=src.dtype)
+        frequencies = np.zeros((max_value_count,), dtype=np.uint32)
+        for out_y in range(out_h):
+            src_yf0 = scale_y * out_y
+            src_yf1 = src_yf0 + scale_y
+            src_y0 = int(src_yf0)
+            src_y1 = int(src_yf1)
+            wy0 = 1.0 - (src_yf0 - src_y0)
+            wy1 = src_yf1 - src_y1
+            if wy1 < _EPS:
+                wy1 = 1.0
+                if src_y1 > src_y0:
+                    src_y1 -= 1
+            for out_x in range(out_w):
+                src_xf0 = scale_x * out_x
+                src_xf1 = src_xf0 + scale_x
+                src_x0 = int(src_xf0)
+                src_x1 = int(src_xf1)
+                wx0 = 1.0 - (src_xf0 - src_x0)
+                wx1 = src_xf1 - src_x1
+                if wx1 < _EPS:
+                    wx1 = 1.0
+                    if src_x1 > src_x0:
+                        src_x1 -= 1
+                value_count = 0
+                for src_y in range(src_y0, src_y1 + 1):
+                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                    for src_x in range(src_x0, src_x1 + 1):
+                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                        v = src[src_y, src_x]
+                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                            w = wx * wy
+                            found = False
+                            for i in range(value_count):
+                                if v == values[i]:
+                                    frequencies[i] += w
+                                    found = True
+                                    break
+                            if not found:
+                                values[value_count] = v
+                                frequencies[value_count] = w
+                                value_count += 1
+                w_max = -1.
+                value = fill_value
+                if rank == 1:
+                    for i in range(value_count):
+                        w = frequencies[i]
+                        if w > w_max:
+                            w_max = w
+                            value = values[i]
+                elif rank <= max_value_count:
+                    max_frequencies = np.full(rank, -1.0, dtype=np.float64)
+                    indices = np.zeros(rank, dtype=np.int64)
+                    for i in range(value_count):
+                        w = frequencies[i]
+                        for j in range(rank):
+                            if w > max_frequencies[j]:
+                                max_frequencies[j] = w
+                                indices[j] = i
+                                break
+                    value = values[indices[rank - 1]]
+
+                out[out_y, out_x] = value
+
+    elif method == 54:
+        for out_y in range(out_h):
+            src_yf0 = scale_y * out_y
+            src_yf1 = src_yf0 + scale_y
+            src_y0 = int(src_yf0)
+            src_y1 = int(src_yf1)
+            wy0 = 1.0 - (src_yf0 - src_y0)
+            wy1 = src_yf1 - src_y1
+            if wy1 < _EPS:
+                wy1 = 1.0
+                if src_y1 > src_y0:
+                    src_y1 -= 1
+            for out_x in range(out_w):
+                src_xf0 = scale_x * out_x
+                src_xf1 = src_xf0 + scale_x
+                src_x0 = int(src_xf0)
+                src_x1 = int(src_xf1)
+                wx0 = 1.0 - (src_xf0 - src_x0)
+                wx1 = src_xf1 - src_x1
+                if wx1 < _EPS:
+                    wx1 = 1.0
+                    if src_x1 > src_x0:
+                        src_x1 -= 1
+                v_sum = 0.0
+                w_sum = 0.0
+                for src_y in range(src_y0, src_y1 + 1):
+                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                    for src_x in range(src_x0, src_x1 + 1):
+                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                        v = src[src_y, src_x]
+                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                            w = wx * wy
+                            v_sum += w * v
+                            w_sum += w
+                if w_sum < _EPS:
+                    out[out_y, out_x] = fill_value
+                else:
+                    out[out_y, out_x] = v_sum / w_sum
+
+    elif method == 57 or method == 58:
+        for out_y in range(out_h):
+            src_yf0 = scale_y * out_y
+            src_yf1 = src_yf0 + scale_y
+            src_y0 = int(src_yf0)
+            src_y1 = int(src_yf1)
+            wy0 = 1.0 - (src_yf0 - src_y0)
+            wy1 = src_yf1 - src_y1
+            if wy1 < _EPS:
+                wy1 = 1.0
+                if src_y1 > src_y0:
+                    src_y1 -= 1
+            for out_x in range(out_w):
+                src_xf0 = scale_x * out_x
+                src_xf1 = src_xf0 + scale_x
+                src_x0 = int(src_xf0)
+                src_x1 = int(src_xf1)
+                wx0 = 1.0 - (src_xf0 - src_x0)
+                wx1 = src_xf1 - src_x1
+                if wx1 < _EPS:
+                    wx1 = 1.0
+                    if src_x1 > src_x0:
+                        src_x1 -= 1
+                v_sum = 0.0
+                w_sum = 0.0
+                wv_sum = 0.0
+                wvv_sum = 0.0
+                for src_y in range(src_y0, src_y1 + 1):
+                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                    for src_x in range(src_x0, src_x1 + 1):
+                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                        v = src[src_y, src_x]
+                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                            w = wx * wy
+                            v_sum += v
+                            w_sum += w
+                            wv_sum += w * v
+                            wvv_sum += w * v * v
+                if w_sum < _EPS:
+                    out[out_y, out_x] = fill_value
+                else:
+                    out[out_y, out_x] = (wvv_sum * w_sum - wv_sum * wv_sum) / w_sum / w_sum
+        if method == 58:
+            out = np.sqrt(out)
+    else:
+        raise ValueError('invalid upsampling method')
+
+    return out
+
+
+
+@ngjit
+def _upsample_2d(src, mask, use_mask, method, fill_value, out):
+    src_w = src.shape[-1]
+    src_h = src.shape[-2]
+    out_w = out.shape[-1]
+    out_h = out.shape[-2]
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w < src_w or out_h < src_h:
+        raise ValueError("invalid target size")
+
+    if method == 10:
+        scale_x = src_w / out_w
+        scale_y = src_h / out_h
+        for out_y in range(out_h):
+            src_y = int(scale_y * out_y)
+            for out_x in range(out_w):
+                src_x = int(scale_x * out_x)
+                value = src[src_y, src_x]
+                if np.isfinite(value) and not (use_mask and mask[src_y, src_x]):
+                    out[out_y, out_x] = value
+                else:
+                    out[out_y, out_x] = fill_value
+
+    elif method == 11:
+        scale_x = (src_w - 1.0) / ((out_w - 1.0) if out_w > 1 else 1.0)
+        scale_y = (src_h - 1.0) / ((out_h - 1.0) if out_h > 1 else 1.0)
+        for out_y in range(out_h):
+            src_yf = scale_y * out_y
+            src_y0 = int(src_yf)
+            wy = src_yf - src_y0
+            src_y1 = src_y0 + 1
+            if src_y1 >= src_h:
+                src_y1 = src_y0
+            for out_x in range(out_w):
+                src_xf = scale_x * out_x
+                src_x0 = int(src_xf)
+                wx = src_xf - src_x0
+                src_x1 = src_x0 + 1
+                if src_x1 >= src_w:
+                    src_x1 = src_x0
+                v00 = src[src_y0, src_x0]
+                v01 = src[src_y0, src_x1]
+                v10 = src[src_y1, src_x0]
+                v11 = src[src_y1, src_x1]
+                if use_mask:
+                    v00_ok = np.isfinite(v00) and not mask[src_y0, src_x0]
+                    v01_ok = np.isfinite(v01) and not mask[src_y0, src_x1]
+                    v10_ok = np.isfinite(v10) and not mask[src_y1, src_x0]
+                    v11_ok = np.isfinite(v11) and not mask[src_y1, src_x1]
+                else:
+                    v00_ok = np.isfinite(v00)
+                    v01_ok = np.isfinite(v01)
+                    v10_ok = np.isfinite(v10)
+                    v11_ok = np.isfinite(v11)
+                if v00_ok and v01_ok and v10_ok and v11_ok:
+                    ok = True
+                    v0 = v00 + wx * (v01 - v00)
+                    v1 = v10 + wx * (v11 - v10)
+                    value = v0 + wy * (v1 - v0)
+                elif wx < 0.5:
+                    # NEAREST according to weight
+                    if wy < 0.5:
+                        ok = v00_ok
+                        value = v00
+                    else:
+                        ok = v10_ok
+                        value = v10
+                else:
+                    # NEAREST according to weight
+                    if wy < 0.5:
+                        ok = v01_ok
+                        value = v01
+                    else:
+                        ok = v11_ok
+                        value = v11
+                if ok:
+                    out[out_y, out_x] = value
+                else:
+                    out[out_y, out_x] = fill_value
+
+    else:
+        raise ValueError('invalid upsampling method')
+
+    return out
+
+    

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -6,9 +6,7 @@ from odo import discover
 from xarray import DataArray
 
 from .utils import Dispatcher, ngjit, calc_res, calc_bbox, get_indices
-from .resampling import (resample_2d, US_NEAREST, US_LINEAR, DS_FIRST, DS_LAST,
-                         DS_MEAN, DS_MODE, DS_VAR, DS_STD)
-
+from .resampling import resample_2d, upsample_linear, downsample_mean
 
 
 class Expr(object):
@@ -205,8 +203,8 @@ class Canvas(object):
     def raster(self,
                source,
                band=1,
-               upsample_method='linear',
-               downsample_method='mean'):
+               upsample_method=upsample_linear,
+               downsample_method=downsample_mean):
         """Sample a raster dataset by canvas size and bounds. 
 
         Missing values (those having the value indicated by the
@@ -231,21 +229,6 @@ class Canvas(object):
         data : xarray.Dataset
 
         """
-        upsample_methods = dict(nearest=US_NEAREST,
-                                linear=US_LINEAR)
-
-        downsample_methods = dict(first=DS_FIRST,
-                                  last=DS_LAST,
-                                  mean=DS_MEAN,
-                                  mode=DS_MODE,
-                                  var=DS_VAR,
-                                  std=DS_STD)
-
-        if upsample_method not in upsample_methods.keys():
-            raise ValueError('Invalid upsample method: options include {}'.format(list(upsample_methods.keys())))
-        if downsample_method not in downsample_methods.keys():
-            raise ValueError('Invalid downsample method: options include {}'.format(list(downsample_methods.keys())))
-
         res = calc_res(source)
         left, bottom, right, top = calc_bbox(source.x.values, source.y.values, res)
 
@@ -270,8 +253,8 @@ class Canvas(object):
 
         data = resample_2d(source_window.values[0].astype(np.float32),
                            w, h,
-                           ds_method=downsample_methods[downsample_method],
-                           us_method=upsample_methods[upsample_method])
+                           ds_method=downsample_method,
+                           us_method=upsample_method)
 
         if w != self.plot_width or h != self.plot_height:
             num_height = self.plot_height - h

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -1,147 +1,127 @@
-from __future__ import absolute_import, division, print_function
+"""
+resample_2d(): resample 2D grid to a new resolution with options
+for up and downsampling (specified by Upsample and Downsample
+family of functions).
+"""
+
+from __future__ import absolute_import, division
 
 import numpy as np
 import param
-from .utils import ngjit
+from ._resampling import _upsample_2d, _downsample_2d
 
 #: Constant indicating an empty 2-D mask
 _NOMASK2D = np.ma.getmaskarray(np.ma.array([[0]], mask=[[0]]))
 
-_EPS = 1e-10
+class Sample2D(param.ParameterizedFunction):
+    """
+    Abstract base class for wrappers around underlying jit'd
+    _upsample_2d() and _downsample_2d().
 
-# TODO: tidy docstrings
-
-# wrappers around _upsample_2d()
-class UpsampleMethod(param.ParameterizedFunction):
+    Concrete subclasses should specify the _sampler and _method class
+    attribute to control the up/down sampling method employed (see
+    _up/downsample_2d).
+    """
     __abstract = True
-    method = None
-    def __call__(self,src,mask,use_mask,fill_value,out,**params):
-        #p = param.ParamOverrides(params)
-        return _upsample_2d(src,mask,use_mask,self.method,fill_value,out)
-
-class upsample_nearest(UpsampleMethod):
-    """Take nearest source grid cell, even if it is
-          invalid."""
-    # TODO: figure out what can be passed to jit'd fn 
-    #method = b"nearest" # TODO python 2
-    method = 1
-
-class upsample_linear(UpsampleMethod):
-    """Bi-linear interpolation between the 4 nearest
-          source grid cells."""
-    #method = b"linear"
-    method = 2
-
-
-# wrappers around _downsample_2d()
-class DownsampleMethod(param.ParameterizedFunction):
-    __abstract = True
-    method = None
-    def __call__(self,src,mask,use_mask,fill_value,out,**params):
-        p = param.ParamOverrides(self, params)
-        return _downsample_2d(src,mask,use_mask,self.method,fill_value,out,**p)
-
-class downsample_first(DownsampleMethod):
-    """Take first valid source grid cell, ignore contribution areas."""
-    #method = b"first"
-    method = 10
-
-class downsample_last(DownsampleMethod):
-    """Take last valid source grid cell, ignore contribution areas."""
-    #method = b"last"
-    method = 11
+    _sampler = None
+    _method = None    
     
-class downsample_mean(DownsampleMethod):
+    def __call__(self,src,mask,use_mask,fill_value,out,**params):
+        assert self._method is not None
+        assert self._sampler is not None
+        p = param.ParamOverrides(self, params)
+        # allow this fn to pass all its params to _sampler fn
+        # TODO: verify it's worked - are there actually any tests for
+        # the different sampling methods?
+        ##
+        # hack to be sorted out in param then removed from here:
+        # paramoverrides.get_param_values, basically
+        _x = dict(p._overridden.get_param_values()) 
+        _x.update(p)
+        del _x['name']
+        ##
+        return self._sampler(src,mask,use_mask,self._method,fill_value,out,**_x)
+
+
+class Upsample(Sample2D):
+    __abstract = True
+    _sampler = staticmethod(_upsample_2d)
+    
+class upsample_nearest(Upsample):
+    """Take nearest source grid cell, even if it is invalid."""
+    _method = 10
+
+class upsample_linear(Upsample):
+    """Bi-linear interpolation between the 4 nearest source grid cells."""
+    _method = 11
+
+
+class Downsample(Sample2D):
+    __abstract = True
+    _sampler = staticmethod(_downsample_2d)
+
+class downsample_first(Downsample):
+    """Take first valid source grid cell, ignore contribution areas."""
+    _method = 50
+
+class downsample_last(Downsample):
+    """Take last valid source grid cell, ignore contribution areas."""
+    _method = 51
+    
+class downsample_mean(Downsample):
     """
     Compute average of all valid source grid cells,
     with weights given by contribution area.
     """
-    method = 12
-    #method = b"mean"
+    _method = 54
         
-class downsample_mode(DownsampleMethod):
+class downsample_mode(Downsample):
     """
     Compute most frequently seen valid source grid cell, with
     frequency given by contribution area.
     """
-    #method = b"mode"
-    method = 13
+    _method = 56
     
     rank = param.Integer(default=1,bounds=(0,None),doc="""
-    can be used to generate the n-th mode
-    or
-    The rank of the frequency determined by the *ds_method* ``DS_MODE``. One (the default) means
-    most frequent value, zwo means second most frequent value, and so forth.""")
+        The rank of the frequency. One (the default) means most frequent
+        value, zwo means second most frequent value, and so forth.""")
     
-class downsample_var(DownsampleMethod):
+class downsample_var(Downsample):
     """
     Compute the biased weighted estimator of variance (see
     https://en.wikipedia.org/wiki/Mean_square_weighted_deviation),
     with weights given by contribution area.
     """
-    #method = b"var"
-    method = 14
+    _method = 57
     
-class downsample_std(DownsampleMethod):
+class downsample_std(Downsample):
     """
     Compute the corresponding standard deviation to the biased
     weighted estimator of variance (see
     https://en.wikipedia.org/wiki/Mean_square_weighted_deviation),
     with weights given by contribution area.
     """
-    #method = b"std"
-    method = 15
+    _method = 58
 
-
-# TODO: PR doc dropping upsample, downsample interfaces (but could
-# restore)
 
 class resample_2d(param.ParameterizedFunction):
     """
     Resample a 2-D grid to a new resolution.
     """
+    # TODO: rename to downsample_method or downsampler or something? (Same for us_method)
+    
     # TODO: or did I mean to use instances?
-    ds_method = param.ClassSelector(DownsampleMethod,default=downsample_mean,is_instance=False,doc="""
+    ds_method = param.ClassSelector(Downsample,default=downsample_mean,is_instance=False,doc="""
         grid cell aggregation method for a possible downsampling.""")
 
-    us_method = param.ClassSelector(UpsampleMethod,default=upsample_linear,is_instance=False,doc="""
+    us_method = param.ClassSelector(Upsample,default=upsample_linear,is_instance=False,doc="""
         Grid cell interpolation method for a possible upsampling""")
 
-    # :param fill_value: *scalar*, optional
     fill_value = param.Number(default=None, doc="""
-        If ``None``, it is taken from **src** if it is a masked array otherwise from *out* if it is a masked array, otherwise numpy's default value is used.""")
+        If ``None``, it is taken from **src** if it is a masked array
+        otherwise from *out* if it is a masked array, otherwise numpy's
+        default value is used.""")
     
-    # TODO: WIP, you are here - shrinking this down to put in __call__
-    @staticmethod
-    def _resample_2d(src, mask, use_mask, ds_method, us_method, fill_value, out):
-        src_w = src.shape[-1]
-        src_h = src.shape[-2]
-        out_w = out.shape[-1]
-        out_h = out.shape[-2]
-        
-        if out_w < src_w and out_h < src_h:
-            return ds_method(src, mask, use_mask, fill_value, out)
-        elif out_w < src_w:
-            if out_h > src_h:
-                temp = np.zeros((src_h, out_w), dtype=src.dtype)
-                temp = ds_method(src, mask, use_mask, fill_value, temp)
-                # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
-                return us_method(temp, mask, use_mask, fill_value, out)
-            else:
-                return ds_method(src, mask, use_mask, fill_value, out)
-        elif out_h < src_h:
-            if out_w > src_w:
-                temp = np.zeros((out_h, src_w), dtype=src.dtype)
-                temp = ds_method(src, mask, use_mask, fill_value, temp)
-                # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
-                return us_method(temp, mask, use_mask, fill_value, out)
-            else:
-                return ds_method(src, mask, use_mask, fill_value, out)
-        elif out_w > src_w or out_h > src_h:
-            return us_method(src, mask, use_mask, fill_value, out)
-        return src
-        
-
     def __call__(self, src, w, h, out=None, **params):
         """
         :param src: 2-D *ndarray*
@@ -150,9 +130,9 @@ class resample_2d(param.ParameterizedFunction):
         :param h:  *int*
             New grid height
         :param out: 2-D *ndarray*, optional
-            Alternate output array in which to place the result. The default is *None*; if provided, it must have the same
+            Alternate output array in which to place the result. The
+            default is *None*; if provided, it must have the same
             shape as the expected output.
-
         :return: An resampled version of the *src* array.
         """
         p = param.ParamOverrides(self,params)
@@ -160,12 +140,40 @@ class resample_2d(param.ParameterizedFunction):
         out = _get_out(out, src, (h, w))
         if out is None:
             return src
+        
         mask, use_mask = _get_mask(src)
         fill_value = _get_fill_value(p.fill_value, src, out)
-        
-        return _mask_or_not(
-            self._resample_2d(src, mask, use_mask, p.ds_method, p.us_method, fill_value, out),
-            src, fill_value)
+
+        src_w = src.shape[-1]
+        src_h = src.shape[-2]
+        out_w = out.shape[-1]
+        out_h = out.shape[-2]
+
+        # TODO: would be nice to simplify this...
+        if out_w < src_w and out_h < src_h:
+            resampled = p.ds_method(src, mask, use_mask, fill_value, out)
+        elif out_w < src_w:
+            if out_h > src_h:
+                temp = np.zeros((src_h, out_w), dtype=src.dtype)
+                temp = p.ds_method(src, mask, use_mask, fill_value, temp)
+                # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
+                resampled = p.us_method(temp, mask, use_mask, fill_value, out)
+            else:
+                resampled = p.ds_method(src, mask, use_mask, fill_value, out)
+        elif out_h < src_h:
+            if out_w > src_w:
+                temp = np.zeros((out_h, src_w), dtype=src.dtype)
+                temp = p.ds_method(src, mask, use_mask, fill_value, temp)
+                # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
+                resampled = p.us_method(temp, mask, use_mask, fill_value, out)
+            else:
+                resampled = p.ds_method(src, mask, use_mask, fill_value, out)
+        elif out_w > src_w or out_h > src_h:
+            resampled = p.us_method(src, mask, use_mask, fill_value, out)
+        else:
+            resampled = src
+ 
+        return _mask_or_not(resampled, src, fill_value)
     
 
 
@@ -211,302 +219,3 @@ def _get_fill_value(fill_value, src, out):
             fill_value = np.ma.array([0], mask=[False], dtype=src.dtype).fill_value
     return fill_value
     
-
-@ngjit
-def _upsample_2d(src, mask, use_mask, method, fill_value, out):
-    src_w = src.shape[-1]
-    src_h = src.shape[-2]
-    out_w = out.shape[-1]
-    out_h = out.shape[-2]
-
-    if src_w == out_w and src_h == out_h:
-        return src
-
-    if out_w < src_w or out_h < src_h:
-        raise ValueError("invalid target size")
-
-    #if method == upsample_nearest.method:
-    if method == 1:
-    #if method == b"nearest":
-        scale_x = src_w / out_w
-        scale_y = src_h / out_h
-        for out_y in range(out_h):
-            src_y = int(scale_y * out_y)
-            for out_x in range(out_w):
-                src_x = int(scale_x * out_x)
-                value = src[src_y, src_x]
-                if np.isfinite(value) and not (use_mask and mask[src_y, src_x]):
-                    out[out_y, out_x] = value
-                else:
-                    out[out_y, out_x] = fill_value
-
-    #elif method == upsample_linear.method:
-    elif method == 2:
-    #elif method == b"linear":
-        scale_x = (src_w - 1.0) / ((out_w - 1.0) if out_w > 1 else 1.0)
-        scale_y = (src_h - 1.0) / ((out_h - 1.0) if out_h > 1 else 1.0)
-        for out_y in range(out_h):
-            src_yf = scale_y * out_y
-            src_y0 = int(src_yf)
-            wy = src_yf - src_y0
-            src_y1 = src_y0 + 1
-            if src_y1 >= src_h:
-                src_y1 = src_y0
-            for out_x in range(out_w):
-                src_xf = scale_x * out_x
-                src_x0 = int(src_xf)
-                wx = src_xf - src_x0
-                src_x1 = src_x0 + 1
-                if src_x1 >= src_w:
-                    src_x1 = src_x0
-                v00 = src[src_y0, src_x0]
-                v01 = src[src_y0, src_x1]
-                v10 = src[src_y1, src_x0]
-                v11 = src[src_y1, src_x1]
-                if use_mask:
-                    v00_ok = np.isfinite(v00) and not mask[src_y0, src_x0]
-                    v01_ok = np.isfinite(v01) and not mask[src_y0, src_x1]
-                    v10_ok = np.isfinite(v10) and not mask[src_y1, src_x0]
-                    v11_ok = np.isfinite(v11) and not mask[src_y1, src_x1]
-                else:
-                    v00_ok = np.isfinite(v00)
-                    v01_ok = np.isfinite(v01)
-                    v10_ok = np.isfinite(v10)
-                    v11_ok = np.isfinite(v11)
-                if v00_ok and v01_ok and v10_ok and v11_ok:
-                    ok = True
-                    v0 = v00 + wx * (v01 - v00)
-                    v1 = v10 + wx * (v11 - v10)
-                    value = v0 + wy * (v1 - v0)
-                elif wx < 0.5:
-                    # NEAREST according to weight
-                    if wy < 0.5:
-                        ok = v00_ok
-                        value = v00
-                    else:
-                        ok = v10_ok
-                        value = v10
-                else:
-                    # NEAREST according to weight
-                    if wy < 0.5:
-                        ok = v01_ok
-                        value = v01
-                    else:
-                        ok = v11_ok
-                        value = v11
-                if ok:
-                    out[out_y, out_x] = value
-                else:
-                    out[out_y, out_x] = fill_value
-
-    else:
-        raise ValueError('invalid upsampling method')
-
-    return out
-
-    
-# TODO: haven't dealt with rank yet; default of 1 should not be left.
-
-@ngjit
-def _downsample_2d(src, mask, use_mask, method, fill_value, out, rank=1):
-    src_w = src.shape[-1]
-    src_h = src.shape[-2]
-    out_w = out.shape[-1]
-    out_h = out.shape[-2]
-
-    if src_w == out_w and src_h == out_h:
-        return src
-
-    if out_w > src_w or out_h > src_h:
-        raise ValueError("invalid target size")
-
-    scale_x = src_w / out_w
-    scale_y = src_h / out_h
-
-    #if method == b"first" or method==b"last":
-    if method == 10 or method==11:
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            if src_y1 == src_yf1 and src_y1 > src_y0:
-                src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                if src_x1 == src_xf1 and src_x1 > src_x0:
-                    src_x1 -= 1
-                done = False
-                value = fill_value
-                for src_y in range(src_y0, src_y1 + 1):
-                    for src_x in range(src_x0, src_x1 + 1):
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            value = v
-                            #if method == b"first":
-                            if method == 10:    
-                                done = True
-                                break
-                    if done:
-                        break
-                out[out_y, out_x] = value
-
-    elif method == 13: #b"mode":
-        max_value_count = int(scale_x + 1) * int(scale_y + 1)
-        values = np.zeros((max_value_count,), dtype=src.dtype)
-        frequencies = np.zeros((max_value_count,), dtype=np.uint32)
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            wy0 = 1.0 - (src_yf0 - src_y0)
-            wy1 = src_yf1 - src_y1
-            if wy1 < _EPS:
-                wy1 = 1.0
-                if src_y1 > src_y0:
-                    src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                wx0 = 1.0 - (src_xf0 - src_x0)
-                wx1 = src_xf1 - src_x1
-                if wx1 < _EPS:
-                    wx1 = 1.0
-                    if src_x1 > src_x0:
-                        src_x1 -= 1
-                value_count = 0
-                for src_y in range(src_y0, src_y1 + 1):
-                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
-                    for src_x in range(src_x0, src_x1 + 1):
-                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            w = wx * wy
-                            found = False
-                            for i in range(value_count):
-                                if v == values[i]:
-                                    frequencies[i] += w
-                                    found = True
-                                    break
-                            if not found:
-                                values[value_count] = v
-                                frequencies[value_count] = w
-                                value_count += 1
-                w_max = -1.
-                value = fill_value
-                if rank == 1:
-                    for i in range(value_count):
-                        w = frequencies[i]
-                        if w > w_max:
-                            w_max = w
-                            value = values[i]
-                elif rank <= max_value_count:
-                    max_frequencies = np.full(rank, -1.0, dtype=np.float64)
-                    indices = np.zeros(rank, dtype=np.int64)
-                    for i in range(value_count):
-                        w = frequencies[i]
-                        for j in range(rank):
-                            if w > max_frequencies[j]:
-                                max_frequencies[j] = w
-                                indices[j] = i
-                                break
-                    value = values[indices[rank - 1]]
-
-                out[out_y, out_x] = value
-
-    #elif method == b"mean":
-    elif method == 12:        
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            wy0 = 1.0 - (src_yf0 - src_y0)
-            wy1 = src_yf1 - src_y1
-            if wy1 < _EPS:
-                wy1 = 1.0
-                if src_y1 > src_y0:
-                    src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                wx0 = 1.0 - (src_xf0 - src_x0)
-                wx1 = src_xf1 - src_x1
-                if wx1 < _EPS:
-                    wx1 = 1.0
-                    if src_x1 > src_x0:
-                        src_x1 -= 1
-                v_sum = 0.0
-                w_sum = 0.0
-                for src_y in range(src_y0, src_y1 + 1):
-                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
-                    for src_x in range(src_x0, src_x1 + 1):
-                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            w = wx * wy
-                            v_sum += w * v
-                            w_sum += w
-                if w_sum < _EPS:
-                    out[out_y, out_x] = fill_value
-                else:
-                    out[out_y, out_x] = v_sum / w_sum
-
-    #elif method == b"var" or method == b"std":
-    elif method == 14 or method == 15:        
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            wy0 = 1.0 - (src_yf0 - src_y0)
-            wy1 = src_yf1 - src_y1
-            if wy1 < _EPS:
-                wy1 = 1.0
-                if src_y1 > src_y0:
-                    src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                wx0 = 1.0 - (src_xf0 - src_x0)
-                wx1 = src_xf1 - src_x1
-                if wx1 < _EPS:
-                    wx1 = 1.0
-                    if src_x1 > src_x0:
-                        src_x1 -= 1
-                v_sum = 0.0
-                w_sum = 0.0
-                wv_sum = 0.0
-                wvv_sum = 0.0
-                for src_y in range(src_y0, src_y1 + 1):
-                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
-                    for src_x in range(src_x0, src_x1 + 1):
-                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            w = wx * wy
-                            v_sum += v
-                            w_sum += w
-                            wv_sum += w * v
-                            wvv_sum += w * v * v
-                if w_sum < _EPS:
-                    out[out_y, out_x] = fill_value
-                else:
-                    out[out_y, out_x] = (wvv_sum * w_sum - wv_sum * wv_sum) / w_sum / w_sum
-        #if method == b"std":
-        if method == 15:                       
-            out = np.sqrt(out)
-    else:
-        raise ValueError('invalid upsampling method')
-
-    return out

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -8,7 +8,8 @@ from __future__ import absolute_import, division
 
 import numpy as np
 import param
-from ._resampling import _upsample_2d, _downsample_2d
+import ._resampling as gtr # gridtools.resampling
+
 
 #: Constant indicating an empty 2-D mask
 _NOMASK2D = np.ma.getmaskarray(np.ma.array([[0]], mask=[[0]]))
@@ -45,42 +46,42 @@ class Sample2D(param.ParameterizedFunction):
 
 class Upsample(Sample2D):
     __abstract = True
-    _sampler = staticmethod(_upsample_2d)
+    _sampler = staticmethod(gtr._upsample_2d)
     
 class upsample_nearest(Upsample):
     """Take nearest source grid cell, even if it is invalid."""
-    _method = 10
+    _method = gtr.US_NEAREST
 
 class upsample_linear(Upsample):
     """Bi-linear interpolation between the 4 nearest source grid cells."""
-    _method = 11
+    _method = gtr.US_LINEAR
 
 
 class Downsample(Sample2D):
     __abstract = True
-    _sampler = staticmethod(_downsample_2d)
+    _sampler = staticmethod(gtr._downsample_2d)
 
 class downsample_first(Downsample):
     """Take first valid source grid cell, ignore contribution areas."""
-    _method = 50
+    _method = gtr.DS_FIRST
 
 class downsample_last(Downsample):
     """Take last valid source grid cell, ignore contribution areas."""
-    _method = 51
+    _method = gtr.DS_LAST
     
 class downsample_mean(Downsample):
     """
     Compute average of all valid source grid cells,
     with weights given by contribution area.
     """
-    _method = 54
+    _method = gtr.DS_MEAN
         
 class downsample_mode(Downsample):
     """
     Compute most frequently seen valid source grid cell, with
     frequency given by contribution area.
     """
-    _method = 56
+    _method = gtr.DS_MODE
     
     rank = param.Integer(default=1,bounds=(0,None),doc="""
         The rank of the frequency. One (the default) means most frequent
@@ -92,7 +93,7 @@ class downsample_var(Downsample):
     https://en.wikipedia.org/wiki/Mean_square_weighted_deviation),
     with weights given by contribution area.
     """
-    _method = 57
+    _method = gtr.DS_VAR
     
 class downsample_std(Downsample):
     """
@@ -101,7 +102,7 @@ class downsample_std(Downsample):
     https://en.wikipedia.org/wiki/Mean_square_weighted_deviation),
     with weights given by contribution area.
     """
-    _method = 58
+    _method = gtr.DS_STD
 
 
 class resample_2d(param.ParameterizedFunction):

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -98,6 +98,7 @@ def test_calc_bbox():
     assert np.allclose(xr_bounds, rio_bounds)
 
 
+# TODO: test can be removed (effectively it's been moved to param)
 def test_resample_methods():
     """Assert that an error is raised when incorrect upsample and/or downsample
     methods are provided to cvs.raster().
@@ -105,21 +106,24 @@ def test_resample_methods():
     with xr.open_rasterio(TEST_RASTER_PATH) as src:
         try:
             agg = cvs.raster(src, upsample_method='santaclaus', downsample_method='toothfairy')
-        except ValueError:
+        except:
             pass
         else:
             assert False
 
-        try:
-            agg = cvs.raster(src, upsample_method='honestlawyer')
-        except ValueError:
-            pass
-        else:
-            assert False
+        # confusing test because with the current test raster I think no upsample will be attempted...
+        #try:
+        #    agg = cvs.raster(src, upsample_method='honestlawyer')
+        #    print(src)
+        #    print(agg)
+        #except:
+        #    pass
+        #else:
+        #    assert False
 
         try:
             agg = cvs.raster(src, downsample_method='tenantfriendlylease')
-        except ValueError:
+        except:
             pass
         else:
             assert False


### PR DESCRIPTION
I've opened this PR just so it's visible, since my progress has stalled. The PR is not ready for merging yet.

I discovered that the resampling comes from https://github.com/CAB-LAB/gridtools after I had already begun refactoring, but I've put back as much of gridtools.resampling as was trivially possible into _resampling.py and made a note of differences (e.g. different jit decorator, plus changes I made). I could put more back in and leave only an interface to _resampling.py in resampling.py, but I'd already done some refactoring by the time I realized. 

So, need to decide whether to continue to keep a copy of gridtools' resampling, or instead to import resampling from gridtools or maybe from a fork of gridtools. gridtools has dependencies on numpy and numba. It has tests. It has a recipe for a conda package. The conda package is at https://anaconda.org/forman/gridtools (no os x package on that channel). But if you already have datashader's dependencies you could just pip install gridtools anyway (from github release). 

I think there are other changes/improvements planned to resampling in datashader, and I don't have much to do with that, so the decision about what to do should probably be made by someone else. If modifications/extensions to resampling are happening, I would go for using a fork of CAB-LAB/gridtools to work unhindered while more slowly attempting to get changes back into the original.  

Other notes for continuing with this PR...

* I've kept names resample_2d() with us_method and ds_method, which are now class selectors. us_method can be any subclass of Upsample, ds_method any subclass of Downsample. I've got this family of Upsample and Downsample functions to replace the constants and collect documentation together, basically. They're parameterized functions, although only one of them actually has a parameter. Upsample and Downsample inherit from 'Sample2D' - but you can't use Upsample and Downsample functions the way you can use resample_2d()! At the very least, the names are confusing. Upsample and Downsample only really exist to collect documentation and one parameter for wrapping the underlying jit'd up/downsample functions. However, what I do like about that is the code reduction, plus most stuff just exists to collect name, doc, and parameters.

* I haven't performance tested yet (in particular, the effect of no longer jit'ing _resample_2d() - although we expect it should not matter.

* Haven't verified results yet (shouldn't have changed, of course, but I did alter how parameters are passed around and un-jit'ing something could have an effect, although you'd expect not...).