### PR TITLE
Fix coordinate and padding bugs in regridding implementation

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -320,7 +320,7 @@ class Canvas(object):
             top_pad = np.empty(shape=tshape).astype(source_window.dtype) * np.nan
             bottom_pad = np.empty(shape=bshape).astype(source_window.dtype) * np.nan
 
-            data = np.concatenate((bottom_pad, data, top_pad), axis=0)
+            data = np.concatenate((top_pad, data, bottom_pad), axis=0)
             data = np.concatenate((left_pad, data, right_pad), axis=1)
 
         # Reorient array to original orientation

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -207,7 +207,7 @@ def compute_coords(width, height, x_range, y_range, res):
         Bottom and top edges of the coordinates
     res : tuple
         Two-tuple (int, int) which includes x and y resolutions (aka "grid/cell
-        sizes"), respectively.
+        sizes"), respectively. Used to determine coordinate orientation.
 
     Returns
     -------
@@ -217,13 +217,15 @@ def compute_coords(width, height, x_range, y_range, res):
         1D array of y-coordinates
     """
     (x0, x1), (y0, y1) = x_range, y_range
-    xpad, ypad = abs(res[0]/2.), -abs(res[1]/2.)
+    xd = (x1-x0)/float(width)
+    yd = (y1-y0)/float(height)
+    xpad, ypad = abs(xd/2.), abs(yd/2.)
     x0, x1 = x0+xpad, x1-xpad
-    y0, y1 = y0-ypad, y1+ypad
-    if res[0] < 0: x0, x1 = x1, x0
-    if res[1] > 0: y0, y1 = y1, y0
+    y0, y1 = y0+ypad, y1-ypad
     xs = np.linspace(x0, x1, width)
     ys = np.linspace(y0, y1, height)
+    if res[0] < 0: xs = xs[::-1]
+    if res[1] > 0: ys = ys[::-1]
     return xs, ys
 
 


### PR DESCRIPTION
Fixes two bugs in canvas.raster regridding implementation. The top and bottom padding of the array was inverted and the coordinates of the output array were being computed incorrectly. Still have to add some unit tests to catch these things.