### PR TITLE
Sidestep datashape.Categorical bottleneck

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -10,7 +10,6 @@ from .resampling import (resample_2d, US_NEAREST, US_LINEAR, DS_FIRST, DS_LAST,
                          DS_MEAN, DS_MODE, DS_VAR, DS_STD, DS_MIN, DS_MAX)
 
 
-
 class Expr(object):
     """Base class for expression-like objects.
 
@@ -368,10 +367,21 @@ def bypixel(source, canvas, glyph, agg):
     glyph : Glyph
     agg : Reduction
     """
+    cols_to_keep = []
+    agg_cols = set()
+    if hasattr(agg, 'values'):
+        for subagg in agg.values:
+            agg_cols.add(subagg.column)
+    else:
+        agg_cols.add(agg.column)
+    some_cats = source[
+        [colname for colname in source.columns.values
+         if source[colname].dtype.name != 'category' or colname in agg_cols]
+    ]
     if isinstance(source, pd.DataFrame):
-        dshape = dshape_from_pandas(source)
+        dshape = dshape_from_pandas(some_cats)
     elif isinstance(source, dd.DataFrame):
-        dshape = dshape_from_dask(source)
+        dshape = dshape_from_dask(some_cats)
     else:
         raise ValueError("source must be a pandas or dask DataFrame")
     schema = dshape.measure

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -5,7 +5,7 @@ import pandas as pd
 import dask.dataframe as dd
 from xarray import DataArray
 
-from .utils import Dispatcher, ngjit, calc_res, calc_bbox, orient_array, compute_coords, get_indices, dshape_from_pandas, dshape_from_dask
+from .utils import Dispatcher, ngjit, calc_res, calc_bbox, orient_array, compute_coords, get_indices, dshape_from_pandas, dshape_from_dask, categorical_in_dtypes
 from .resampling import (resample_2d, US_NEAREST, US_LINEAR, DS_FIRST, DS_LAST,
                          DS_MEAN, DS_MODE, DS_VAR, DS_STD, DS_MIN, DS_MAX)
 
@@ -371,7 +371,7 @@ def bypixel(source, canvas, glyph, agg):
     # Avoid datashape.Categorical instantiation bottleneck
     # by only retaining the necessary columns:
     # https://github.com/bokeh/datashader/issues/396
-    if 'category' in str(source.dtypes.values):
+    if categorical_in_dtypes(source.dtypes.values):
         cols_to_keep = [glyph.x, glyph.y]
         if hasattr(agg, 'values'):
             for subagg in agg.values:

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -373,19 +373,17 @@ def bypixel(source, canvas, glyph, agg):
     # by only retaining the necessary columns:
     # https://github.com/bokeh/datashader/issues/396
     if categorical_in_dtypes(source.dtypes.values):
-        # Use an OrderedDict as an "OrderedSet",
-        # since we want to preserve column ordering
-        # without duplicates.
-        cols_to_keep = OrderedDict()
-        cols_to_keep[glyph.x] = None
-        cols_to_keep[glyph.y] = None
+        # Preserve column ordering without duplicates
+        cols_to_keep = OrderedDict({col: False for col in source.columns})
+        cols_to_keep[glyph.x] = True
+        cols_to_keep[glyph.y] = True
         if hasattr(agg, 'values'):
             for subagg in agg.values:
                 if subagg.column is not None:
-                    cols_to_keep[subagg.column] = None
+                    cols_to_keep[subagg.column] = True
         elif agg.column is not None:
-            cols_to_keep[agg.column] = None
-        src = source[list(cols_to_keep)]
+            cols_to_keep[agg.column] = True
+        src = source[[col for col, keepit in cols_to_keep.items() if keepit]]
     else:
         src = source
 

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -362,9 +362,11 @@ def dshape_from_pandas(df):
     return len(df) * datashape.Record([(k, dshape_from_pandas_helper(df[k]))
                                        for k in df.columns])
 
+
 def dshape_from_dask(df):
     """Return a datashape.DataShape object given a dask dataframe."""
     return datashape.var * dshape_from_pandas(df.head()).measure
+
 
 categoricals_in_dtypes = np.vectorize(lambda dtype: dtype.name == 'category', otypes='?')
 def categorical_in_dtypes(dtype_arr):

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -328,8 +328,11 @@ def lnglat_to_meters(longitude, latitude):
     northing = np.log(np.tan((90 + latitude) * np.pi / 360.0)) * origin_shift / np.pi
     return (easting, northing)
 
-# Heavily inspired by (and upstreamed back into) odo
+# Heavily inspired by odo
 def dshape_from_pandas_helper(col):
+    """Return an object from datashape.coretypes given a column from a pandas
+    dataframe.
+    """
     if isinstance(col.dtype, type(pd.Categorical.dtype)):
         cat_dshape = datashape.dshape('{} * {}'.format(
             len(col.cat.categories),
@@ -351,8 +354,11 @@ def dshape_from_pandas_helper(col):
     return dshape
 
 def dshape_from_pandas(df):
+    """Return a datashape.DataShape object given a pandas dataframe."""
     return len(df) * datashape.Record([(k, dshape_from_pandas_helper(df[k]))
                                        for k in df.columns])
 
 def dshape_from_dask(df):
+    """Return a datashape.DataShape object given a dask dataframe."""
     return datashape.var * dshape_from_pandas(df.head()).measure
+

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -61,6 +61,7 @@ def isreal(dt):
     dt = datashape.predicates.launder(dt)
     return isinstance(dt, datashape.Unit) and dt in datashape.typesets.real
 
+
 def calc_res(raster):
     """Calculate the resolution of xarray.DataArray raster and return it as the
     two-tuple (xres, yres).
@@ -72,6 +73,7 @@ def calc_res(raster):
     xres = (xcoords[-1] - xcoords[0]) / (w - 1)
     yres = (ycoords[0] - ycoords[-1]) / (h - 1)
     return xres, yres
+
 
 def calc_bbox(xs, ys, res):
     """Calculate the bounding box of a raster, and return it in a four-element
@@ -328,6 +330,7 @@ def lnglat_to_meters(longitude, latitude):
     northing = np.log(np.tan((90 + latitude) * np.pi / 360.0)) * origin_shift / np.pi
     return (easting, northing)
 
+
 # Heavily inspired by odo
 def dshape_from_pandas_helper(col):
     """Return an object from datashape.coretypes given a column from a pandas
@@ -353,6 +356,7 @@ def dshape_from_pandas_helper(col):
         return datashape.Option(dshape)
     return dshape
 
+
 def dshape_from_pandas(df):
     """Return a datashape.DataShape object given a pandas dataframe."""
     return len(df) * datashape.Record([(k, dshape_from_pandas_helper(df[k]))
@@ -362,3 +366,6 @@ def dshape_from_dask(df):
     """Return a datashape.DataShape object given a dask dataframe."""
     return datashape.var * dshape_from_pandas(df.head()).measure
 
+categoricals_in_dtypes = np.vectorize(lambda dtype: dtype.name == 'category', otypes='?')
+def categorical_in_dtypes(dtype_arr):
+    return categoricals_in_dtypes(dtype_arr).any()


### PR DESCRIPTION
This PR adds an additional performance enhancement which emerged when running `canvas.points()` over one thousand iterations with the dataset from #396. When categorical columns are detected, the `datashape.Categorical` constructor casts the categorical column to a tuple, resulting in a slowdown. Datashader now sidesteps this bottleneck by checking if a categorical dtype is in the dataframe; if so, the dataframe's columns are subset to only the "x", "y", and column(s) used for aggregation. Benchmarks suggest this leads to a ~40% performance increase on dataframes that contain categorical dtypes, and ~10% performance decrease on dataframes that don't contain categoricals.