### PR TITLE
Add categorical data to PCAP example

### DIFF
--- a/examples/datasets.yml
+++ b/examples/datasets.yml
@@ -111,3 +111,5 @@ data:
     files:
       - maccdc2012_nodes.parq
       - maccdc2012_edges.parq
+      - maccdc2012_full_nodes.parq
+      - maccdc2012_full_edges.parq

--- a/examples/packet_capture_graph.ipynb
+++ b/examples/packet_capture_graph.ipynb
@@ -86,7 +86,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
     "import datashader as ds\n",
     "import datashader.transfer_functions as tf\n",
     "\n",

--- a/examples/packet_capture_graph.ipynb
+++ b/examples/packet_capture_graph.ipynb
@@ -18,10 +18,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The data source comes from a publicly available network forensics repository: http://www.netresec.com/?page=PcapFiles. The selected file is https://download.netresec.com/pcap/maccdc-2012/maccdc2012_00000.pcap.gz. We will select only TCP traffic.\n",
+    "The data source comes from a publicly available network forensics repository: http://www.netresec.com/?page=PcapFiles. The selected file is https://download.netresec.com/pcap/maccdc-2012/maccdc2012_00000.pcap.gz.\n",
     "\n",
     "```\n",
-    "tcpdump -qns 0 -r maccdc2012_00000.pcap | grep tcp > maccdc2012_00000.txt\n",
+    "tcpdump -qns 0 -r maccdc2012_00000.pcap > maccdc2012_00000.txt\n",
     "```"
    ]
   },
@@ -90,9 +90,10 @@
     "import datashader as ds\n",
     "import datashader.transfer_functions as tf\n",
     "\n",
+    "from bokeh.palettes import Blues9, Greens9, Oranges9\n",
     "from colorcet import fire\n",
     "from datashader.bundling import hammer_bundle\n",
-    "from datashader.layout import circular_layout\n",
+    "from datashader.layout import circular_layout, forceatlas2_layout, random_layout\n",
     "\n",
     "from dask.distributed import Client\n",
     "from fastparquet import ParquetFile\n",
@@ -109,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nodes_df = ParquetFile('maccdc2012_nodes.parq').to_pandas()\n",
+    "nodes_df = ParquetFile('data/maccdc2012_full_nodes.parq').to_pandas()\n",
     "len(nodes_df)"
    ]
   },
@@ -119,8 +120,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edges_df = ParquetFile('maccdc2012_edges.parq').to_pandas()\n",
-    "len(edges_df)"
+    "edges_df = ParquetFile('data/maccdc2012_full_edges.parq').to_pandas()\n",
+    "edges_df.head()"
    ]
   },
   {
@@ -138,8 +139,10 @@
    },
    "outputs": [],
    "source": [
-    "positioned_df = circular_layout(nodes_df, edges_df)\n",
-    "positioned_df = positioned_df.set_index('id')"
+    "def create_image(bundle, aggregator, nodes, edges, cmap=fire):\n",
+    "    bundled_df = bundle(nodes, edges)\n",
+    "    img = tf.shade(aggregator(bundled_df, 'x', 'y'), cmap=cmap)\n",
+    "    return tf.set_background(img, color='black')"
    ]
   },
   {
@@ -150,7 +153,28 @@
    },
    "outputs": [],
    "source": [
-    "bundled_df = hammer_bundle(positioned_df, edges_df)"
+    "def assign_positions(nodes, edges, layout):\n",
+    "    bare_edges = edges.copy()\n",
+    "    del bare_edges['protocol']\n",
+    "    bare_edges = bare_edges.drop_duplicates()\n",
+    "    return layout(nodes, bare_edges)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    'tcp': {'colormap': Blues9},\n",
+    "    'udp': {'colormap': Greens9},\n",
+    "    'icmp': {'colormap': Oranges9}\n",
+    "}\n",
+    "for protocol in config.keys():\n",
+    "    config[protocol]['edges'] = edges_df[edges_df['protocol'] == protocol]"
    ]
   },
   {
@@ -162,8 +186,38 @@
    "outputs": [],
    "source": [
     "cvs = ds.Canvas(width, height, x_range, y_range)\n",
-    "img = tf.shade(cvs.points(bundled_df, 'x', 'y'), cmap=fire)\n",
-    "bundled_img = tf.set_background(img, color='black')"
+    "nodes_by_layout = {name: assign_positions(nodes_df, edges_df, layout)\n",
+    "                   for name, layout in [('random', random_layout),\n",
+    "                                        ('circular', circular_layout),\n",
+    "                                        ('forceatlas2', forceatlas2_layout)]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "images = {(protocol, layout): create_image(hammer_bundle,\n",
+    "                                           cvs.points,\n",
+    "                                           nodes=nodes_by_layout[layout],\n",
+    "                                           edges=config[protocol]['edges'],\n",
+    "                                           cmap=config[protocol]['colormap'])\n",
+    "          for protocol in config.keys()\n",
+    "          for layout in nodes_by_layout.keys()}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "sum([images[(protocol, 'random')] for protocol in config.keys()])"
    ]
   },
   {
@@ -172,23 +226,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bundled_img"
+    "sum([images[(protocol, 'circular')] for protocol in config.keys()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sum([images[(protocol, 'forceatlas2')] for protocol in config.keys()])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Showing nodes with active traffic"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "active_edges_df = edges_df[edges_df['weight'] > 0]"
+    "## Nodes with active traffic"
    ]
   },
   {
@@ -199,10 +253,35 @@
    },
    "outputs": [],
    "source": [
-    "active_nodes = active_edges_df.source.append(active_edges_df.target, ignore_index=True).unique()\n",
-    "active_nodes_df = pd.DataFrame(active_nodes, columns=['id'])\n",
-    "active_nodes_df = active_nodes_df.set_index('id')\n",
-    "active_nodes_df = active_nodes_df.join(positioned_df)"
+    "def nodes_by_protocol(protocol, nodes, aggregator, min_weight=0):\n",
+    "    grouped_edges_df = config[protocol]['edges'].groupby(['source'])[['weight']].sum()\n",
+    "    active_edges_df = grouped_edges_df[grouped_edges_df['weight'] >= min_weight]\n",
+    "    del active_edges_df['weight']\n",
+    "    \n",
+    "    active_nodes_df = active_edges_df.rename(columns={'source': 'id'})\n",
+    "    active_nodes_df = active_nodes_df.join(nodes)\n",
+    "    \n",
+    "    agg = aggregator(active_nodes_df, 'x', 'y')\n",
+    "    return tf.spread(tf.shade(agg, cmap='red'), px=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def create_graph_for_protocol_and_layout(protocol, layout, min_weight):\n",
+    "    return images[(protocol, layout)] + nodes_by_protocol(protocol, nodes_by_layout[layout], cvs.points, min_weight)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Nodes with at least 1MB of TCP traffic"
    ]
   },
   {
@@ -211,9 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cvs = ds.Canvas(width, height, x_range, y_range)\n",
-    "agg = cvs.points(active_nodes_df, 'x', 'y')\n",
-    "nodes_img = tf.spread(tf.shade(agg, cmap='red'), px=5)"
+    "create_graph_for_protocol_and_layout('tcp', 'random', 1024*1024)"
    ]
   },
   {
@@ -222,7 +299,84 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bundled_img + nodes_img"
+    "create_graph_for_protocol_and_layout('tcp', 'circular', 1024*1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_graph_for_protocol_and_layout('tcp', 'forceatlas2', 1024*1024)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Nodes with at least 16K of UDP traffic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_graph_for_protocol_and_layout('udp', 'random', 16*1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_graph_for_protocol_and_layout('udp', 'circular', 16*1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_graph_for_protocol_and_layout('udp', 'forceatlas2', 16*1024)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Nodes with at least 1K of ICMP traffic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_graph_for_protocol_and_layout('icmp', 'random', 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_graph_for_protocol_and_layout('icmp', 'circular', 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_graph_for_protocol_and_layout('icmp', 'forceatlas2', 1024)"
    ]
   },
   {

--- a/examples/pcap_to_parquet.py
+++ b/examples/pcap_to_parquet.py
@@ -20,32 +20,51 @@ def ip_to_integer(s):
     return struct.unpack("!I", socket.inet_aton(s))[0]
 
 
+def get_ip_protocol(s):
+    if "tcp" in s:
+        return "tcp"
+    if "UDP" in s:
+        return "udp"
+    if "EIGRP" in s:
+        return "eigrp"
+    if "ICMP" in s:
+        return "icmp"
+    return None
+
+
 def to_parquet(filename, prefix="maccdc2012"):
     with open(filename) as f:
         traffic = {}
         nodes = set()
 
         for line in f.readlines():
+            if "unreachable" in line:
+                continue
             fields = line.split()
             if not fields:
+                continue
+            if fields[1] != "IP":
+                continue
+            protocol = get_ip_protocol(line)
+            if protocol not in ("tcp", "udp", "eigrp", "icmp"):
                 continue
             try:
                 addresses = []
 
                 # Extract source IP address and convert to integer
-                m = re.match(r'\d+\.\d+\.\d+\.\d+', fields[2])
+                m = re.match(r'(?P<address>\d+\.\d+\.\d+\.\d+)', fields[2])
                 if not m:
                     continue
-                addresses.append(ip_to_integer(m.group(0)))
+                addresses.append(ip_to_integer(m.group('address')))
 
                 # Extract target IP address and convert to integer
-                m = re.match(r'\d+\.\d+\.\d+\.\d+', fields[4])
+                m = re.match(r'(?P<address>\d+\.\d+\.\d+\.\d+)', fields[4])
                 if not m:
                     continue
-                addresses.append(ip_to_integer(m.group(0)))
+                addresses.append(ip_to_integer(m.group('address')))
 
                 nodes = nodes.union(addresses)
-                key = tuple(sorted(addresses))
+                key = (protocol, *sorted(addresses))
 
                 # Extract packet size
                 nbytes = int(fields[-1])
@@ -57,21 +76,28 @@ def to_parquet(filename, prefix="maccdc2012"):
             except:
                 pass
 
-        # Anonymize IP addresses by subtracting minimum from all integers
-        min_node_id = min(nodes)
+        nodes = dict([(node, i) for i, node in enumerate(sorted(nodes))])
+
         edges = []
-        for key in traffic:
-            edge = [key[0] - min_node_id, key[1] - min_node_id, traffic[key]]
+        for i, key in enumerate(traffic):
+            edge = [i, nodes[key[1]], nodes[key[2]], key[0], traffic[key]]
             edges.append(edge)
 
-        nodes_df = pd.DataFrame(np.array(list(nodes)) - min_node_id, columns=['id'])
-        edges_df = pd.DataFrame(np.array(edges), columns=['source', 'target', 'weight'])
+        nodes_df = pd.DataFrame(np.arange(len(nodes)), columns=['id'])
+        nodes_df = nodes_df.set_index('id')
+
+        edges_df = pd.DataFrame(np.array(edges), columns=['id', 'source', 'target', 'protocol', 'weight'])
+        edges_df = edges_df.set_index('id')
+        edges_df['source'] = pd.to_numeric(edges_df['source'])
+        edges_df['target'] = pd.to_numeric(edges_df['target'])
+        edges_df['weight'] = pd.to_numeric(edges_df['weight'])
+        edges_df['protocol'] = edges_df['protocol'].astype('category')
 
         fp.write('{}_nodes.parq'.format(prefix), nodes_df)
         fp.write('{}_edges.parq'.format(prefix), edges_df)
 
 if __name__ == '__main__':
-    if len(sys.argv) >= 2:
+    if len(sys.argv) > 2:
         to_parquet(sys.argv[1], prefix=sys.argv[2])
     else:
         to_parquet(sys.argv[1])


### PR DESCRIPTION
Instead of filtering non-TCP traffic, we now add a category for the network protocol in order to distinguish traffic.