### PR TITLE
Fix internal column mismatch for forceatlas2_layout

### DIFF
--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -109,8 +109,10 @@ def _convert_graph_to_sparse_matrix(nodes, edges, dtype=None, format='csr'):
         edges = edges.copy()
         edges['weight'] = np.ones(len(edges))
 
+    edge_values = edges[['source', 'target', 'weight']].values
+
     rows, cols, data = zip(*((index[src], index[dst], weight)
-                             for src, dst, weight in [tuple(edge) for edge in edges.values]
+                             for src, dst, weight in [tuple(edge) for edge in edge_values]
                              if src in index and dst in index))
 
     M = sp.sparse.coo_matrix((data, (rows, cols)), shape=(nlen, nlen), dtype=dtype)

--- a/examples/packet_capture_graph.ipynb
+++ b/examples/packet_capture_graph.ipynb
@@ -120,6 +120,7 @@
    "outputs": [],
    "source": [
     "edges_df = ParquetFile('data/maccdc2012_full_edges.parq').to_pandas()\n",
+    "edges_df = edges_df.set_index('id')\n",
     "edges_df.head()"
    ]
   },


### PR DESCRIPTION
We found an error caused by a column mismatch when converting a dataframe to a list.