### PR TITLE
Fix bug for all-NaN arrays

### DIFF
--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -128,7 +128,7 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha):
 
         masked = data[~mask]
         if len(masked) == 0:
-            return Image(agg.data.view(np.uint32), coords=agg.coords, dims=agg.dims, attrs=agg.attrs)
+            return Image(agg.data.astype(np.uint32), coords=agg.coords, dims=agg.dims, attrs=agg.attrs)
 
         offset = masked.min()
 


### PR DESCRIPTION
Commit 9843c77c fixed one problem for completely masked aggregates (all-NaN) but introduced another: a uint64 array ends up getting interpreted as a much larger uint32 array, causing problems when arithmetic is done on aggregates.  Properly converts the type now, but there may be a better way that doesn't change the type at all.