### PR TITLE
Remove minimum Bokeh requirement for examples

### DIFF
--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -8,7 +8,7 @@ channels:
 
 dependencies:
  - attrs
- - bokeh>=0.12.6dev3
+ - bokeh
  - cartopy
  - colorcet
  - dask


### PR DESCRIPTION
The issue requiring this addition was resolved (see PR #341 - Bokeh embedded server issues).