### PR TITLE
Ignore IPython checkpoints for conda builds

### DIFF
--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -9,7 +9,10 @@ SRC_DIR=$RECIPE_DIR/..
 pushd $SRC_DIR
 
 $PYTHON setup.py --quiet install --single-version-externally-managed --record=record.txt
+
+# Copy all examples files but exclude IPython checkpoints
 cp -r $SRC_DIR/examples $PREFIX/share/datashader-examples
+rm -rf $PREFIX/share/datashader-examples/.ipynb_checkpoints
 
 popd
 


### PR DESCRIPTION
Even though we ignore checkpoint files when building pip packages, those files are still copied into conda packages.