### PR TITLE
Pin Holoviews to import Bokeh backend w/o error

### DIFF
--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -16,7 +16,7 @@ dependencies:
  - dill
  - distributed
  - geoviews
- - holoviews
+ - ioam::holoviews>=1.8.3
  - iris
  - jupyter
  - krb5


### PR DESCRIPTION
The edge bundling example had multiple warnings and errors caused by Holoviews failing to import the Bokeh backend. This issue was solved with Holoviews 1.8.3 so we pin that version for the examples.