### PR TITLE
Denormalize edge coordinates after bundling

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -281,6 +281,16 @@ class directly_connect_edges(param.ParameterizedFunction):
         return _convert_edge_segments_to_dataframe(edges, point_dims)
 
 
+@nb.jit
+def minmax_normalize(X, lower, upper):
+    return (X - lower) / (upper - lower)
+
+
+@nb.jit
+def minmax_denormalize(X, lower, upper):
+    return X * (upper - lower) + lower
+
+
 class hammer_bundle(directly_connect_edges):
     """
     Iteratively group edges and return as paths suitable for datashading.
@@ -322,12 +332,6 @@ class hammer_bundle(directly_connect_edges):
         # Calculate min/max for coordinates
         xmin, xmax = np.min(nodes['x']), np.max(nodes['x'])
         ymin, ymax = np.min(nodes['y']), np.max(nodes['y'])
-
-        def minmax_normalize(X, lower, upper):
-            return (X - lower) / (upper - lower)
-
-        def minmax_denormalize(X, lower, upper):
-            return X * (upper - lower) + lower
 
         # Normalize coordinates
         nodes = nodes.copy()

--- a/datashader/tests/test_bundling.py
+++ b/datashader/tests/test_bundling.py
@@ -52,11 +52,11 @@ def test_directly_connect_with_weights(nodes, weighted_edges):
     # Expect four lines starting at center (0.5, 0.5) and terminating
     # at a different corner and NaN
     data = pd.DataFrame({'x':
-                            [0.5, 0.0, np.nan, 0.5, 1.0, np.nan,
-                             0.5, 0.0, np.nan, 0.5, 1.0, np.nan],
+                            [0.0, -100.0, np.nan, 0.0, 100.0, np.nan,
+                             0.0, -100.0, np.nan, 0.0, 100.0, np.nan],
                          'y':
-                            [0.5, 1.0, np.nan, 0.5, 1.0, np.nan,
-                             0.5, 0.0, np.nan, 0.5, 0.0, np.nan]})
+                            [0.0, 100.0, np.nan, 0.0, 100.0, np.nan,
+                             0.0, -100.0, np.nan, 0.0, -100.0, np.nan]})
     expected = pd.DataFrame(data, columns=['x', 'y'])
 
     given = directly_connect_edges(nodes, weighted_edges)
@@ -67,11 +67,11 @@ def test_directly_connect_without_weights(nodes, edges):
     # Expect four lines starting at center (0.5, 0.5) and terminating
     # at a different corner and NaN
     data = pd.DataFrame({'x':
-                            [0.5, 0.0, np.nan, 0.5, 1.0, np.nan,
-                             0.5, 0.0, np.nan, 0.5, 1.0, np.nan],
+                            [0.0, -100.0, np.nan, 0.0, 100.0, np.nan,
+                             0.0, -100.0, np.nan, 0.0, 100.0, np.nan],
                          'y':
-                            [0.5, 1.0, np.nan, 0.5, 1.0, np.nan,
-                             0.5, 0.0, np.nan, 0.5, 0.0, np.nan]})
+                            [0.0, 100.0, np.nan, 0.0, 100.0, np.nan,
+                             0.0, -100.0, np.nan, 0.0, -100.0, np.nan]})
     expected = pd.DataFrame(data, columns=['x', 'y'])
 
     given = directly_connect_edges(nodes, edges)
@@ -79,14 +79,14 @@ def test_directly_connect_without_weights(nodes, edges):
 
 
 def test_hammer_bundle_with_weights(nodes, weighted_edges):
-    # Expect four lines starting at center (0.5, 0.5) and terminating
+    # Expect four lines starting at center (0.0, 0.0) and terminating
     # with NaN
     data = pd.DataFrame({'x':
-                            [0.5, np.nan, 0.5, np.nan,
-                             0.5, np.nan, 0.5, np.nan],
+                            [0.0, np.nan, 0.0, np.nan,
+                             0.0, np.nan, 0.0, np.nan],
                          'y':
-                            [0.5, np.nan, 0.5, np.nan,
-                             0.5, np.nan, 0.5, np.nan],
+                            [0.0, np.nan, 0.0, np.nan,
+                             0.0, np.nan, 0.0, np.nan],
                          'weight':
                             [1.0, np.nan, 1.0, np.nan,
                              1.0, np.nan, 1.0, np.nan]})
@@ -94,7 +94,7 @@ def test_hammer_bundle_with_weights(nodes, weighted_edges):
 
     df = hammer_bundle(nodes, weighted_edges)
 
-    starts = df[(df.x == 0.5) & (df.y == 0.5)]
+    starts = df[(df.x == 0.0) & (df.y == 0.0)]
     ends = df[df.isnull().any(axis=1)]
     given = pd.concat([starts, ends])
     given.sort_index(inplace=True)
@@ -104,19 +104,19 @@ def test_hammer_bundle_with_weights(nodes, weighted_edges):
 
 
 def test_hammer_bundle_without_weights(nodes, edges):
-    # Expect four lines starting at center (0.5, 0.5) and terminating
+    # Expect four lines starting at center (0.0, 0.0) and terminating
     # with NaN
     data = pd.DataFrame({'x':
-                            [0.5, np.nan, 0.5, np.nan,
-                             0.5, np.nan, 0.5, np.nan],
+                            [0.0, np.nan, 0.0, np.nan,
+                             0.0, np.nan, 0.0, np.nan],
                          'y':
-                            [0.5, np.nan, 0.5, np.nan,
-                             0.5, np.nan, 0.5, np.nan]})
+                            [0.0, np.nan, 0.0, np.nan,
+                             0.0, np.nan, 0.0, np.nan]})
     expected = pd.DataFrame(data, columns=['x', 'y'])
 
     df = hammer_bundle(nodes, edges)
 
-    starts = df[(df.x == 0.5) & (df.y == 0.5)]
+    starts = df[(df.x == 0.0) & (df.y == 0.0)]
     ends = df[df.isnull().any(axis=1)]
     given = pd.concat([starts, ends])
     given.sort_index(inplace=True)


### PR DESCRIPTION
Previously, we returned edges that used normalized coordinates. When layering the non-normalized nodes onto the normalized edges, the result was misaligned.

We now denormalize the edges coordinates only in hammer_bundle. The directly_connect_edges method is simplified by not normalizing the nodes in the first place.

Thus, performance will decrease for hammer_bundle, but will improve for directly_connect_edges.