### PR TITLE
Partial fix to landsat example; selected band even when only 1

### DIFF
--- a/examples/landsat.ipynb
+++ b/examples/landsat.ipynb
@@ -80,7 +80,7 @@
     "band10 = xr.open_rasterio(os.path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_B10.TIF'))\n",
     "band11 = xr.open_rasterio(os.path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_B11.TIF'))\n",
     "band12 = xr.open_rasterio(os.path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_BQA.TIF'))\n",
-    "# Notice the MERCATOR prefix which indicates the data was project to Mercator CRS\n",
+    "# Notice the MERCATOR prefix which indicates the data was projected to Mercator CRS\n",
     "\n",
     "res = ds.utils.calc_res(band1)\n",
     "xmin, ymin, xmax, ymax = ds.utils.calc_bbox(band1.x.values, band1.y.values, res)\n",
@@ -142,7 +142,7 @@
    "source": [
     "def update_image(x_range, y_range, w, h, how='log'):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    agg = cvs.raster(band2)\n",
+    "    agg = cvs.raster(band2).sel(band=1).astype(float)\n",
     "    agg.data[agg.data<nodata]=np.nan\n",
     "    blue_img = tf.shade(agg,cmap=['black','white'])\n",
     "    return blue_img\n",
@@ -223,7 +223,7 @@
    "source": [
     "def true_color(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band4, band3, band2)]\n",
+    "    r, g, b = [cvs.raster(b).sel(band=1).data for b in (band4, band3, band2)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -247,7 +247,7 @@
    "source": [
     "def color_infrared(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band5, band4, band3)]\n",
+    "    r, g, b = [cvs.raster(b).sel(band=1).data for b in (band5, band4, band3)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -269,7 +269,7 @@
    "source": [
     "def false_color_urban(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band7, band6, band4)]\n",
+    "    r, g, b = [cvs.raster(b).sel(band=1).data for b in (band7, band6, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -291,7 +291,7 @@
    "source": [
     "def false_color_veg(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band5, band7, band1)]\n",
+    "    r, g, b = [cvs.raster(b).sel(band=1).data for b in (band5, band7, band1)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -313,7 +313,7 @@
    "source": [
     "def land_vs_water(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band5, band6, band4)]\n",
+    "    r, g, b = [cvs.raster(b).sel(band=1).data for b in (band5, band6, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -337,7 +337,7 @@
    "source": [
     "def shortwave_infrared(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band7, band5, band4)]\n",
+    "    r, g, b = [cvs.raster(b).sel(band=1).data for b in (band7, band5, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -368,7 +368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   },
   "widgets": {
    "state": {},


### PR DESCRIPTION
I can't tell what changed to require this PR, but the landsat example is broken in current master. From the error messages, it looks like xarray used to ignore the ``band`` dimension when it has only a single value in a TIFF file, but now we have to explicitly select the value for that dimension if we want to get down to an x,y array.  

Still WIP, because the orientation of the image is now completely wrong.  It should be like:

![image](https://user-images.githubusercontent.com/1695496/30045125-d1d2814c-91c7-11e7-8c97-75113b2c4e31.png)

But instead it's:

![image](https://user-images.githubusercontent.com/1695496/30045166-191d6198-91c8-11e7-8769-d168a124b24d.png)

@jbcrail and @philippjfr , any idea why these changes were needed?  Any idea why the rotation is mixed up now (could it be a side effect of my "fixes"?)? Something to do with the new rasterio backend for xarray? The new regridding code? Any idea how to get it working?