### PR TITLE
Ensure shade transfer function respects array orientation

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -280,7 +280,7 @@ class Canvas(object):
         ah, aw = array.shape if array.ndim == 2 else array.shape[1:]
         cmin, rmin = get_indices(xmin, ymin, source[xdim].values, source[ydim].values, res)
         cmax, rmax = get_indices(xmax, ymax, source[xdim].values, source[ydim].values, res)
-        rmin, rmax = ah-rmin, ah-rmax
+        rmin, rmax = ah-rmin-1, ah-rmax-1
         if rmin > rmax: rmin, rmax = rmax, rmin
         if cmin > cmax: cmin, cmax = cmax, cmin
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -277,8 +277,10 @@ class Canvas(object):
         w = int(np.ceil(self.plot_width * width_ratio))
         h = int(np.ceil(self.plot_height * height_ratio))
 
+        ah, aw = array.shape if array.ndim == 2 else array.shape[1:]
         cmin, rmin = get_indices(xmin, ymin, source[xdim].values, source[ydim].values, res)
         cmax, rmax = get_indices(xmax, ymax, source[xdim].values, source[ydim].values, res)
+        rmin, rmax = ah-rmin, ah-rmax
         if rmin > rmax: rmin, rmax = rmax, rmin
         if cmin > cmax: cmin, cmax = cmax, cmin
 

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -129,6 +129,23 @@ def test_raster_both_ascending():
     assert np.allclose(agg.Y.values, ys)
 
 
+def test_raster_both_ascending_partial_range():
+    """
+    Assert raster with ascending x- and y-coordinates and a partial canvas
+    range is aggregated correctly.
+    """
+    xs = np.arange(10)
+    ys = np.arange(5)
+    arr = xs*ys[np.newaxis].T
+    xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
+    cvs = ds.Canvas(9, 4, x_range=(-.5, 8.5), y_range=(-.5, 3.5))
+    agg = cvs.raster(xarr)
+
+    assert np.allclose(agg.data, arr[1:, :-1])
+    assert np.allclose(agg.X.values, xs[:-1])
+    assert np.allclose(agg.Y.values, ys[:-1])
+
+
 def test_raster_both_descending():
     """
     Assert raster with ascending x- and y-coordinates is aggregated correctly.
@@ -143,6 +160,23 @@ def test_raster_both_descending():
     assert np.allclose(agg.data, arr)
     assert np.allclose(agg.X.values, xs)
     assert np.allclose(agg.Y.values, ys)
+
+
+def test_raster_both_descending_partial_range():
+    """
+    Assert raster with ascending x- and y-coordinates and a partial canvas range
+    is aggregated correctly.
+    """
+    xs = np.arange(10)[::-1]
+    ys = np.arange(5)[::-1]
+    arr = xs*ys[np.newaxis].T
+    xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
+    cvs = ds.Canvas(9, 4, x_range=(.5, 9.5), y_range=(.5, 4.5))
+    agg = cvs.raster(xarr)
+
+    assert np.allclose(agg.data, arr[:-1, 1:])
+    assert np.allclose(agg.X.values, xs[:-1])
+    assert np.allclose(agg.Y.values, ys[:-1])
 
 
 def test_raster_x_ascending_y_descending():

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -193,8 +193,10 @@ def _colorize(agg, color_key, how, min_alpha):
         raise ValueError("min_alpha ({}) must be between 0 and 255".format(min_alpha))
     colors = [rgb(color_key[c]) for c in cats]
     rs, gs, bs = map(np.array, zip(*colors))
-    res = calc_res(agg)
-    data = orient_array(agg, res)
+    # Reorient array (transposing the category dimension first)
+    agg_t = agg.transpose(*((agg.dims[-1],)+agg.dims[:2]))
+    res = calc_res(agg_t)
+    data = orient_array(agg_t, res).transpose([1, 2, 0])
     total = data.sum(axis=2)
     # zero-count pixels will be 0/0, but it's safe to ignore that when dividing
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -116,8 +116,7 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha):
     if agg.ndim != 2:
         raise ValueError("agg must be 2D")
     interpolater = _normalize_interpolate_how(how)
-    res = calc_res(agg)
-    data = orient_array(agg, res)
+    data = orient_array(agg)
     if np.issubdtype(data.dtype, np.bool_):
         mask = ~data
         interp = data
@@ -195,8 +194,7 @@ def _colorize(agg, color_key, how, min_alpha):
     rs, gs, bs = map(np.array, zip(*colors))
     # Reorient array (transposing the category dimension first)
     agg_t = agg.transpose(*((agg.dims[-1],)+agg.dims[:2]))
-    res = calc_res(agg_t)
-    data = orient_array(agg_t, res).transpose([1, 2, 0])
+    data = orient_array(agg_t).transpose([1, 2, 0])
     total = data.sum(axis=2)
     # zero-count pixels will be 0/0, but it's safe to ignore that when dividing
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -12,7 +12,7 @@ from PIL.Image import fromarray
 
 from .colors import rgb, Sets1to3
 from .composite import composite_op_lookup, over
-from .utils import ngjit, calc_res, orient_array
+from .utils import ngjit, orient_array
 
 
 __all__ = ['Image', 'stack', 'shade', 'set_background', 'spread', 'dynspread']

--- a/datashader/transfer_functions.py
+++ b/datashader/transfer_functions.py
@@ -12,7 +12,7 @@ from PIL.Image import fromarray
 
 from .colors import rgb, Sets1to3
 from .composite import composite_op_lookup, over
-from .utils import ngjit
+from .utils import ngjit, calc_res, orient_array
 
 
 __all__ = ['Image', 'stack', 'shade', 'set_background', 'spread', 'dynspread']
@@ -116,7 +116,8 @@ def _interpolate(agg, cmap, how, alpha, span, min_alpha):
     if agg.ndim != 2:
         raise ValueError("agg must be 2D")
     interpolater = _normalize_interpolate_how(how)
-    data = agg.data
+    res = calc_res(agg)
+    data = orient_array(agg, res)
     if np.issubdtype(data.dtype, np.bool_):
         mask = ~data
         interp = data
@@ -192,7 +193,8 @@ def _colorize(agg, color_key, how, min_alpha):
         raise ValueError("min_alpha ({}) must be between 0 and 255".format(min_alpha))
     colors = [rgb(color_key[c]) for c in cats]
     rs, gs, bs = map(np.array, zip(*colors))
-    data = agg.data
+    res = calc_res(agg)
+    data = orient_array(agg, res)
     total = data.sum(axis=2)
     # zero-count pixels will be 0/0, but it's safe to ignore that when dividing
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -157,7 +157,7 @@ def get_indices(x, y, xs, ys, res):
     return int(x_), int(y_)
 
 
-def orient_array(raster, res, layer):
+def orient_array(raster, res, layer=None):
     """
     Reorients the array to a canonical orientation depending on
     whether the x and y-resolution values are positive or negative.

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -178,11 +178,11 @@ def orient_array(raster, res, layer=None):
         Reoriented 2d NumPy ndarray
     """
     array = raster.data
+    if layer is not None: array = array[layer-1]
     if array.ndim == 2:
         if res[0] < 0: array = array[:, ::-1]
         if res[1] > 0: array = array[::-1]
     else:
-        if layer is not None: array = array[layer-1]
         if res[0] < 0: array = array[:, :, ::-1]
         if res[1] > 0: array = array[:, ::-1]
     return array

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -157,7 +157,7 @@ def get_indices(x, y, xs, ys, res):
     return int(x_), int(y_)
 
 
-def orient_array(raster, res, layer=None):
+def orient_array(raster, res=None, layer=None):
     """
     Reorients the array to a canonical orientation depending on
     whether the x and y-resolution values are positive or negative.
@@ -177,6 +177,8 @@ def orient_array(raster, res, layer=None):
     array : numpy.ndarray
         Reoriented 2d NumPy ndarray
     """
+    if res is None:
+        res = calc_res(raster)
     array = raster.data
     if layer is not None: array = array[layer-1]
     if array.ndim == 2:

--- a/examples/landsat.ipynb
+++ b/examples/landsat.ipynb
@@ -194,13 +194,14 @@
    "outputs": [],
    "source": [
     "def combine_bands(r, g, b):\n",
+    "    r, g, b = [ds.utils.orient_array(img) for img in (r, g, b)]\n",
     "    a = (np.where(np.logical_or(np.isnan(r),r<=nodata),0,255)).astype(np.uint8)    \n",
     "    r = (normalize_data(r)).astype(np.uint8)\n",
     "    g = (normalize_data(g)).astype(np.uint8)\n",
     "    b = (normalize_data(b)).astype(np.uint8)\n",
     "    col, rows = r.shape\n",
     "    img = np.dstack([r, g, b, a]).view(np.uint32).reshape(r.shape)\n",
-    "    return tf.Image(data=img[::-1])"
+    "    return tf.Image(data=img)"
    ]
   },
   {
@@ -220,7 +221,7 @@
    "source": [
     "def true_color(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band4, band3, band2)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0) for b in (band4, band3, band2)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -244,7 +245,7 @@
    "source": [
     "def color_infrared(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band5, band4, band3)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0) for b in (band5, band4, band3)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -266,7 +267,7 @@
    "source": [
     "def false_color_urban(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band7, band6, band4)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0) for b in (band7, band6, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -288,7 +289,7 @@
    "source": [
     "def false_color_veg(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band5, band7, band1)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0) for b in (band5, band7, band1)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -310,7 +311,7 @@
    "source": [
     "def land_vs_water(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band5, band6, band4)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0) for b in (band5, band6, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -334,7 +335,7 @@
    "source": [
     "def shortwave_infrared(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band7, band5, band4)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0) for b in (band7, band5, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",

--- a/examples/landsat.ipynb
+++ b/examples/landsat.ipynb
@@ -61,9 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data_dir = './data'\n",
@@ -142,8 +140,7 @@
    "source": [
     "def update_image(x_range, y_range, w, h, how='log'):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    agg = cvs.raster(band2)\n",
-    "    agg.data[agg.data<nodata]=np.nan\n",
+    "    agg = cvs.raster(band2, layer=0)\n",
     "    blue_img = tf.shade(agg,cmap=['black','white'])\n",
     "    return blue_img\n",
     "\n",
@@ -203,7 +200,7 @@
     "    b = (normalize_data(b)).astype(np.uint8)\n",
     "    col, rows = r.shape\n",
     "    img = np.dstack([r, g, b, a]).view(np.uint32).reshape(r.shape)\n",
-    "    return tf.Image(data=img)"
+    "    return tf.Image(data=img[::-1])"
    ]
   },
   {
@@ -223,7 +220,7 @@
    "source": [
     "def true_color(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band4, band3, band2)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band4, band3, band2)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -247,7 +244,7 @@
    "source": [
     "def color_infrared(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band5, band4, band3)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band5, band4, band3)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -269,7 +266,7 @@
    "source": [
     "def false_color_urban(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band7, band6, band4)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band7, band6, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -291,7 +288,7 @@
    "source": [
     "def false_color_veg(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band5, band7, band1)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band5, band7, band1)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -313,7 +310,7 @@
    "source": [
     "def land_vs_water(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band5, band6, band4)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band5, band6, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -337,7 +334,7 @@
    "source": [
     "def shortwave_infrared(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
-    "    r, g, b = [cvs.raster(b).data for b in (band7, band5, band4)]\n",
+    "    r, g, b = [cvs.raster(b, layer=0).data for b in (band7, band5, band4)]\n",
     "    return combine_bands(r, g, b)\n",
     "\n",
     "p = base_plot(x_range=(xmin, xmax), y_range=(ymin, ymax))\n",
@@ -368,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.2"
   },
   "widgets": {
    "state": {},

--- a/examples/landsat.ipynb
+++ b/examples/landsat.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Datashading LandSat8 raster satellite imagery\n",
     "\n",
-    "Datashader is fundamentally a rasterizing library, turning data into rasters (image-like arrays), but it is also useful for already-rasterized data like satellite imagery.  For raster data, datashader uses the separate [rasterio](https://mapbox.github.io/rasterio) library to re-render the data to whatever new bounding box and resolution the user requests, and the rest of the datashader pipeline can then be used to visualize and analyze the data.  This demo shows how to work with a set of raster satellite data, generating images as needed and overlaying them on geographic coordinates."
+    "Datashader is fundamentally a rasterizing library, turning data into rasters (image-like arrays), but it is also useful for already-rasterized data like satellite imagery.  For raster data, datashader uses the separate [xarray](http://xarray.pydata.org/) library to re-render the data to whatever new bounding box and resolution the user requests, and the rest of the datashader pipeline can then be used to visualize and analyze the data.  This demo shows how to work with a set of raster satellite data, generating images as needed and overlaying them on geographic coordinates."
    ]
   },
   {
@@ -78,7 +78,7 @@
     "band10 = xr.open_rasterio(os.path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_B10.TIF'))\n",
     "band11 = xr.open_rasterio(os.path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_B11.TIF'))\n",
     "band12 = xr.open_rasterio(os.path.join(data_dir, 'MERCATOR_LC80210392016114LGN00_BQA.TIF'))\n",
-    "# Notice the MERCATOR prefix which indicates the data was project to Mercator CRS\n",
+    "# Notice the MERCATOR prefix which indicates the data was projected to Mercator CRS\n",
     "\n",
     "res = ds.utils.calc_res(band1)\n",
     "xmin, ymin, xmax, ymax = ds.utils.calc_bbox(band1.x.values, band1.y.values, res)\n",


### PR DESCRIPTION
Recent changes to ``canvas.raster`` now allow regridding of xarray DataArrays with ascending and descending coordinates. Currently the ``shade`` transfer function and the ``_interpolate`` and ``_colorize`` methods don't respect these orientations, resulting in flipped images in some cases. This PR uses the existing utilities to reorient the array to the expected orientation to fix this issue.