### PR TITLE
Ensure bundling retains order of edges

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -223,6 +223,7 @@ def _convert_graph_to_edge_segments(nodes, edges, ignore_weights=False):
 
     df = pd.merge(nodes, df, left_index=True, right_on=['target'])
     df = df.rename(columns={'x': 'dst_x', 'y': 'dst_y'})
+    df = df.sort_index()
 
     if ignore_weights or 'weight' not in edges:
         point_dims = 2


### PR DESCRIPTION
Turned out to be a trivial fix, simply sorting by the index after performing the merge of the node and edge dataframes. Retaining this ordering is important if we want to use the edges for anything other than datashading.