### PR TITLE
Add edge ID to bundled dataframe

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -207,10 +207,10 @@ def _convert_graph_to_edge_segments(nodes, edges, ignore_weights=False):
     the accumulator function for drawing to an image.
     """
 
-    df = pd.merge(nodes, edges, left_index=True, right_on=['source'])
+    df = pd.merge(edges, nodes, left_on=['source'], right_index=True)
     df = df.rename(columns={'x': 'src_x', 'y': 'src_y'})
 
-    df = pd.merge(nodes, df, left_index=True, right_on=['target'])
+    df = pd.merge(df, nodes, left_on=['target'], right_index=True)
     df = df.rename(columns={'x': 'dst_x', 'y': 'dst_y'})
     df = df.sort_index()
 

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -183,11 +183,7 @@ def get_gradients(img):
     return (vert, horiz)
 
 
-class UnweightedSegment(object):
-    ndims = 3
-    columns = ['edge_id', 'x', 'y']
-    merged_columns = ['edge_id', 'src_x', 'src_y', 'dst_x', 'dst_y']
-
+class BaseSegment(object):
     @classmethod
     @nb.jit
     def create_point(cls):
@@ -202,6 +198,12 @@ class UnweightedSegment(object):
     @nb.jit
     def create_delimiter(cls):
         return np.array([[np.nan] * cls.ndims])
+
+
+class UnweightedSegment(BaseSegment):
+    ndims = 3
+    columns = ['edge_id', 'x', 'y']
+    merged_columns = ['edge_id', 'src_x', 'src_y', 'dst_x', 'dst_y']
 
     @staticmethod
     @nb.jit
@@ -214,25 +216,10 @@ class UnweightedSegment(object):
         img[int(point[1] * accuracy), int(point[2] * accuracy)] += 1
 
 
-class EdgelessUnweightedSegment(object):
+class EdgelessUnweightedSegment(BaseSegment):
     ndims = 2
     columns = ['x', 'y']
     merged_columns = ['src_x', 'src_y', 'dst_x', 'dst_y']
-
-    @classmethod
-    @nb.jit
-    def create_point(cls):
-        return np.array([0.0] * cls.ndims)
-
-    @classmethod
-    @nb.jit
-    def create_empty_points(cls, n):
-        return np.empty((n, cls.ndims))
-
-    @classmethod
-    @nb.jit
-    def create_delimiter(cls):
-        return np.array([[np.nan] * cls.ndims])
 
     @staticmethod
     @nb.jit
@@ -245,25 +232,10 @@ class EdgelessUnweightedSegment(object):
         img[int(point[0] * accuracy), int(point[1] * accuracy)] += 1
 
 
-class WeightedSegment(object):
+class WeightedSegment(BaseSegment):
     ndims = 4
     columns = ['edge_id', 'x', 'y', 'weight']
     merged_columns = ['edge_id', 'src_x', 'src_y', 'dst_x', 'dst_y', 'weight']
-
-    @classmethod
-    @nb.jit
-    def create_point(cls):
-        return np.array([0.0] * cls.ndims)
-
-    @classmethod
-    @nb.jit
-    def create_empty_points(cls, n):
-        return np.empty((n, cls.ndims))
-
-    @classmethod
-    @nb.jit
-    def create_delimiter(cls):
-        return np.array([[np.nan] * cls.ndims])
 
     @staticmethod
     @nb.jit
@@ -276,25 +248,10 @@ class WeightedSegment(object):
         img[int(point[1] * accuracy), int(point[2] * accuracy)] += point[3]
 
 
-class EdgelessWeightedSegment(object):
+class EdgelessWeightedSegment(BaseSegment):
     ndims = 3
     columns = ['x', 'y', 'weight']
     merged_columns = ['src_x', 'src_y', 'dst_x', 'dst_y', 'weight']
-
-    @classmethod
-    @nb.jit
-    def create_point(cls):
-        return np.array([0.0] * cls.ndims)
-
-    @classmethod
-    @nb.jit
-    def create_empty_points(cls, n):
-        return np.empty((n, cls.ndims))
-
-    @classmethod
-    @nb.jit
-    def create_delimiter(cls):
-        return np.array([[np.nan] * cls.ndims])
 
     @staticmethod
     @nb.jit

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -291,7 +291,7 @@ def _convert_graph_to_edge_segments(nodes, edges, include_edge_id, ignore_weight
     if include_edge_id:
         df = df.rename(columns={'id': 'edge_id'})
 
-    include_weight = not (ignore_weights or 'weight' not in edges)
+    include_weight = not ignore_weights and 'weight' in edges
 
     if include_edge_id:
         if include_weight:

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -385,7 +385,7 @@ class directly_connect_edges(param.ParameterizedFunction):
     """
 
     include_edge_id = param.Boolean(default=False, doc="""
-        """)
+        Include edge IDs in bundled dataframe""")
 
     def __call__(self, nodes, edges, **params):
         """
@@ -450,7 +450,7 @@ class hammer_bundle(directly_connect_edges):
         Maximum length (in data space?) for an edge segment""")
 
     include_edge_id = param.Boolean(default=False, doc="""
-        """)
+        Include edge IDs in bundled dataframe""")
 
     def __call__(self, nodes, edges, **params):
         p = param.ParamOverrides(self, params)

--- a/datashader/tests/test_bundling.py
+++ b/datashader/tests/test_bundling.py
@@ -23,7 +23,7 @@ def edges():
     # Four edges originating from the center node and connected to each
     # corner
     edges_df = pd.DataFrame({'id': np.arange(4),
-                             'source': np.zeros(4),
+                             'source': np.zeros(4, dtype=np.int),
                              'target': np.arange(1, 5)})
     edges_df.set_index('id')
     return edges_df
@@ -34,7 +34,7 @@ def weighted_edges():
     # Four weighted edges originating from the center node and connected
     # to each corner
     edges_df = pd.DataFrame({'id': np.arange(4),
-                             'source': np.zeros(4),
+                             'source': np.zeros(4, dtype=np.int),
                              'target': np.arange(1, 5),
                              'weight': np.ones(4)})
     edges_df.set_index('id')
@@ -51,13 +51,16 @@ def test_immutable_nodes(nodes, edges):
 def test_directly_connect_with_weights(nodes, weighted_edges):
     # Expect four lines starting at center (0.5, 0.5) and terminating
     # at a different corner and NaN
-    data = pd.DataFrame({'x':
+    data = pd.DataFrame({'edge_id':
+                            [1.0, 1.0, np.nan, 2.0, 2.0, np.nan,
+                             3.0, 3.0, np.nan, 4.0, 4.0, np.nan],
+                         'x':
                             [0.0, -100.0, np.nan, 0.0, 100.0, np.nan,
                              0.0, -100.0, np.nan, 0.0, 100.0, np.nan],
                          'y':
                             [0.0, 100.0, np.nan, 0.0, 100.0, np.nan,
                              0.0, -100.0, np.nan, 0.0, -100.0, np.nan]})
-    expected = pd.DataFrame(data, columns=['x', 'y'])
+    expected = pd.DataFrame(data, columns=['edge_id', 'x', 'y'])
 
     given = directly_connect_edges(nodes, weighted_edges)
     assert given.equals(expected)
@@ -66,13 +69,16 @@ def test_directly_connect_with_weights(nodes, weighted_edges):
 def test_directly_connect_without_weights(nodes, edges):
     # Expect four lines starting at center (0.5, 0.5) and terminating
     # at a different corner and NaN
-    data = pd.DataFrame({'x':
+    data = pd.DataFrame({'edge_id':
+                            [1.0, 1.0, np.nan, 2.0, 2.0, np.nan,
+                             3.0, 3.0, np.nan, 4.0, 4.0, np.nan],
+                         'x':
                             [0.0, -100.0, np.nan, 0.0, 100.0, np.nan,
                              0.0, -100.0, np.nan, 0.0, 100.0, np.nan],
                          'y':
                             [0.0, 100.0, np.nan, 0.0, 100.0, np.nan,
                              0.0, -100.0, np.nan, 0.0, -100.0, np.nan]})
-    expected = pd.DataFrame(data, columns=['x', 'y'])
+    expected = pd.DataFrame(data, columns=['edge_id', 'x', 'y'])
 
     given = directly_connect_edges(nodes, edges)
     assert given.equals(expected)
@@ -81,7 +87,10 @@ def test_directly_connect_without_weights(nodes, edges):
 def test_hammer_bundle_with_weights(nodes, weighted_edges):
     # Expect four lines starting at center (0.0, 0.0) and terminating
     # with NaN
-    data = pd.DataFrame({'x':
+    data = pd.DataFrame({'edge_id':
+                            [1.0, np.nan, 2.0, np.nan,
+                             3.0, np.nan, 4.0, np.nan],
+                         'x':
                             [0.0, np.nan, 0.0, np.nan,
                              0.0, np.nan, 0.0, np.nan],
                          'y':
@@ -90,7 +99,7 @@ def test_hammer_bundle_with_weights(nodes, weighted_edges):
                          'weight':
                             [1.0, np.nan, 1.0, np.nan,
                              1.0, np.nan, 1.0, np.nan]})
-    expected = pd.DataFrame(data, columns=['x', 'y', 'weight'])
+    expected = pd.DataFrame(data, columns=['edge_id', 'x', 'y', 'weight'])
 
     df = hammer_bundle(nodes, weighted_edges)
 
@@ -106,13 +115,16 @@ def test_hammer_bundle_with_weights(nodes, weighted_edges):
 def test_hammer_bundle_without_weights(nodes, edges):
     # Expect four lines starting at center (0.0, 0.0) and terminating
     # with NaN
-    data = pd.DataFrame({'x':
+    data = pd.DataFrame({'edge_id':
+                            [1.0, np.nan, 2.0, np.nan,
+                             3.0, np.nan, 4.0, np.nan],
+                         'x':
                             [0.0, np.nan, 0.0, np.nan,
                              0.0, np.nan, 0.0, np.nan],
                          'y':
                             [0.0, np.nan, 0.0, np.nan,
                              0.0, np.nan, 0.0, np.nan]})
-    expected = pd.DataFrame(data, columns=['x', 'y'])
+    expected = pd.DataFrame(data, columns=['edge_id', 'x', 'y'])
 
     df = hammer_bundle(nodes, edges)
 

--- a/datashader/tests/test_bundling.py
+++ b/datashader/tests/test_bundling.py
@@ -48,7 +48,8 @@ def test_immutable_nodes(nodes, edges):
     assert original.equals(nodes)
 
 
-def test_directly_connect_with_weights(nodes, weighted_edges):
+@pytest.mark.parametrize("include_edge_id", [True, False])
+def test_directly_connect_with_weights(nodes, weighted_edges, include_edge_id):
     # Expect four lines starting at center (0.5, 0.5) and terminating
     # at a different corner and NaN
     data = pd.DataFrame({'edge_id':
@@ -60,13 +61,15 @@ def test_directly_connect_with_weights(nodes, weighted_edges):
                          'y':
                             [0.0, 100.0, np.nan, 0.0, 100.0, np.nan,
                              0.0, -100.0, np.nan, 0.0, -100.0, np.nan]})
-    expected = pd.DataFrame(data, columns=['edge_id', 'x', 'y'])
+    columns = ['edge_id', 'x', 'y'] if include_edge_id else ['x', 'y']
+    expected = pd.DataFrame(data, columns=columns)
 
-    given = directly_connect_edges(nodes, weighted_edges)
+    given = directly_connect_edges(nodes, weighted_edges, include_edge_id=include_edge_id)
     assert given.equals(expected)
 
 
-def test_directly_connect_without_weights(nodes, edges):
+@pytest.mark.parametrize("include_edge_id", [True, False])
+def test_directly_connect_without_weights(nodes, edges, include_edge_id):
     # Expect four lines starting at center (0.5, 0.5) and terminating
     # at a different corner and NaN
     data = pd.DataFrame({'edge_id':
@@ -78,13 +81,15 @@ def test_directly_connect_without_weights(nodes, edges):
                          'y':
                             [0.0, 100.0, np.nan, 0.0, 100.0, np.nan,
                              0.0, -100.0, np.nan, 0.0, -100.0, np.nan]})
-    expected = pd.DataFrame(data, columns=['edge_id', 'x', 'y'])
+    columns = ['edge_id', 'x', 'y'] if include_edge_id else ['x', 'y']
+    expected = pd.DataFrame(data, columns=columns)
 
-    given = directly_connect_edges(nodes, edges)
+    given = directly_connect_edges(nodes, edges, include_edge_id=include_edge_id)
     assert given.equals(expected)
 
 
-def test_hammer_bundle_with_weights(nodes, weighted_edges):
+@pytest.mark.parametrize("include_edge_id", [True, False])
+def test_hammer_bundle_with_weights(nodes, weighted_edges, include_edge_id):
     # Expect four lines starting at center (0.0, 0.0) and terminating
     # with NaN
     data = pd.DataFrame({'edge_id':
@@ -99,9 +104,10 @@ def test_hammer_bundle_with_weights(nodes, weighted_edges):
                          'weight':
                             [1.0, np.nan, 1.0, np.nan,
                              1.0, np.nan, 1.0, np.nan]})
-    expected = pd.DataFrame(data, columns=['edge_id', 'x', 'y', 'weight'])
+    columns = ['edge_id', 'x', 'y', 'weight'] if include_edge_id else ['x', 'y', 'weight']
+    expected = pd.DataFrame(data, columns=columns)
 
-    df = hammer_bundle(nodes, weighted_edges)
+    df = hammer_bundle(nodes, weighted_edges, include_edge_id=include_edge_id)
 
     starts = df[(df.x == 0.0) & (df.y == 0.0)]
     ends = df[df.isnull().any(axis=1)]
@@ -112,7 +118,8 @@ def test_hammer_bundle_with_weights(nodes, weighted_edges):
     assert given.equals(expected)
 
 
-def test_hammer_bundle_without_weights(nodes, edges):
+@pytest.mark.parametrize("include_edge_id", [True, False])
+def test_hammer_bundle_without_weights(nodes, edges, include_edge_id):
     # Expect four lines starting at center (0.0, 0.0) and terminating
     # with NaN
     data = pd.DataFrame({'edge_id':
@@ -124,9 +131,10 @@ def test_hammer_bundle_without_weights(nodes, edges):
                          'y':
                             [0.0, np.nan, 0.0, np.nan,
                              0.0, np.nan, 0.0, np.nan]})
-    expected = pd.DataFrame(data, columns=['edge_id', 'x', 'y'])
+    columns = ['edge_id', 'x', 'y'] if include_edge_id else ['x', 'y']
+    expected = pd.DataFrame(data, columns=columns)
 
-    df = hammer_bundle(nodes, edges)
+    df = hammer_bundle(nodes, edges, include_edge_id=include_edge_id)
 
     starts = df[(df.x == 0.0) & (df.y == 0.0)]
     ends = df[df.isnull().any(axis=1)]


### PR DESCRIPTION
The edge ID is added to the bundled dataframe so that a user can retrieve the additional edge metadata without copying it into the dataframe.

The implementation was refactored for two reasons:

1. The edge segment constants and methods are collected into a specialized class. This replaces using the dimensions of an edge to differentiate.

2. We can now switch to structured NumPy arrays or XArray for easier reference to the individual points (instead of opaque numeric indices).