### PR TITLE
Enable appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Datashader
 ----------
 
-[![Build Status](https://travis-ci.org/bokeh/datashader.svg?branch=master)](https://travis-ci.org/bokeh/datashader)
+[![Travis build Status](https://travis-ci.org/bokeh/datashader.svg?branch=master)](https://travis-ci.org/bokeh/datashader)
+[![Appveyor build status](https://ci.appveyor.com/api/projects/status/h3lwh6ju4hfcgkm8/branch/master?svg=true)](https://ci.appveyor.com/project/bokeh-integrations/datashader/branch/master)
 [![Documentation Status](https://readthedocs.org/projects/datashader/badge/?version=latest)](http://datashader.readthedocs.org/en/latest/?badge=latest)
 [![Task Status](https://badge.waffle.io/bokeh/datashader.png?label=ready&title=tasks)](https://waffle.io/bokeh/datashader)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,12 @@ environment:
       PYTHON: "C:\\Python36-x64"
       CONDA: "C:\\Miniconda36-x64"
 
+matrix:
+  allow_failures:
+    - PY: "3.4"
+      PYTHON: "C:\\Python34-x64"
+      CONDA: "C:\\Miniconda3-x64"
+
 install:
   # Update path
   -  "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"


### PR DESCRIPTION
Includes allowing python 3.4 to fail (copying travis config).