### PR TITLE
Reorganize/update CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,54 @@
-language: python
-sudo: false
-python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
-    - "3.6"
+# Since Python doesn't work on osx travis images (see
+# https://github.com/travis-ci/travis-ci/issues/4729), and because
+# this project installs miniconda and uses conda rather than using
+# travis's python, we're deliberately not using travis's
+# language=python option.
 
-matrix:
-  fast_finish: True
-  # Allow py3.4 to fail; conda-forge no longer supports it
-  allow_failures:
-    - python: "3.4"
+language: generic
+
+os:
+  - linux
+  - osx
+
+# get a more recent version of osx than the default image
+osx_image: xcode8.3
+
+sudo: false
+
+env:
+  - PYTHON_VERSION="2.7"
+  - PYTHON_VERSION="3.5"
+  - PYTHON_VERSION="3.6"
 
 install:
   # Install conda
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi  
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
 
   # Install dependencies
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION
+  - conda create -n test-environment python=$PYTHON_VERSION
   - source activate test-environment
   - conda install dask numba numpy pandas pillow pytest toolz xarray datashape colorcet rasterio scikit-image param
   - conda install -c gbrener -c conda-forge xarray # remove this line when xarray >= 0.9.7
-
   # Optional dependencies, for testing only
   - conda install matplotlib
   # Dependencies for lint checking only
   - conda install jupyter flake8
 
   - python setup.py develop --no-deps
+  - conda env export
+
 
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then py.test datashader --doctest-modules --doctest-ignore-import-errors --verbose; else py.test datashader --verbose; fi
+    # TODO: why different tests for python 2 vs 3?
+    - if [[ $PYTHON_VERSION == '2.7' ]]; then py.test datashader --doctest-modules --doctest-ignore-import-errors --verbose; else py.test datashader --verbose; fi
     - flake8 --ignore E,W datashader examples
     # lint checking of example notebooks (ugly)
     - for NB in examples/*.ipynb; do sed -e 's/"[ ]*%/"#%/' "$NB" > "${NB}~"; done && jupyter nbconvert examples/*.ipynb~ --to script --output-dir examples/lint && flake8 --ignore=E,W examples/lint/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
-# Since Python doesn't work on osx travis images (see
-# https://github.com/travis-ci/travis-ci/issues/4729), and because
-# this project installs miniconda and uses conda rather than using
-# travis's python, we're deliberately not using travis's
-# language=python option.
-
+# We deliberately don't use travis's language=python option because
+# we install miniconda and use conda to get python. Additionally, 
+# Travis's auto-install of python doesn't work on osx images (see
+# https://github.com/travis-ci/travis-ci/issues/4729).
 language: generic
 
 os:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,21 +3,12 @@ environment:
     - PY: "2.7"
       PYTHON: "C:\\Python27-x64"
       CONDA: "C:\\Miniconda-x64"
-    - PY: "3.4"
-      PYTHON: "C:\\Python34-x64"
-      CONDA: "C:\\Miniconda3-x64"
     - PY: "3.5"
       PYTHON: "C:\\Python35-x64"
       CONDA: "C:\\Miniconda35-x64"
     - PY: "3.6"
       PYTHON: "C:\\Python36-x64"
       CONDA: "C:\\Miniconda36-x64"
-
-matrix:
-  allow_failures:
-    - PY: "3.4"
-      PYTHON: "C:\\Python34-x64"
-      CONDA: "C:\\Miniconda3-x64"
 
 install:
   # Update path
@@ -30,13 +21,14 @@ install:
   # Install dependencies
   - "conda create -n test-environment python=%PY%"
   - "activate test-environment"
+  # TODO: does not match linux/osx (see https://github.com/bokeh/datashader/issues/404)
   - "conda install dask numba numpy pandas pillow pytest toolz xarray datashape colorcet scikit-image param"
   - "conda install rasterio -c conda-forge"
-
   # Optional dependencies, for testing only
   - "conda install matplotlib"
 
   - "python setup.py develop --no-deps"
+  - "conda env export"
 
 build: off
 


### PR DESCRIPTION
1. Add osx (using osx_image to get a recent osx version).  

2. Switch to language=generic from language=python. Travis's python was not previously being used (conda is being used), but travis's python was still being installed. Apart from being unused, travis's auto-installation of python on osx fails.  

3. Drop python 3.4. Python 3.4 has already effectively been dropped because it's been failing every time (allowed failure).  

4. Some additional minor reorganization.