### PR TITLE
Fix inverted array indexing and off-by-one errors in canvas.raster

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -260,7 +260,8 @@ class Canvas(object):
 
         res = calc_res(source)
         ydim, xdim = source.dims[-2:]
-        left, bottom, right, top = calc_bbox(source[xdim].values, source[ydim].values, res)
+        xvals, yvals = source[xdim].values, source[ydim].values
+        left, bottom, right, top = calc_bbox(xvals, yvals, res)
         array = orient_array(source, res, layer)
         dtype = array.dtype
         if dtype.kind != 'f':
@@ -287,13 +288,8 @@ class Canvas(object):
 
         w = int(np.ceil(self.plot_width * width_ratio))
         h = int(np.ceil(self.plot_height * height_ratio))
-
-        ah, aw = array.shape if array.ndim == 2 else array.shape[1:]
-        cmin, rmin = get_indices(xmin, ymin, source[xdim].values, source[ydim].values, res)
-        cmax, rmax = get_indices(xmax, ymax, source[xdim].values, source[ydim].values, res)
-        rmin, rmax = ah-rmin-1, ah-rmax-1
-        if rmin > rmax: rmin, rmax = rmax, rmin
-        if cmin > cmax: cmin, cmax = cmax, cmin
+        cmin, cmax = get_indices(xmin, xmax, xvals, res[0])
+        rmin, rmax = get_indices(ymin, ymax, yvals, res[1])
 
         kwargs = dict(w=w, h=h, ds_method=downsample_methods[downsample_method],
                       us_method=upsample_methods[upsample_method], fill_value=fill_value)
@@ -351,7 +347,7 @@ class Canvas(object):
 
         # Compute DataArray metadata
         xs, ys = compute_coords(self.plot_width, self.plot_height, self.x_range, self.y_range, res)
-        coords = {xdim: xs, ydim: ys}
+        coords = {xdim: xs.astype(xvals.dtype), ydim: ys.astype(yvals.dtype)}
         dims = [ydim, xdim]
         attrs = dict(res=res[0])
         if source._file_obj is not None:

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -138,12 +138,12 @@ def test_raster_both_ascending_partial_range():
     ys = np.arange(5)
     arr = xs*ys[np.newaxis].T
     xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
-    cvs = ds.Canvas(9, 4, x_range=(-.5, 8.5), y_range=(-.5, 3.5))
+    cvs = ds.Canvas(7, 3, x_range=(.5, 7.5), y_range=(.5, 3.5))
     agg = cvs.raster(xarr)
 
-    assert np.allclose(agg.data, arr[1:, :-1])
-    assert np.allclose(agg.X.values, xs[:-1])
-    assert np.allclose(agg.Y.values, ys[:-1])
+    assert np.allclose(agg.data, xarr.sel(X=slice(1, 7), Y=slice(1, 3)))
+    assert np.allclose(agg.X.values, xs[1:8])
+    assert np.allclose(agg.Y.values, ys[1:4])
 
 
 def test_raster_both_descending():
@@ -171,12 +171,12 @@ def test_raster_both_descending_partial_range():
     ys = np.arange(5)[::-1]
     arr = xs*ys[np.newaxis].T
     xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
-    cvs = ds.Canvas(9, 4, x_range=(.5, 9.5), y_range=(.5, 4.5))
+    cvs = ds.Canvas(7, 3, x_range=(.5, 7.5), y_range=(.5, 3.5))
     agg = cvs.raster(xarr)
 
-    assert np.allclose(agg.data, arr[:-1, 1:])
-    assert np.allclose(agg.X.values, xs[:-1])
-    assert np.allclose(agg.Y.values, ys[:-1])
+    assert np.allclose(agg.data, xarr.sel(Y=slice(3,1), X=slice(7, 1)).data)
+    assert np.allclose(agg.X.values, xs[2:9])
+    assert np.allclose(agg.Y.values, ys[1:4])
 
 
 def test_raster_x_ascending_y_descending():
@@ -195,6 +195,22 @@ def test_raster_x_ascending_y_descending():
     assert np.allclose(agg.Y.values, ys)
 
 
+def test_raster_x_ascending_y_descending_partial_range():
+    """
+    Assert raster with ascending x- and descending y-coordinates is aggregated correctly.
+    """
+    xs = np.arange(10)
+    ys = np.arange(5)[::-1]
+    arr = xs*ys[np.newaxis].T
+    xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
+    cvs = ds.Canvas(7, 2, x_range=(0.5, 7.5), y_range=(1.5, 3.5))
+    agg = cvs.raster(xarr)
+
+    assert np.allclose(agg.data, xarr.sel(X=slice(1, 7), Y=slice(3, 2)).data)
+    assert np.allclose(agg.X.values, xs[1:8])
+    assert np.allclose(agg.Y.values, ys[1:3])
+
+
 def test_raster_x_descending_y_ascending():
     """
     Assert raster with descending x- and ascending y-coordinates is aggregated correctly.
@@ -209,6 +225,22 @@ def test_raster_x_descending_y_ascending():
     assert np.allclose(agg.data, arr)
     assert np.allclose(agg.X.values, xs)
     assert np.allclose(agg.Y.values, ys)
+
+
+def test_raster_x_descending_y_ascending_partial_range():
+    """
+    Assert raster with descending x- and ascending y-coordinates is aggregated correctly.
+    """
+    xs = np.arange(10)[::-1]
+    ys = np.arange(5)
+    arr = xs*ys[np.newaxis].T
+    xarr = xr.DataArray(arr, coords={'X': xs, 'Y': ys}, dims=['Y', 'X'])
+    cvs = ds.Canvas(7, 2, x_range=(.5, 7.5), y_range=(1.5, 3.5))
+    agg = cvs.raster(xarr)
+
+    assert np.allclose(agg.data, xarr.sel(X=slice(7, 1), Y=slice(2, 3)).data)
+    assert np.allclose(agg.X.values, xs[2:9])
+    assert np.allclose(agg.Y.values, ys[2:4])
 
 
 def test_raster_integer_nan_value():

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import math
 
 from inspect import getmro
 
@@ -115,48 +116,27 @@ def calc_bbox(xs, ys, res):
     return xmin-xpad, ymin+ypad, xmax-xpad, ymax+ypad
 
 
-def get_indices(x, y, xs, ys, res):
-    """Return indices corresponding to transformed coordinates (x, y).
-    This calculation assumes the raster is uniformly sampled
-    (equivalent to a flat-earth assumption, for geographic data) with
-    an invertible affine transformation matrix, so that an inverse
-    affine transform can be used:
-    https://en.wikipedia.org/wiki/Affine_transformation#Groups 
-    
+def get_indices(start, end, coords, res):
+    """
+    Transform continuous start and end coordinates into array indices.
+
     Parameters
     ----------
-    x : float
-        x-coordinate of the transformed point.
-    y : float
-        y-coordinate of the transformed point.
-    xs : numpy.array
-        1D NumPy array of floats representing the x-values of a raster. This
-        likely originated from an xarray.DataArray or xarray.Dataset object
-        (xr.open_rasterio).
-    ys : numpy.array
-        1D NumPy array of floats representing the y-values of a raster. This
-        likely originated from an xarray.DataArray or xarray.Dataset object
-        (xr.open_rasterio).
+    start : float
+        coordinate of the lower bound.
+    end : float
+        coordinate of the upper bound.
+    coords : numpy.ndarray
+        coordinate values along the axis.
     res : tuple
-        Two-tuple (int, int) which includes x and y resolutions (aka "grid/cell
-        sizes"), respectively.
+        Resolution along an axis (aka "grid/cell sizes")
     """
-    ybound = ys.min() if res[1] < 0 else ys.max()
-    xbound = xs.max() if res[0] < 0 else xs.min()
-
-    Ab = np.array([[res[0], 0.,      xbound],
-                   [0.,     -res[1], ybound],
-                   [0.,     0.,      1.]])
-    nrows, ncols = Ab.shape
-    A = Ab[:nrows-1, :ncols-1]
-    b = Ab[:, ncols-1][:nrows-1]
-    A_inv = np.linalg.inv(A)
-    A_ = np.vstack([A_inv, np.zeros(A_inv.shape[1])])
-    neg__Ainv__dot__b = -np.dot(A_inv, b)
-    b_ = np.hstack([neg__Ainv__dot__b, [1]]).reshape(neg__Ainv__dot__b.shape[0]+1, 1)
-    affine_inv = np.hstack([A_, b_])
-    x_, y_, _ = np.dot(affine_inv, np.array([x, y, 1.]))
-    return int(x_), int(y_)
+    size = len(coords)
+    half = abs(res)/2.
+    vmin, vmax = coords.min(), coords.max()
+    span = vmax-vmin
+    start, end = start+half-vmin, end-half-vmin
+    return int((start/span)*size), int((end/span)*size)
 
 
 def orient_array(raster, res=None, layer=None):

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import math
 
 from inspect import getmro
 


### PR DESCRIPTION
While testing the regridding implementation @jbednar identified a bug in the code, which were caused by array indices being inverted in certain cases. I tried for a long time to get the previous approach using affine transforms working but kept running into various off-by-one issues, which seemed to be caused by rounding issues in the affine transform code. I've now replaced this code with an approach that simply converts continuous coordinates to array indices by normalizing and then rescaling them. Not only do I understand this approach better but it now works consistently.

If you have a minute it would be good if you could review this @gbrener as I'm still trying to figure out what the affine transform approach gives us that's not handled by this simpler normalize and rescale approach.