### PR TITLE
Fix segmentation fault due to improper indices

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -114,18 +114,18 @@ def resample_edges(edge_segments, min_segment_length, max_segment_length, segmen
 
 
 @nb.jit
-def smooth_segment(segments, tension):
+def smooth_segment(segments, tension, idx, idy):
     seg_length = len(segments) - 2
     for i in range(1, seg_length):
         previous, current, next_point = segments[i - 1], segments[i], segments[i + 1]
-        current[1] = ((1 - tension) * current[1]) + (tension * (previous[1] + next_point[1]) / 2)
-        current[2] = ((1 - tension) * current[2]) + (tension * (previous[2] + next_point[2]) / 2)
+        current[idx] = ((1 - tension) * current[idx]) + (tension * (previous[idx] + next_point[idx]) / 2)
+        current[idy] = ((1 - tension) * current[idy]) + (tension * (previous[idy] + next_point[idy]) / 2)
 
 
 @nb.jit
-def smooth(edge_segments, tension):
+def smooth(edge_segments, tension, idx, idy):
     for segments in edge_segments:
-        smooth_segment(segments, tension)
+        smooth_segment(segments, tension, idx, idy)
 
 
 @ngjit
@@ -462,7 +462,7 @@ class hammer_bundle(directly_connect_edges):
         # Smooth out the graph
         for i in range(10):
             for batch in edge_segments:
-                smooth(batch, p.tension)
+                smooth(batch, p.tension, segment_class.idx, segment_class.idy)
 
         # Flatten things
         new_segs = []

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -67,7 +67,7 @@ def resample_segment(segments, new_segments, min_segment_length, max_segment_len
 
 
 @nb.jit
-def calculate_length(segments, min_segment_length, max_segment_length, segment_class):
+def calculate_length(segments, min_segment_length, max_segment_length):
     current_point = segments[0]
     index = 1
     total = 0
@@ -97,7 +97,7 @@ def calculate_length(segments, min_segment_length, max_segment_length, segment_c
 
 
 def resample_edge(segments, min_segment_length, max_segment_length, segment_class):
-    change, total_resamples = calculate_length(segments, min_segment_length, max_segment_length, segment_class)
+    change, total_resamples = calculate_length(segments, min_segment_length, max_segment_length)
     if not change:
         return segments
     resampled = segment_class.create_empty_points(total_resamples)

--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -129,19 +129,19 @@ def smooth(edge_segments, tension):
 
 
 @ngjit
-def advect_segments(segments, vert, horiz, accuracy):
+def advect_segments(segments, vert, horiz, accuracy, idx, idy):
     for i in range(1, len(segments) - 1):
-        x = int(segments[i][1] * accuracy)
-        y = int(segments[i][2] * accuracy)
-        segments[i][1] = segments[i][1] + horiz[x, y] / accuracy
-        segments[i][2] = segments[i][2] + vert[x, y] / accuracy
-        segments[i][1] = max(0, min(segments[i][1], 1))
-        segments[i][2] = max(0, min(segments[i][2], 1))
+        x = int(segments[i][idx] * accuracy)
+        y = int(segments[i][idy] * accuracy)
+        segments[i][idx] = segments[i][idx] + horiz[x, y] / accuracy
+        segments[i][idy] = segments[i][idy] + vert[x, y] / accuracy
+        segments[i][idx] = max(0, min(segments[i][idx], 1))
+        segments[i][idy] = max(0, min(segments[i][idy], 1))
 
 
 def advect_and_resample(vert, horiz, segments, iterations, accuracy, min_segment_length, max_segment_length, segment_class):
     for it in range(iterations):
-        advect_segments(segments, vert, horiz, accuracy)
+        advect_segments(segments, vert, horiz, accuracy, segment_class.idx, segment_class.idy)
         if it % 2 == 0:
             segments = resample_edge(segments, min_segment_length, max_segment_length, segment_class)
     return segments
@@ -203,6 +203,7 @@ class UnweightedSegment(BaseSegment):
     ndims = 3
     columns = ['edge_id', 'x', 'y']
     merged_columns = ['edge_id', 'src_x', 'src_y', 'dst_x', 'dst_y']
+    idx, idy = 1, 2
 
     @staticmethod
     @nb.jit
@@ -219,6 +220,7 @@ class EdgelessUnweightedSegment(BaseSegment):
     ndims = 2
     columns = ['x', 'y']
     merged_columns = ['src_x', 'src_y', 'dst_x', 'dst_y']
+    idx, idy = 0, 1
 
     @staticmethod
     @nb.jit
@@ -235,6 +237,7 @@ class WeightedSegment(BaseSegment):
     ndims = 4
     columns = ['edge_id', 'x', 'y', 'weight']
     merged_columns = ['edge_id', 'src_x', 'src_y', 'dst_x', 'dst_y', 'weight']
+    idx, idy = 1, 2
 
     @staticmethod
     @nb.jit
@@ -251,6 +254,7 @@ class EdgelessWeightedSegment(BaseSegment):
     ndims = 3
     columns = ['x', 'y', 'weight']
     merged_columns = ['src_x', 'src_y', 'dst_x', 'dst_y', 'weight']
+    idx, idy = 0, 1
 
     @staticmethod
     @nb.jit


### PR DESCRIPTION
Since edge IDs are optional, the exact coordinate indices for a segment can change. I added pre-defined x-y coordinate indices for a given segment to each subclass.

This will be deprecated if we switch over to structured NumPy arrays or xarray.

Fix #477 and #481