### PR TITLE
Optimize resampling operations

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -265,8 +265,6 @@ class Canvas(object):
         left, bottom, right, top = calc_bbox(xvals, yvals, res)
         array = orient_array(source, res, layer)
         dtype = array.dtype
-        if dtype.kind != 'f':
-            array = array.astype(np.float64)
 
         if nan_value is not None:
             mask = array==nan_value
@@ -298,10 +296,14 @@ class Canvas(object):
             source_window = array[rmin:rmax+1, cmin:cmax+1]
             if isinstance(source_window, Array):
                 source_window = source_window.compute()
+            if downsample_method in ['var', 'std']:
+                source_window = source_window.astype('f')
             data = resample_2d(source_window, **kwargs)
             layers = 1
         else:
             source_window = array[:, rmin:rmax+1, cmin:cmax+1]
+            if downsample_method in ['var', 'std']:
+                source_window = source_window.astype('f')
             arrays = []
             for arr in source_window:
                 if isinstance(arr, Array):
@@ -348,11 +350,12 @@ class Canvas(object):
             data = data.filled()
 
         # Restore original dtype
-        data = data.astype(dtype)
+        if dtype != data.dtype:
+            data = data.astype(dtype)
 
         # Compute DataArray metadata
         xs, ys = compute_coords(self.plot_width, self.plot_height, self.x_range, self.y_range, res)
-        coords = {xdim: xs.astype(xvals.dtype), ydim: ys.astype(yvals.dtype)}
+        coords = {xdim: xs, ydim: ys}
         dims = [ydim, xdim]
         attrs = dict(res=res[0])
         if source._file_obj is not None:

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -37,7 +37,7 @@ try:
     def _sentinel_function(): return 0
     _sentinel_function()
 except:
-    ngjit_parallel, prange = ngjit, range
+    ngjit_parallel, prange = ngjit, range # NOQA
 
 
 #: Interpolation method for upsampling: Take nearest source grid cell, even if it is invalid.
@@ -252,7 +252,7 @@ def _resample_2d(src, mask, use_mask, ds_method, us_method, fill_value, mode_ran
             # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
             return upsampling_method(temp, mask, use_mask, fill_value, out)
         else:
-            return downsampling_method(src, mask, use_mask, fill_value, mode_rank, out)
+            return downsampling_method(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
     elif out_h < src_h:
         if out_w > src_w:
             temp = np.zeros((out_h, src_w), dtype=src.dtype)

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -1,8 +1,18 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-from .utils import ngjit_parallel
+
 from numba import prange
+from .utils import ngjit, ngjit_parallel
+
+try:
+    # Determine if system support numba 'parallel' target
+    @ngjit_parallel
+    def _sentinel_function(): return 0
+    _sentinel_function()
+except:
+    ngjit_parallel, prange = ngjit, range
+
 
 #: Interpolation method for upsampling: Take nearest source grid cell, even if it is invalid.
 US_NEAREST = 10

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -97,7 +97,12 @@ def upsample_2d(src, w, h, method=US_LINEAR, fill_value=None, out=None):
         return src
     mask, use_mask = _get_mask(src)
     fill_value = _get_fill_value(fill_value, src, out)
-    return _mask_or_not(_upsample_2d(src, mask, use_mask, method, fill_value, out), src, fill_value)
+
+    if method not in UPSAMPLING_METHODS:
+        raise ValueError('invalid upsampling method')
+
+    upsampling_method = UPSAMPLING_METHODS[method]
+    return _mask_or_not(upsampling_method(src, mask, use_mask, fill_value, out), src, fill_value)
 
 
 def downsample_2d(src, w, h, method=DS_MEAN, fill_value=None, mode_rank=1, out=None):
@@ -130,7 +135,12 @@ def downsample_2d(src, w, h, method=DS_MEAN, fill_value=None, mode_rank=1, out=N
         return src
     mask, use_mask = _get_mask(src)
     fill_value = _get_fill_value(fill_value, src, out)
-    return _mask_or_not(_downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out), src, fill_value)
+
+    if method not in DOWNSAMPLING_METHODS:
+        raise ValueError('invalid downsampling method')
+
+    downsampling_method = DOWNSAMPLING_METHODS[method]
+    return _mask_or_not(downsampling_method(src, mask, use_mask, method, fill_value, mode_rank, out), src, fill_value)
 
 
 def _get_out(out, src, shape):
@@ -177,130 +187,145 @@ def _get_fill_value(fill_value, src, out):
 
 
 @ngjit
-def _resample_2d(src, mask, use_mask, ds_method, us_method, fill_value, mode_rank, out):
+def _get_dimensions(src, out):
     src_w = src.shape[-1]
     src_h = src.shape[-2]
     out_w = out.shape[-1]
     out_h = out.shape[-2]
+    return src_w, src_h, out_w, out_h
+
+
+def _resample_2d(src, mask, use_mask, ds_method, us_method, fill_value, mode_rank, out):
+    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
+
+    if us_method not in UPSAMPLING_METHODS:
+        raise ValueError('invalid upsampling method')
+    elif ds_method not in DOWNSAMPLING_METHODS:
+        raise ValueError('invalid downsampling method')
+
+    downsampling_method = DOWNSAMPLING_METHODS[ds_method]
+    upsampling_method = UPSAMPLING_METHODS[us_method]
 
     if out_w < src_w and out_h < src_h:
-        return _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
+        return downsampling_method(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
     elif out_w < src_w:
         if out_h > src_h:
             temp = np.zeros((src_h, out_w), dtype=src.dtype)
-            temp = _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, temp)
+            temp = downsampling_method(src, mask, use_mask, ds_method, fill_value, mode_rank, temp)
             # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
-            return _upsample_2d(temp, mask, use_mask, us_method, fill_value, out)
+            return upsampling_method(temp, mask, use_mask, fill_value, out)
         else:
-            return _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
+            return downsampling_method(src, mask, use_mask, fill_value, mode_rank, out)
     elif out_h < src_h:
         if out_w > src_w:
             temp = np.zeros((out_h, src_w), dtype=src.dtype)
-            temp = _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, temp)
+            temp = downsampling_method(src, mask, use_mask, ds_method, fill_value, mode_rank, temp)
             # todo - write test & fix: must use mask=np.ma.getmaskarray(temp) here if use_mask==True
-            return _upsample_2d(temp, mask, use_mask, us_method, fill_value, out)
+            return upsampling_method(temp, mask, use_mask, fill_value, out)
         else:
-            return _downsample_2d(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
+            return downsampling_method(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
     elif out_w > src_w or out_h > src_h:
-        return _upsample_2d(src, mask, use_mask, us_method, fill_value, out)
+        return upsampling_method(src, mask, use_mask, fill_value, out)
     return src
 
 
 @ngjit
-def _upsample_2d(src, mask, use_mask, method, fill_value, out):
-    src_w = src.shape[-1]
-    src_h = src.shape[-2]
-    out_w = out.shape[-1]
-    out_h = out.shape[-2]
-
+def _upsample_2d_nearest(src, mask, use_mask, fill_value, out):
+    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
     if src_w == out_w and src_h == out_h:
         return src
 
     if out_w < src_w or out_h < src_h:
         raise ValueError("invalid target size")
 
-    if method == US_NEAREST:
-        scale_x = src_w / out_w
-        scale_y = src_h / out_h
-        for out_y in range(out_h):
-            src_y = int(scale_y * out_y)
-            for out_x in range(out_w):
-                src_x = int(scale_x * out_x)
-                value = src[src_y, src_x]
-                if np.isfinite(value) and not (use_mask and mask[src_y, src_x]):
-                    out[out_y, out_x] = value
-                else:
-                    out[out_y, out_x] = fill_value
-
-    elif method == US_LINEAR:
-        scale_x = (src_w - 1.0) / ((out_w - 1.0) if out_w > 1 else 1.0)
-        scale_y = (src_h - 1.0) / ((out_h - 1.0) if out_h > 1 else 1.0)
-        for out_y in range(out_h):
-            src_yf = scale_y * out_y
-            src_y0 = int(src_yf)
-            wy = src_yf - src_y0
-            src_y1 = src_y0 + 1
-            if src_y1 >= src_h:
-                src_y1 = src_y0
-            for out_x in range(out_w):
-                src_xf = scale_x * out_x
-                src_x0 = int(src_xf)
-                wx = src_xf - src_x0
-                src_x1 = src_x0 + 1
-                if src_x1 >= src_w:
-                    src_x1 = src_x0
-                v00 = src[src_y0, src_x0]
-                v01 = src[src_y0, src_x1]
-                v10 = src[src_y1, src_x0]
-                v11 = src[src_y1, src_x1]
-                if use_mask:
-                    v00_ok = np.isfinite(v00) and not mask[src_y0, src_x0]
-                    v01_ok = np.isfinite(v01) and not mask[src_y0, src_x1]
-                    v10_ok = np.isfinite(v10) and not mask[src_y1, src_x0]
-                    v11_ok = np.isfinite(v11) and not mask[src_y1, src_x1]
-                else:
-                    v00_ok = np.isfinite(v00)
-                    v01_ok = np.isfinite(v01)
-                    v10_ok = np.isfinite(v10)
-                    v11_ok = np.isfinite(v11)
-                if v00_ok and v01_ok and v10_ok and v11_ok:
-                    ok = True
-                    v0 = v00 + wx * (v01 - v00)
-                    v1 = v10 + wx * (v11 - v10)
-                    value = v0 + wy * (v1 - v0)
-                elif wx < 0.5:
-                    # NEAREST according to weight
-                    if wy < 0.5:
-                        ok = v00_ok
-                        value = v00
-                    else:
-                        ok = v10_ok
-                        value = v10
-                else:
-                    # NEAREST according to weight
-                    if wy < 0.5:
-                        ok = v01_ok
-                        value = v01
-                    else:
-                        ok = v11_ok
-                        value = v11
-                if ok:
-                    out[out_y, out_x] = value
-                else:
-                    out[out_y, out_x] = fill_value
-
-    else:
-        raise ValueError('invalid upsampling method')
-
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+    for out_y in range(out_h):
+        src_y = int(scale_y * out_y)
+        for out_x in range(out_w):
+            src_x = int(scale_x * out_x)
+            value = src[src_y, src_x]
+            if np.isfinite(value) and not (use_mask and mask[src_y, src_x]):
+                out[out_y, out_x] = value
+            else:
+                out[out_y, out_x] = fill_value
     return out
 
 
 @ngjit
-def _downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out):
-    src_w = src.shape[-1]
-    src_h = src.shape[-2]
-    out_w = out.shape[-1]
-    out_h = out.shape[-2]
+def _upsample_2d_linear(src, mask, use_mask, fill_value, out):
+    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w < src_w or out_h < src_h:
+        raise ValueError("invalid target size")
+
+    scale_x = (src_w - 1.0) / ((out_w - 1.0) if out_w > 1 else 1.0)
+    scale_y = (src_h - 1.0) / ((out_h - 1.0) if out_h > 1 else 1.0)
+    for out_y in range(out_h):
+        src_yf = scale_y * out_y
+        src_y0 = int(src_yf)
+        wy = src_yf - src_y0
+        src_y1 = src_y0 + 1
+        if src_y1 >= src_h:
+            src_y1 = src_y0
+        for out_x in range(out_w):
+            src_xf = scale_x * out_x
+            src_x0 = int(src_xf)
+            wx = src_xf - src_x0
+            src_x1 = src_x0 + 1
+            if src_x1 >= src_w:
+                src_x1 = src_x0
+            v00 = src[src_y0, src_x0]
+            v01 = src[src_y0, src_x1]
+            v10 = src[src_y1, src_x0]
+            v11 = src[src_y1, src_x1]
+            if use_mask:
+                v00_ok = np.isfinite(v00) and not mask[src_y0, src_x0]
+                v01_ok = np.isfinite(v01) and not mask[src_y0, src_x1]
+                v10_ok = np.isfinite(v10) and not mask[src_y1, src_x0]
+                v11_ok = np.isfinite(v11) and not mask[src_y1, src_x1]
+            else:
+                v00_ok = np.isfinite(v00)
+                v01_ok = np.isfinite(v01)
+                v10_ok = np.isfinite(v10)
+                v11_ok = np.isfinite(v11)
+            if v00_ok and v01_ok and v10_ok and v11_ok:
+                ok = True
+                v0 = v00 + wx * (v01 - v00)
+                v1 = v10 + wx * (v11 - v10)
+                value = v0 + wy * (v1 - v0)
+            elif wx < 0.5:
+                # NEAREST according to weight
+                if wy < 0.5:
+                    ok = v00_ok
+                    value = v00
+                else:
+                    ok = v10_ok
+                    value = v10
+            else:
+                # NEAREST according to weight
+                if wy < 0.5:
+                    ok = v01_ok
+                    value = v01
+                else:
+                    ok = v11_ok
+                    value = v11
+            if ok:
+                out[out_y, out_x] = value
+            else:
+                out[out_y, out_x] = fill_value
+    return out
+
+
+UPSAMPLING_METHODS = {US_LINEAR: _upsample_2d_linear,
+                      US_NEAREST: _upsample_2d_nearest}
+
+
+@ngjit
+def _downsample_2d_first_last(src, mask, use_mask, method, fill_value, mode_rank, out):
+    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
 
     if src_w == out_w and src_h == out_h:
         return src
@@ -311,222 +336,284 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out):
     scale_x = src_w / out_w
     scale_y = src_h / out_h
 
-    if method == DS_FIRST or method == DS_LAST:
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            wy1 = src_yf1 - src_y1
-            if wy1 < _EPS and src_y1 > src_y0:
-                src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                wx1 = src_xf1 - src_x1
-                if wx1 < _EPS and src_x1 > src_x0:
-                    src_x1 -= 1
-                done = False
-                value = fill_value
-                for src_y in range(src_y0, src_y1 + 1):
-                    for src_x in range(src_x0, src_x1 + 1):
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            value = v
-                            if method == DS_FIRST:
-                                done = True
-                                break
-                    if done:
-                        break
-                out[out_y, out_x] = value
-    elif method in [DS_MIN, DS_MAX]:
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            wy1 = src_yf1 - src_y1
-            if wy1 < _EPS and src_y1 > src_y0:
-                src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                wx1 = src_xf1 - src_x1
-                if wx1 < _EPS and src_x1 > src_x0:
-                    src_x1 -= 1
-                if method == DS_MIN:
-                    value = np.inf
-                else:
-                    value = -np.inf
-                for src_y in range(src_y0, src_y1 + 1):
-                    for src_x in range(src_x0, src_x1 + 1):
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            if method == DS_MIN:
-                                if v < value:
-                                    value = v
-                            else:
-                                if v > value:
-                                    value = v
-                if np.isfinite(value):
-                    out[out_y, out_x] = value
-                else:
-                    out[out_y, out_x] = fill_value
-
-    elif method == DS_MODE:
-        max_value_count = int(scale_x + 1) * int(scale_y + 1)
-        values = np.zeros((max_value_count,), dtype=src.dtype)
-        frequencies = np.zeros((max_value_count,), dtype=np.uint32)
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            wy0 = 1.0 - (src_yf0 - src_y0)
-            wy1 = src_yf1 - src_y1
-            if wy1 < _EPS:
-                wy1 = 1.0
-                if src_y1 > src_y0:
-                    src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                wx0 = 1.0 - (src_xf0 - src_x0)
-                wx1 = src_xf1 - src_x1
-                if wx1 < _EPS:
-                    wx1 = 1.0
-                    if src_x1 > src_x0:
-                        src_x1 -= 1
-                value_count = 0
-                for src_y in range(src_y0, src_y1 + 1):
-                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
-                    for src_x in range(src_x0, src_x1 + 1):
-                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            w = wx * wy
-                            found = False
-                            for i in range(value_count):
-                                if v == values[i]:
-                                    frequencies[i] += w
-                                    found = True
-                                    break
-                            if not found:
-                                values[value_count] = v
-                                frequencies[value_count] = w
-                                value_count += 1
-                w_max = -1.
-                value = fill_value
-                if mode_rank == 1:
-                    for i in range(value_count):
-                        w = frequencies[i]
-                        if w > w_max:
-                            w_max = w
-                            value = values[i]
-                elif mode_rank <= max_value_count:
-                    max_frequencies = np.full(mode_rank, -1.0, dtype=np.float64)
-                    indices = np.zeros(mode_rank, dtype=np.int64)
-                    for i in range(value_count):
-                        w = frequencies[i]
-                        for j in range(mode_rank):
-                            if w > max_frequencies[j]:
-                                max_frequencies[j] = w
-                                indices[j] = i
-                                break
-                    value = values[indices[mode_rank - 1]]
-
-                out[out_y, out_x] = value
-
-    elif method == DS_MEAN:
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            wy0 = 1.0 - (src_yf0 - src_y0)
-            wy1 = src_yf1 - src_y1
-            if wy1 < _EPS:
-                wy1 = 1.0
-                if src_y1 > src_y0:
-                    src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                wx0 = 1.0 - (src_xf0 - src_x0)
-                wx1 = src_xf1 - src_x1
-                if wx1 < _EPS:
-                    wx1 = 1.0
-                    if src_x1 > src_x0:
-                        src_x1 -= 1
-                v_sum = 0.0
-                w_sum = 0.0
-                for src_y in range(src_y0, src_y1 + 1):
-                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
-                    for src_x in range(src_x0, src_x1 + 1):
-                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            w = wx * wy
-                            v_sum += w * v
-                            w_sum += w
-                if w_sum < _EPS:
-                    out[out_y, out_x] = fill_value
-                else:
-                    out[out_y, out_x] = v_sum / w_sum
-
-    elif method == DS_VAR or method == DS_STD:
-        for out_y in range(out_h):
-            src_yf0 = scale_y * out_y
-            src_yf1 = src_yf0 + scale_y
-            src_y0 = int(src_yf0)
-            src_y1 = int(src_yf1)
-            wy0 = 1.0 - (src_yf0 - src_y0)
-            wy1 = src_yf1 - src_y1
-            if wy1 < _EPS:
-                wy1 = 1.0
-                if src_y1 > src_y0:
-                    src_y1 -= 1
-            for out_x in range(out_w):
-                src_xf0 = scale_x * out_x
-                src_xf1 = src_xf0 + scale_x
-                src_x0 = int(src_xf0)
-                src_x1 = int(src_xf1)
-                wx0 = 1.0 - (src_xf0 - src_x0)
-                wx1 = src_xf1 - src_x1
-                if wx1 < _EPS:
-                    wx1 = 1.0
-                    if src_x1 > src_x0:
-                        src_x1 -= 1
-                v_sum = 0.0
-                w_sum = 0.0
-                wv_sum = 0.0
-                wvv_sum = 0.0
-                for src_y in range(src_y0, src_y1 + 1):
-                    wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
-                    for src_x in range(src_x0, src_x1 + 1):
-                        wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
-                        v = src[src_y, src_x]
-                        if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
-                            w = wx * wy
-                            v_sum += v
-                            w_sum += w
-                            wv_sum += w * v
-                            wvv_sum += w * v * v
-                if w_sum < _EPS:
-                    out[out_y, out_x] = fill_value
-                else:
-                    out[out_y, out_x] = (wvv_sum * w_sum - wv_sum * wv_sum) / w_sum / w_sum
-        if method == DS_STD:
-            out = np.sqrt(out)
-    else:
-        raise ValueError('invalid upsampling method')
-
+    for out_y in range(out_h):
+        src_yf0 = scale_y * out_y
+        src_yf1 = src_yf0 + scale_y
+        src_y0 = int(src_yf0)
+        src_y1 = int(src_yf1)
+        wy1 = src_yf1 - src_y1
+        if wy1 < _EPS and src_y1 > src_y0:
+            src_y1 -= 1
+        for out_x in range(out_w):
+            src_xf0 = scale_x * out_x
+            src_xf1 = src_xf0 + scale_x
+            src_x0 = int(src_xf0)
+            src_x1 = int(src_xf1)
+            wx1 = src_xf1 - src_x1
+            if wx1 < _EPS and src_x1 > src_x0:
+                src_x1 -= 1
+            done = False
+            value = fill_value
+            for src_y in range(src_y0, src_y1 + 1):
+                for src_x in range(src_x0, src_x1 + 1):
+                    v = src[src_y, src_x]
+                    if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                        value = v
+                        if method == DS_FIRST:
+                            done = True
+                            break
+                if done:
+                    break
+            out[out_y, out_x] = value
     return out
+
+
+@ngjit
+def _downsample_2d_min_max(src, mask, use_mask, method, fill_value, mode_rank, out):
+    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w > src_w or out_h > src_h:
+        raise ValueError("invalid target size")
+
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+
+    for out_y in range(out_h):
+        src_yf0 = scale_y * out_y
+        src_yf1 = src_yf0 + scale_y
+        src_y0 = int(src_yf0)
+        src_y1 = int(src_yf1)
+        wy1 = src_yf1 - src_y1
+        if wy1 < _EPS and src_y1 > src_y0:
+            src_y1 -= 1
+        for out_x in range(out_w):
+            src_xf0 = scale_x * out_x
+            src_xf1 = src_xf0 + scale_x
+            src_x0 = int(src_xf0)
+            src_x1 = int(src_xf1)
+            wx1 = src_xf1 - src_x1
+            if wx1 < _EPS and src_x1 > src_x0:
+                src_x1 -= 1
+            if method == DS_MIN:
+                value = np.inf
+            else:
+                value = -np.inf
+            for src_y in range(src_y0, src_y1 + 1):
+                for src_x in range(src_x0, src_x1 + 1):
+                    v = src[src_y, src_x]
+                    if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                        if method == DS_MIN:
+                            if v < value:
+                                value = v
+                        else:
+                            if v > value:
+                                value = v
+            if np.isfinite(value):
+                out[out_y, out_x] = value
+            else:
+                out[out_y, out_x] = fill_value
+    return out
+
+
+@ngjit
+def _downsample_2d_mode(src, mask, use_mask, method, fill_value, mode_rank, out):
+    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w > src_w or out_h > src_h:
+        raise ValueError("invalid target size")
+
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+
+    max_value_count = int(scale_x + 1) * int(scale_y + 1)
+    values = np.zeros((max_value_count,), dtype=src.dtype)
+    frequencies = np.zeros((max_value_count,), dtype=np.uint32)
+    for out_y in range(out_h):
+        src_yf0 = scale_y * out_y
+        src_yf1 = src_yf0 + scale_y
+        src_y0 = int(src_yf0)
+        src_y1 = int(src_yf1)
+        wy0 = 1.0 - (src_yf0 - src_y0)
+        wy1 = src_yf1 - src_y1
+        if wy1 < _EPS:
+            wy1 = 1.0
+            if src_y1 > src_y0:
+                src_y1 -= 1
+        for out_x in range(out_w):
+            src_xf0 = scale_x * out_x
+            src_xf1 = src_xf0 + scale_x
+            src_x0 = int(src_xf0)
+            src_x1 = int(src_xf1)
+            wx0 = 1.0 - (src_xf0 - src_x0)
+            wx1 = src_xf1 - src_x1
+            if wx1 < _EPS:
+                wx1 = 1.0
+                if src_x1 > src_x0:
+                    src_x1 -= 1
+            value_count = 0
+            for src_y in range(src_y0, src_y1 + 1):
+                wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                for src_x in range(src_x0, src_x1 + 1):
+                    wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                    v = src[src_y, src_x]
+                    if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                        w = wx * wy
+                        found = False
+                        for i in range(value_count):
+                            if v == values[i]:
+                                frequencies[i] += w
+                                found = True
+                                break
+                        if not found:
+                            values[value_count] = v
+                            frequencies[value_count] = w
+                            value_count += 1
+            w_max = -1.
+            value = fill_value
+            if mode_rank == 1:
+                for i in range(value_count):
+                    w = frequencies[i]
+                    if w > w_max:
+                        w_max = w
+                        value = values[i]
+            elif mode_rank <= max_value_count:
+                max_frequencies = np.full(mode_rank, -1.0, dtype=np.float64)
+                indices = np.zeros(mode_rank, dtype=np.int64)
+                for i in range(value_count):
+                    w = frequencies[i]
+                    for j in range(mode_rank):
+                        if w > max_frequencies[j]:
+                            max_frequencies[j] = w
+                            indices[j] = i
+                            break
+                value = values[indices[mode_rank - 1]]
+            out[out_y, out_x] = value
+    return out
+
+
+@ngjit
+def _downsample_2d_mean(src, mask, use_mask, method, fill_value, mode_rank, out):
+    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w > src_w or out_h > src_h:
+        raise ValueError("invalid target size")
+
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+            
+    for out_y in range(out_h):
+        src_yf0 = scale_y * out_y
+        src_yf1 = src_yf0 + scale_y
+        src_y0 = int(src_yf0)
+        src_y1 = int(src_yf1)
+        wy0 = 1.0 - (src_yf0 - src_y0)
+        wy1 = src_yf1 - src_y1
+        if wy1 < _EPS:
+            wy1 = 1.0
+            if src_y1 > src_y0:
+                src_y1 -= 1
+        for out_x in range(out_w):
+            src_xf0 = scale_x * out_x
+            src_xf1 = src_xf0 + scale_x
+            src_x0 = int(src_xf0)
+            src_x1 = int(src_xf1)
+            wx0 = 1.0 - (src_xf0 - src_x0)
+            wx1 = src_xf1 - src_x1
+            if wx1 < _EPS:
+                wx1 = 1.0
+                if src_x1 > src_x0:
+                    src_x1 -= 1
+            v_sum = 0.0
+            w_sum = 0.0
+            for src_y in range(src_y0, src_y1 + 1):
+                wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                for src_x in range(src_x0, src_x1 + 1):
+                    wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                    v = src[src_y, src_x]
+                    if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                        w = wx * wy
+                        v_sum += w * v
+                        w_sum += w
+            if w_sum < _EPS:
+                out[out_y, out_x] = fill_value
+            else:
+                out[out_y, out_x] = v_sum / w_sum
+    return out
+
+
+@ngjit
+def _downsample_2d_std_var(src, mask, use_mask, method, fill_value, mode_rank, out):
+    src_w, src_h, out_w, out_h = _get_dimensions(src, out)
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w > src_w or out_h > src_h:
+        raise ValueError("invalid target size")
+
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+
+    for out_y in range(out_h):
+        src_yf0 = scale_y * out_y
+        src_yf1 = src_yf0 + scale_y
+        src_y0 = int(src_yf0)
+        src_y1 = int(src_yf1)
+        wy0 = 1.0 - (src_yf0 - src_y0)
+        wy1 = src_yf1 - src_y1
+        if wy1 < _EPS:
+            wy1 = 1.0
+            if src_y1 > src_y0:
+                src_y1 -= 1
+        for out_x in range(out_w):
+            src_xf0 = scale_x * out_x
+            src_xf1 = src_xf0 + scale_x
+            src_x0 = int(src_xf0)
+            src_x1 = int(src_xf1)
+            wx0 = 1.0 - (src_xf0 - src_x0)
+            wx1 = src_xf1 - src_x1
+            if wx1 < _EPS:
+                wx1 = 1.0
+                if src_x1 > src_x0:
+                    src_x1 -= 1
+            v_sum = 0.0
+            w_sum = 0.0
+            wv_sum = 0.0
+            wvv_sum = 0.0
+            for src_y in range(src_y0, src_y1 + 1):
+                wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                for src_x in range(src_x0, src_x1 + 1):
+                    wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                    v = src[src_y, src_x]
+                    if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                        w = wx * wy
+                        v_sum += v
+                        w_sum += w
+                        wv_sum += w * v
+                        wvv_sum += w * v * v
+            if w_sum < _EPS:
+                out[out_y, out_x] = fill_value
+            else:
+                out[out_y, out_x] = (wvv_sum * w_sum - wv_sum * wv_sum) / w_sum / w_sum
+    if method == DS_STD:
+        out = np.sqrt(out)
+    return out
+
+
+DOWNSAMPLING_METHODS = {DS_MEAN: _downsample_2d_mean,
+                        DS_FIRST: _downsample_2d_first_last,
+                        DS_LAST: _downsample_2d_first_last,
+                        DS_MIN: _downsample_2d_min_max,
+                        DS_MAX: _downsample_2d_min_max,
+                        DS_MODE: _downsample_2d_mode,
+                        DS_STD: _downsample_2d_std_var,
+                        DS_VAR: _downsample_2d_std_var}

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -27,15 +27,14 @@ SOFTWARE.
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+import numba as nb
 
 from numba import prange
-from .utils import ngjit, ngjit_parallel
+from .utils import ngjit
 
 try:
-    # Determine if system supports numba 'parallel' target
-    @ngjit_parallel
-    def _sentinel_function(): return 0
-    _sentinel_function()
+    # Try to create numba JIT with 'parallel' target
+    ngjit_parallel = nb.jit(nopython=True, nogil=True, parallel=True)
 except:
     ngjit_parallel, prange = ngjit, range # NOQA
 

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -1,5 +1,5 @@
 """
-This module was copied and adapted from https://github.com/CAB-LAB/gridtools
+This module was adapted from https://github.com/CAB-LAB/gridtools
 
                         The MIT License (MIT)
 

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -32,7 +32,7 @@ from numba import prange
 from .utils import ngjit, ngjit_parallel
 
 try:
-    # Determine if system support numba 'parallel' target
+    # Determine if system supports numba 'parallel' target
     @ngjit_parallel
     def _sentinel_function(): return 0
     _sentinel_function()

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -1,3 +1,29 @@
+"""
+This module was copied and adapted from https://github.com/CAB-LAB/gridtools
+
+                        The MIT License (MIT)
+
+Copyright (c) 2016, Brockmann Consult GmbH and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
 from __future__ import absolute_import, division, print_function
 
 import numpy as np

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -12,7 +12,6 @@ from xarray import DataArray
 import datashape
 
 ngjit = nb.jit(nopython=True, nogil=True)
-ngjit_parallel = nb.jit(nopython=True, nogil=True, parallel=True)
 
 
 class Dispatcher(object):

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -12,6 +12,7 @@ from xarray import DataArray
 import datashape
 
 ngjit = nb.jit(nopython=True, nogil=True)
+ngjit_parallel = nb.jit(nopython=True, nogil=True, parallel=True)
 
 
 class Dispatcher(object):


### PR DESCRIPTION
The resampling operations we copied from gridtools are all in a massive monolithic numba-ized function, which has several disadvantages, which I'll try to outline:

1) Huge functions with deep nesting are unreadable
2) The entire function needs to be compiled in one go which slows down the initial compile step (takes about ~5 seconds)
3) The JIT compiler has to validate types and since np.sqrt is apparently only defined for float types all the data **must** be of float type even for downsampling methods which do not use ``np.sqrt``.

While splitting the huge function into individual functions should only be seen as an initial step towards refactoring this code, it already has two major advantages:

1) No super long compile step to begin with.
2) No requirement to cast the input arrays to floats unless using downsampling with standard deviation and variance methods

When running resampling on the landsat data (using mean downsampling) the timings before and after this PR are:

PRE:

  * Compilation: 6.88 s
  * Downsampling: 2.58 s

POST:

  * Compilation: 1.56 s
  * Downsampling: 1.26 s