### PR TITLE
Add benchmarks to test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ install:
   # Install dependencies
   - conda create -n test-environment python=$PYTHON_VERSION
   - source activate test-environment
-  - conda install dask numba numpy pandas pillow pytest toolz xarray datashape colorcet rasterio scikit-image param
+  - conda install dask numba numpy pandas pillow toolz xarray datashape colorcet rasterio scikit-image param
   - conda install -c gbrener -c conda-forge xarray # remove this line when xarray >= 0.9.7
   # Optional dependencies, for testing only
+  - conda install pytest pytest-benchmark
   - conda install matplotlib
   # Dependencies for lint checking only
   - conda install jupyter flake8
@@ -46,10 +47,12 @@ install:
 
 script:
     # TODO: why different tests for python 2 vs 3?
-    - if [[ $PYTHON_VERSION == '2.7' ]]; then py.test datashader --doctest-modules --doctest-ignore-import-errors --verbose; else py.test datashader --verbose; fi
+    - if [[ $PYTHON_VERSION == '2.7' ]]; then py.test datashader/tests --doctest-modules --doctest-ignore-import-errors --verbose; else py.test datashader/tests --verbose; fi
     - flake8 --ignore E,W datashader examples
     # lint checking of example notebooks (ugly)
     - for NB in examples/*.ipynb; do sed -e 's/"[ ]*%/"#%/' "$NB" > "${NB}~"; done && jupyter nbconvert examples/*.ipynb~ --to script --output-dir examples/lint && flake8 --ignore=E,W examples/lint/*.py
+    # benchmarks
+    - py.test datashader/benchmarks
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - conda install dask numba numpy pandas pillow toolz xarray datashape colorcet rasterio scikit-image param
   - conda install -c gbrener -c conda-forge xarray # remove this line when xarray >= 0.9.7
   # Optional dependencies, for testing only
-  - conda install pytest pytest-benchmark
+  - conda install -c conda-forge pytest pytest-benchmark
   - conda install matplotlib
   # Dependencies for lint checking only
   - conda install jupyter flake8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,4 +33,4 @@ install:
 build: off
 
 test_script:
-  - "pytest -x -v datashader"
+  - "pytest -x -v datashader/tests"

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
 
 test:
   requires:
-    - pytest >=2.8.5
-    - pytest-benchmark >=3.0.0
+    - conda-forge::pytest >=2.8.5
+    - conda-forge::pytest-benchmark >=3.0.0
     - rasterio
     - scipy
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
 test:
   requires:
     - pytest >=2.8.5
+    - pytest-benchmark >=3.0.0
     - rasterio
     - scipy
 

--- a/datashader/benchmarks/test_bundling.py
+++ b/datashader/benchmarks/test_bundling.py
@@ -1,0 +1,38 @@
+import pytest
+skimage = pytest.importorskip("skimage")
+
+import numpy as np
+import pandas as pd
+
+from datashader.bundling import directly_connect_edges, hammer_bundle
+from datashader.layout import circular_layout, forceatlas2_layout, random_layout
+
+
+@pytest.fixture
+def nodes():
+    # Four nodes arranged at the corners of a 200x200 square with one node
+    # at the center
+    nodes_df = pd.DataFrame({'id': np.arange(5),
+                             'x': [0.0, -100.0, 100.0, -100.0, 100.0],
+                             'y': [0.0, 100.0, 100.0, -100.0, -100.0]})
+    nodes_df.set_index('id')
+    return nodes_df
+
+
+@pytest.fixture
+def edges():
+    # Four edges originating from the center node and connected to each
+    # corner
+    edges_df = pd.DataFrame({'id': np.arange(4),
+                             'source': np.zeros(4, dtype=np.int),
+                             'target': np.arange(1, 5)})
+    edges_df.set_index('id')
+    return edges_df
+
+
+@pytest.mark.parametrize('bundle', [directly_connect_edges, hammer_bundle])
+@pytest.mark.parametrize('layout', [random_layout, circular_layout, forceatlas2_layout])
+@pytest.mark.benchmark(group="bundling")
+def test_bundle(benchmark, nodes, edges, layout, bundle):
+    node_positions = layout(nodes, edges)
+    benchmark(bundle, node_positions, edges)

--- a/datashader/benchmarks/test_canvas.py
+++ b/datashader/benchmarks/test_canvas.py
@@ -1,0 +1,30 @@
+import pytest
+
+import numpy as np
+import pandas as pd
+
+import datashader as ds
+
+
+@pytest.fixture
+def time_series():
+    n = 10**6
+    signal = np.random.normal(0, 0.3, size=n).cumsum() + 50
+    noise = lambda var, bias, n: np.random.normal(bias, var, n)
+    ys = signal + noise(1, 10*(np.random.random() - 0.5), n)
+
+    df = pd.DataFrame({'y': ys})
+    df['x'] = df.index
+    return df
+
+
+@pytest.mark.benchmark(group="canvas")
+def test_line(benchmark, time_series):
+    cvs = ds.Canvas(plot_height=300, plot_width=900)
+    benchmark(cvs.line, time_series, 'x', 'y')
+
+
+@pytest.mark.benchmark(group="canvas")
+def test_points(benchmark, time_series):
+    cvs = ds.Canvas(plot_height=300, plot_width=900)
+    benchmark(cvs.points, time_series, 'x', 'y')

--- a/datashader/benchmarks/test_draw_line.py
+++ b/datashader/benchmarks/test_draw_line.py
@@ -1,0 +1,47 @@
+from __future__ import division
+
+import pytest
+
+import numpy as np
+
+from datashader.glyphs import _build_draw_line
+from datashader.utils import ngjit
+
+
+@pytest.fixture
+def draw_line():
+    @ngjit
+    def append(i, x, y, agg):
+        agg[y, x] += 1
+
+    return _build_draw_line(append)
+
+
+@pytest.mark.benchmark(group="draw_line")
+def test_draw_line_left_border(benchmark, draw_line):
+    n = 10**4
+    x0, y0 = (0, 0)
+    x1, y1 = (0, n)
+
+    agg = np.zeros((n+1, n+1), dtype='i4')
+    benchmark(draw_line, x0, y0, x1, y1, 0, True, False, agg)
+
+
+@pytest.mark.benchmark(group="draw_line")
+def test_draw_line_diagonal(benchmark, draw_line):
+    n = 10**4
+    x0, y0 = (0, 0)
+    x1, y1 = (n, n)
+
+    agg = np.zeros((n+1, n+1), dtype='i4')
+    benchmark(draw_line, x0, y0, x1, y1, 0, True, False, agg)
+
+
+@pytest.mark.benchmark(group="draw_line")
+def test_draw_line_offset(benchmark, draw_line):
+    n = 10**4
+    x0, y0 = (0, n//4)
+    x1, y1 = (n, n//4-1)
+
+    agg = np.zeros((n+1, n+1), dtype='i4')
+    benchmark(draw_line, x0, y0, x1, y1, 0, True, False, agg)

--- a/datashader/benchmarks/test_extend_line.py
+++ b/datashader/benchmarks/test_extend_line.py
@@ -1,0 +1,51 @@
+import pytest
+
+import numpy as np
+
+from datashader.glyphs import _build_draw_line, _build_extend_line, _build_map_onto_pixel
+from datashader.utils import ngjit
+
+
+@pytest.fixture
+def extend_line():
+    @ngjit
+    def append(i, x, y, agg):
+        agg[y, x] += 1
+
+    mapper = ngjit(lambda x: x)
+    map_onto_pixel = _build_map_onto_pixel(mapper, mapper)
+    draw_line = _build_draw_line(append)
+    return _build_extend_line(draw_line, map_onto_pixel)
+
+
+@pytest.mark.parametrize('high', [0, 10**5])
+@pytest.mark.parametrize('low', [0, -10**5])
+@pytest.mark.benchmark(group="extend_line")
+def test_extend_line_uniform(benchmark, extend_line, low, high):
+    n = 10**6
+    vt = (1, 0, 1, 0)
+    bounds = (0, 0, 10**4, 10**4)
+
+    xs = np.random.uniform(bounds[0] + low, bounds[2] + high, n)
+    ys = np.random.uniform(bounds[1] + low, bounds[3] + high, n)
+
+    agg = np.zeros((bounds[2], bounds[3]), dtype='i4')
+    benchmark(extend_line, vt, bounds, xs, ys, True, agg)
+
+
+@pytest.mark.benchmark(group="extend_line")
+def test_extend_line_normal(benchmark, extend_line):
+    n = 10**6
+    vt = (1, 0, 1, 0)
+    bounds = (0, 0, 10**4, 10**4)
+
+    start = 1456297053
+    end = start + 60 * 60 * 24
+    xs = np.linspace(start, end, n)
+
+    signal = np.random.normal(0, 0.3, size=n).cumsum() + 50
+    noise = lambda var, bias, n: np.random.normal(bias, var, n)
+    ys = signal + noise(1, 10*(np.random.random() - 0.5), n)
+
+    agg = np.zeros((bounds[2], bounds[3]), dtype='i4')
+    benchmark(extend_line, vt, bounds, xs, ys, True, agg)

--- a/datashader/benchmarks/test_layout.py
+++ b/datashader/benchmarks/test_layout.py
@@ -1,0 +1,32 @@
+import pytest
+
+import numpy as np
+import pandas as pd
+
+from datashader.layout import circular_layout, forceatlas2_layout, random_layout
+
+
+@pytest.fixture
+def nodes():
+    # Four nodes arranged at the corners of a 200x200 square with one node
+    # at the center
+    nodes_df = pd.DataFrame({'id': np.arange(5),
+                             'x': [0., -100., 100., -100., 100.],
+                             'y': [0., 100., 100., -100., -100.]})
+    return nodes_df.set_index('id')
+
+
+@pytest.fixture
+def edges():
+    # Four edges originating from the center node and connected to each
+    # corner
+    edges_df = pd.DataFrame({'id': np.arange(4),
+                             'source': np.zeros(4, dtype=np.int64),
+                             'target': np.arange(1, 5)})
+    return edges_df.set_index('id')
+
+
+@pytest.mark.parametrize('layout', [random_layout, circular_layout, forceatlas2_layout])
+@pytest.mark.benchmark(group="layout")
+def test_layout(benchmark, nodes, edges, layout):
+    benchmark(layout, nodes, edges)

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -28,6 +28,7 @@ dependencies:
  - pyproj
  - pytables
  - pytest
+ - pytest-benchmark
  - python=3.6
  - rasterio
  - requests

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -27,8 +27,8 @@ dependencies:
  - paramnb
  - pyproj
  - pytables
- - pytest
- - pytest-benchmark
+ - conda-forge::pytest
+ - conda-forge::pytest-benchmark
  - python=3.6
  - rasterio
  - requests


### PR DESCRIPTION
For simplicity and success when profiling previous PRs, I selected `pytest-benchmark` at this time instead of airspeed velocity (`asv`).

Fix #346 