### PR TITLE
Run Travis-CI osx tests on master only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
       script: scripts/ci/test_examples
       os: osx
       osx_image: xcode8.3
+      if: branch = master AND type != pull_request
       env:
       - GROUP=examples
       - PYTHON_VERSION=3.6
@@ -46,6 +47,7 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
+      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=2.7
@@ -53,6 +55,7 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
+      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=3.5
@@ -60,6 +63,7 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
+      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=3.6


### PR DESCRIPTION
Mac on travis is slow, and has been for a while. Therefore, we wondered about running Mac tests only after merging a PR to master. Otherwise, tests on PRs take too long.

We hope that generally if the build passes on linux, it'll pass on Mac - but if on the odd occasion it does fail on Mac, we want to know about.

(As requested by Jim - but please still consider whether or not you want this. There are downsides, e.g. potential confusion.)
