### PR TITLE
Graph tidy

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -349,7 +349,7 @@ def _convert_edge_segments_to_dataframe(edge_segments, segment_class, params):
     return df
 
 
-class directly_connect_edges(param.ParameterizedFunction):
+class connect_edges(param.ParameterizedFunction):
     """
     Convert a graph into paths suitable for datashading.
 
@@ -392,6 +392,7 @@ class directly_connect_edges(param.ParameterizedFunction):
         edges, segment_class = _convert_graph_to_edge_segments(nodes, edges, p)
         return _convert_edge_segments_to_dataframe(edges, segment_class, p)
 
+directly_connect_edges = connect_edges # For bockwards compatibility; deprecated
 
 @nb.jit
 def minmax_normalize(X, lower, upper):
@@ -403,7 +404,7 @@ def minmax_denormalize(X, lower, upper):
     return X * (upper - lower) + lower
 
 
-class hammer_bundle(directly_connect_edges):
+class hammer_bundle(connect_edges):
     """
     Iteratively group edges and return as paths suitable for datashading.
 


### PR DESCRIPTION
Minor backwards-compatible API cleanup for graph functions:

- ``directly_connect_edges`` was both painfully long and also a bit of a misnomer, because it was the base class for algorithms that do *not* directly connect.  I've renamed it ``connect_edges``, which I think conveys a default of "directly" already, while also being correct as the name for a base class of algorithms that also connect in other ways.  The old name is now an alias for the new one, and can presumably eventually be deleted.

- Some layout functions use the edge data, and others don't, but all were requiring them.  Instead, all must still *accept* edge data, to provide a consistent API for configuring layouts, but now only those that actually use the edge data require it.

- The `id` field name is now configurable, by providing ``id='name'`` to the layout algorithm.  (Previously it was hard-coded to 'id' if present, and falling back to the dataframe index if not.

Minor backwards-incompatible change:

- Now, a dataframe that has a column named `id` will use the index by default, not that column.  I think this makes the behavior more predictable (by default, it will use the index for *all* dataframes now, though this can be overridden).  The reason I made the change is that these functions failed for a dataset where `id` was some other (text) information unrelated to the node number.