### PR TITLE
Improve aggregation of streamed dataframes

### DIFF
--- a/examples/streaming-aggregation.ipynb
+++ b/examples/streaming-aggregation.ipynb
@@ -74,8 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def aggregate_df(df, x, y, plot_width=800, plot_height=600, agg=None):\n",
-    "    cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height)\n",
+    "def aggregate_df(df, cvs, x, y, agg=None):\n",
     "    return df.index.min(), df.index.max(), cvs.points(df, x, y, agg)"
    ]
   },
@@ -87,8 +86,7 @@
    "source": [
     "def aggregate_images(iterable, cmap):\n",
     "    name = \"{:.10} - {:.10}\".format(str(iterable[0][0]), str(iterable[-1][1]))\n",
-    "    merged = xr.concat((item[2] for item in iterable), dim='cols')\n",
-    "    total = merged.sum(dim='cols')\n",
+    "    total = sum([item[2] for item in iterable])\n",
     "    return tf.shade(total, cmap=cmap, name=name)"
    ]
   },
@@ -144,14 +142,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "x_range = (-8243204.0, -8226511.0)\n",
+    "y_range = (4968192.0, 4982886.0)\n",
+    "cvs = ds.Canvas(plot_width=800, plot_height=600, x_range=x_range, y_range=y_range)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Helper functions for useful aggregations\n",
-    "min_amount     = partial(aggregate_df, x='pickup_x', y='pickup_y', agg=ds.min('total_amount'))\n",
-    "max_amount     = partial(aggregate_df, x='pickup_x', y='pickup_y', agg=ds.max('total_amount'))\n",
-    "mean_amount    = partial(aggregate_df, x='pickup_x', y='pickup_y', agg=ds.mean('total_amount'))\n",
-    "sum_amount     = partial(aggregate_df, x='pickup_x', y='pickup_y', agg=ds.sum('total_amount'))\n",
-    "max_passengers = partial(aggregate_df, x='pickup_x', y='pickup_y', agg=ds.max('passenger_count'))\n",
-    "sum_passengers = partial(aggregate_df, x='pickup_x', y='pickup_y', agg=ds.sum('passenger_count'))\n",
-    "sum_pickups    = partial(aggregate_df, x='pickup_x', y='pickup_y', agg=ds.count())\n",
+    "min_amount     = partial(aggregate_df, cvs, x='pickup_x', y='pickup_y', agg=ds.min('total_amount'))\n",
+    "max_amount     = partial(aggregate_df, cvs, x='pickup_x', y='pickup_y', agg=ds.max('total_amount'))\n",
+    "mean_amount    = partial(aggregate_df, cvs, x='pickup_x', y='pickup_y', agg=ds.mean('total_amount'))\n",
+    "sum_amount     = partial(aggregate_df, cvs, x='pickup_x', y='pickup_y', agg=ds.sum('total_amount'))\n",
+    "max_passengers = partial(aggregate_df, cvs, x='pickup_x', y='pickup_y', agg=ds.max('passenger_count'))\n",
+    "sum_passengers = partial(aggregate_df, cvs, x='pickup_x', y='pickup_y', agg=ds.sum('passenger_count'))\n",
+    "sum_pickups    = partial(aggregate_df, cvs, x='pickup_x', y='pickup_y', agg=ds.count())\n",
     "\n",
     "reduce_viridis = partial(aggregate_images, cmap=viridis)"
    ]
@@ -209,19 +218,17 @@
    "outputs": [],
    "source": [
     "class SlidingWindowImageAggregate(Stream):\n",
-    "    def __init__(self, source, x, y, agg, n=7, cmap=None, plot_width=800, plot_height=600):\n",
+    "    def __init__(self, source, canvas, x, y, agg, n=7, cmap=None, bgcolor='black'):\n",
     "        # Set internal streamz instance variables to control names in diagram\n",
     "        self.n = n\n",
     "        \n",
     "        def aggregate_df(df):\n",
-    "            cvs = ds.Canvas(plot_width=plot_width, plot_height=plot_height)\n",
-    "            return df.index.min(), df.index.max(), cvs.points(df, x, y, agg)\n",
+    "            return df.index.min(), df.index.max(), canvas.points(df, x, y, agg)\n",
     "\n",
     "        def aggregate_images(iterable):\n",
     "            name = \"{:.10} - {:.10}\".format(str(iterable[0][0]), str(iterable[-1][1]))\n",
-    "            merged = xr.concat((item[2] for item in iterable), dim='cols')\n",
-    "            total = merged.sum(dim='cols')\n",
-    "            return tf.shade(total, cmap, name=name)\n",
+    "            total = sum([item[2] for item in iterable])\n",
+    "            return tf.set_background(tf.shade(total, cmap, name=name), color=bgcolor)\n",
     "        \n",
     "        self.cache = deque(maxlen=n)\n",
     "        self.agg1 = aggregate_df\n",
@@ -267,12 +274,14 @@
    "source": [
     "source = Stream()\n",
     "\n",
+    "cvs = ds.Canvas(plot_width=800, plot_height=600, x_range=x_range, y_range=y_range)\n",
+    "\n",
     "q_days = deque(maxlen=6)\n",
-    "s_days = SlidingWindowImageAggregate(source, 'pickup_x', 'pickup_y', ds.max('total_amount'), n=2, cmap=viridis)\n",
+    "s_days = SlidingWindowImageAggregate(source, cvs, 'pickup_x', 'pickup_y', ds.max('total_amount'), n=2, cmap=viridis)\n",
     "s_days.sink(q_days.append)\n",
     "\n",
     "q_week = deque(maxlen=1)\n",
-    "s_week = SlidingWindowImageAggregate(source, 'pickup_x', 'pickup_y', ds.max('total_amount'), n=7, cmap=viridis)\n",
+    "s_week = SlidingWindowImageAggregate(source, cvs, 'pickup_x', 'pickup_y', ds.max('total_amount'), n=7, cmap=viridis)\n",
     "s_week.sink(q_week.append)\n",
     "\n",
     "q_avg_passengers = deque(maxlen=7)\n",

--- a/examples/streaming-aggregation.ipynb
+++ b/examples/streaming-aggregation.ipynb
@@ -11,7 +11,6 @@
     "from itertools import cycle\n",
     "\n",
     "import pandas as pd\n",
-    "import xarray as xr\n",
     "\n",
     "import datashader as ds\n",
     "import datashader.transfer_functions as tf\n",


### PR DESCRIPTION
Prior to this, the aggregated images contained an odd purplish background and the data points were unclear.

Now, instead of concatenating and then summing the data, we now just sum the list of xarrays. We also manually set the canvas's range and background, passing that to the helper methods.

Relies on #523 to fix failing tests