### PR TITLE
Remove interfering brew-installed libraries from travis/osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ sudo: false
 
 before_install:
   - export PATH="$HOME/miniconda/bin:$PATH"
+  # brew-installed geos interferes with cartopy?
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew uninstall --ignore-dependencies geos gdal postgis;
+    fi
 
 jobs:
   include:
@@ -39,7 +43,6 @@ jobs:
       script: scripts/ci/test_examples
       os: osx
       osx_image: xcode8.3
-      if: branch = master AND type != pull_request
       env:
       - GROUP=examples
       - PYTHON_VERSION=3.6
@@ -47,7 +50,6 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
-      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=2.7
@@ -55,7 +57,6 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
-      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=3.5
@@ -63,7 +64,6 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
-      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ jobs:
       script: scripts/ci/test_examples
       os: osx
       osx_image: xcode8.3
+      if: branch = master AND type != pull_request
       env:
       - GROUP=examples
       - PYTHON_VERSION=3.6
@@ -50,6 +51,7 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
+      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=2.7
@@ -57,6 +59,7 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
+      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=3.5
@@ -64,6 +67,7 @@ jobs:
       script: scripts/ci/test_unit
       os: osx
       osx_image: xcode8.3
+      if: branch = master AND type != pull_request
       env:
       - GROUP=unit
       - PYTHON_VERSION=3.6


### PR DESCRIPTION
Based on a discovery in a project I'm working on, seems like all travis osx images have a variety of brew installed packages (which can change over time). Also seems that some conda packages will pick up such 'system' libraries in preference to conda supplied ones. Those are both difficult things for us to address properly, but we can at least remove interfering system libraries from travis as we discover them. In any case, these kinds of issues can affect users too (many have brew installed libraries).

If the build passes, I'll revert the changes that make osx test the PR.