### PR TITLE
Updated and fixed test and example environments

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,7 @@ install:
   - "activate test-environment"
   # TODO: does not match linux/osx (see https://github.com/bokeh/datashader/issues/404)
   - "conda install dask numba numpy pandas pillow pytest toolz xarray datashape colorcet scikit-image param"
-  - "conda install rasterio -c conda-forge"
-  # Optional dependencies, for testing only
-  - "conda install matplotlib"
+  - "conda install -c conda-forge rasterio matplotlib pillow=4.3.0 xarray"
 
   - "python setup.py develop --no-deps"
   - "conda env export"

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -20,7 +20,6 @@ dependencies:
  - distributed
  - fastparquet
  - flake8
- - gbrener::xarray>=0.9.6 # For xarray.open_rasterio()
  - geoviews
  - ioam::holoviews>=1.8.3
  - ipython
@@ -49,6 +48,7 @@ dependencies:
  - snappy
  - statsmodels
  - tblib
+ - xarray
  - yaml
  - pip:
    - cachey

--- a/scripts/ci/install_unit
+++ b/scripts/ci/install_unit
@@ -10,8 +10,7 @@ bash scripts/ci/install
 conda create -n test-environment python=$PYTHON_VERSION
 source activate test-environment
 conda install dask numba numpy pandas pillow toolz xarray datashape colorcet rasterio scikit-image param
-conda install -c gbrener -c conda-forge xarray # remove this line when xarray >= 0.9.7
-conda install -c conda-forge pytest pytest-benchmark
+conda install -c conda-forge pytest pytest-benchmark xarray
 conda install flake8 matplotlib
 python setup.py develop --no-deps
 conda env export


### PR DESCRIPTION
Ensures that matplotlib and pillow are installed from conda-forge on Windows trying to fix issues in https://github.com/bokeh/datashader/issues/534 and unpins @gbrener's xarray branch since the required changes have since been released.