### PR TITLE
Add ds.utils.mesh

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -238,9 +238,8 @@ class Canvas(object):
         mesh : pandas.DataFrame, optional
             An ordered triangle mesh in tabular form, used for optimization
             purposes. This dataframe is expected to have come from
-            ``datashader.utils.pd_mesh()``, or
-            ``datashader.utils.dd_mesh()``. If this argument is not None, the
-            first two arguments are ignored.
+            ``datashader.utils.mesh()``. If this argument is not None, the first
+            two arguments are ignored.
         interp : boolean, optional
             Specify whether to do bilinear interpolation of the pixels within each
             triangle. This can be thought of as a "weighted average" of the vertex
@@ -248,17 +247,13 @@ class Canvas(object):
         """
         from .glyphs import Triangles
         from .reductions import mean as mean_rdn
-        from .utils import pd_mesh, dd_mesh
+        from .utils import mesh as create_mesh
 
         source = mesh
 
         # Validation is done inside the [pd]d_mesh utility functions
         if source is None:
-            if (isinstance(vertices, dd.DataFrame) and
-                    isinstance(simplices, dd.DataFrame)):
-                source = dd_mesh(vertices, simplices)
-            else:
-                source = pd_mesh(vertices, simplices)
+            source = create_mesh(vertices, simplices)
 
         verts_have_weights = len(vertices.columns) > 2
         if verts_have_weights:

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -237,11 +237,10 @@ class Canvas(object):
             Reduction to compute. Default is ``mean()``.
         mesh : pandas.DataFrame, optional
             An ordered triangle mesh in tabular form, used for optimization
-            purposes. This dataframe is expected to have at least three columns
-            - corresponding to x, y, and vertex weights. Each row corresponds to
-            a vertex, and three rows in a row correspond to a triangle
-            definition. Vertices must be in clockwise order. If this argument is
-            not None, the first two arguments are ignored.
+            purposes. This dataframe is expected to have come from
+            ``datashader.utils.pd_mesh()``, or
+            ``datashader.utils.dd_mesh()``. If this argument is not None, the
+            first two arguments are ignored.
         interp : boolean, optional
             Specify whether to do bilinear interpolation of the pixels within each
             triangle. This can be thought of as a "weighted average" of the vertex

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -515,7 +515,7 @@ def test_trimesh_mesharg():
     ], dtype='f8')
     np.testing.assert_array_equal(np.flipud(agg.fillna(0.).values)[:5], sol)
 
-    mesh = ds.utils.pd_mesh(verts, tris)
+    mesh = ds.utils.mesh(verts, tris)
     cvs = ds.Canvas(plot_width=20, plot_height=20, x_range=(0, 5), y_range=(0, 5))
     agg = cvs.trimesh(verts[:1], tris[:1], mesh=mesh)
     np.testing.assert_array_equal(np.flipud(agg.fillna(0.).values)[:5], sol)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -515,8 +515,7 @@ def test_trimesh_mesharg():
     ], dtype='f8')
     np.testing.assert_array_equal(np.flipud(agg.fillna(0.).values)[:5], sol)
 
-    mesh = pd.DataFrame(verts.values[tris.values[:, [0, 1, 2]]].reshape(3*len(tris), len(verts.columns)),
-                        columns=verts.columns)
+    mesh = ds.utils.pd_mesh(verts, tris)
     cvs = ds.Canvas(plot_width=20, plot_height=20, x_range=(0, 5), y_range=(0, 5))
     agg = cvs.trimesh(verts[:1], tris[:1], mesh=mesh)
     np.testing.assert_array_equal(np.flipud(agg.fillna(0.).values)[:5], sol)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from xarray import DataArray
+import dask.dataframe as dd
 import datashape
 
 ngjit = nb.jit(nopython=True, nogil=True)
@@ -383,23 +384,10 @@ def dataframe_from_multiple_sequences(x_values, y_values):
    return pd.DataFrame({'x': x, 'y': y.flatten()})
 
    
-def pd_mesh(vertices, simplices):
-    """Merge vertices and simplices into a triangular mesh, suitable to be
-    passed into the ``Canvas.trimesh()`` method via the ``mesh``
-    keyword-argument. Both arguments are assumed to be Pandas DataFrame
-    objects.
+def _pd_mesh(vertices, simplices):
+    """Helper for ``datashader.utils.mesh()``. Both arguments are assumed to be
+    Pandas DataFrame objects.
     """
-    # Verify the simplex data structure
-    assert simplices.values.shape[1] >= 3, ('At least three vertex columns '
-                                            'are required for the triangle '
-                                            'definition')
-    simplices_all_ints = simplices.dtypes.iloc[:3].map(
-        lambda dt: np.issubdtype(dt, np.integer)
-    ).all()
-    assert simplices_all_ints, ('Simplices must be integral. You may '
-                                'consider casting simplices to integers '
-                                'with ".astype(int)"')
-
     # Winding auto-detect
     winding = [0, 1, 2]
     first_tri = vertices.values[simplices.values[0, winding].astype(np.int64), :2]
@@ -411,19 +399,40 @@ def pd_mesh(vertices, simplices):
     vertex_idxs = simplices.values[:, winding].astype(np.int64)
     vals = vertices.values[vertex_idxs]
     vals = vals.reshape(np.prod(vals.shape[:2]), vals.shape[2])
-    mesh = pd.DataFrame(vals, columns=vertices.columns)
+    res = pd.DataFrame(vals, columns=vertices.columns)
 
     # If vertices don't have weights, use simplex weights
     verts_have_weights = len(vertices.columns) > 2
     if not verts_have_weights:
         assert simplices.values.shape[1] > 3, 'If no vertex weight column is provided, a triangle weight column is required.'
         weight_col = simplices.columns[3]
-        mesh[weight_col] = simplices.values[:, 3].repeat(3)
+        res[weight_col] = simplices.values[:, 3].repeat(3)
 
-    return mesh
+    return res
 
 
-def dd_mesh(vertices, simplices):
+def _dd_mesh(vertices, simplices):
+    """Helper for ``datashader.utils.mesh()``. Both arguments are assumed to be
+    Dask DataFrame objects.
+    """
+    # Construct mesh by indexing into vertices with simplex indices
+    # TODO: For dask: avoid .compute() calls, and add winding auto-detection
+    vertex_idxs = simplices.values[:, :3].astype(np.int64)
+    vals = vertices.values.compute()[vertex_idxs]
+    vals = vals.reshape(np.prod(vals.shape[:2]), vals.shape[2])
+    res = pd.DataFrame(vals, columns=vertices.columns)
+
+    # If vertices don't have weights, use simplex weights
+    verts_have_weights = len(vertices.columns) > 2
+    if not verts_have_weights:
+        assert simplices.values.shape[1] > 3, 'If no vertex weight column is provided, a triangle weight column is required.'
+        weight_col = simplices.columns[3]
+        res[weight_col] = simplices.values[:, 3].compute().repeat(3)
+
+    return res
+
+
+def mesh(vertices, simplices):
     """Merge vertices and simplices into a triangular mesh, suitable to be
     passed into the ``Canvas.trimesh()`` method via the ``mesh``
     keyword-argument. Both arguments are assumed to be Dask DataFrame
@@ -440,17 +449,8 @@ def dd_mesh(vertices, simplices):
                                 'consider casting simplices to integers '
                                 'with ".astype(int)"')
 
-    # TODO: For dask: avoid .compute() calls, and add winding auto-detection
-    vertex_idxs = simplices.values[:, :3].astype(np.int64)
-    vals = vertices.values.compute()[vertex_idxs]
-    vals = vals.reshape(np.prod(vals.shape[:2]), vals.shape[2])
-    mesh = pd.DataFrame(vals, columns=vertices.columns)
 
-    # If vertices don't have weights, use simplex weights
-    verts_have_weights = len(vertices.columns) > 2
-    if not verts_have_weights:
-        assert simplices.values.shape[1] > 3, 'If no vertex weight column is provided, a triangle weight column is required.'
-        weight_col = simplices.columns[3]
-        mesh[weight_col] = simplices.values[:, 3].compute().repeat(3)
+    if isinstance(vertices, dd.DataFrame) and isinstance(simplices, dd.DataFrame):
+        return _dd_mesh(vertices, simplices)
 
-    return mesh
+    return _pd_mesh(vertices, simplices)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -404,7 +404,6 @@ def _pd_mesh(vertices, simplices):
     # If vertices don't have weights, use simplex weights
     verts_have_weights = len(vertices.columns) > 2
     if not verts_have_weights:
-        assert simplices.values.shape[1] > 3, 'If no vertex weight column is provided, a triangle weight column is required.'
         weight_col = simplices.columns[3]
         res[weight_col] = simplices.values[:, 3].repeat(3)
 
@@ -425,7 +424,6 @@ def _dd_mesh(vertices, simplices):
     # If vertices don't have weights, use simplex weights
     verts_have_weights = len(vertices.columns) > 2
     if not verts_have_weights:
-        assert simplices.values.shape[1] > 3, 'If no vertex weight column is provided, a triangle weight column is required.'
         weight_col = simplices.columns[3]
         res[weight_col] = simplices.values[:, 3].compute().repeat(3)
 
@@ -448,6 +446,8 @@ def mesh(vertices, simplices):
     assert simplices_all_ints, ('Simplices must be integral. You may '
                                 'consider casting simplices to integers '
                                 'with ".astype(int)"')
+
+    assert len(vertices.columns) > 2 or simplices.values.shape[1] > 3, 'If no vertex weight column is provided, a triangle weight column is required.'
 
 
     if isinstance(vertices, dd.DataFrame) and isinstance(simplices, dd.DataFrame):


### PR DESCRIPTION
Addresses the first API enhancement in #540 by adding a utility function: `mesh()`, which handles both pandas dataframes and dask dataframes. This utility function supports the `Canvas.trimesh()` API, returning a data structure that can be passed directly via the `mesh` keyword-argument. In addition, the `Canvas.trimesh()` method was simplified and now relies on this utility internally.