### PR TITLE
Pin lower bound on pandas version

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - datashape >=0.5.1
     - numba >=0.35.0
     - numpy >=1.7
-    - pandas >=0.15.0
+    - pandas >=0.20.3
     - pillow >=3.1.1
     - xarray >=0.9.6
     - toolz >=0.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ dask >= 0.15.4
 datashape >= 0.5.1
 numba >= 0.35.0
 numpy >= 1.7
-pandas >= 0.15.0
+pandas >= 0.20.3
 pillow
 toolz
 xarray >= 0.9.6


### PR DESCRIPTION
Should fix https://stackoverflow.com/questions/47718604/typeerror-during-datashader-aggregate-creation-between-python-3-5-and-3-6-enviro 