### PR TITLE
Small optimizations to trimesh pd_mesh utility

### DIFF
--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -383,7 +383,7 @@ def dataframe_from_multiple_sequences(x_values, y_values):
    # Return a dataframe with this new set of x and y values
    return pd.DataFrame({'x': x, 'y': y.flatten()})
 
-   
+
 def _pd_mesh(vertices, simplices):
     """Helper for ``datashader.utils.mesh()``. Both arguments are assumed to be
     Pandas DataFrame objects.
@@ -396,8 +396,10 @@ def _pd_mesh(vertices, simplices):
         winding = [0, 2, 1]
 
     # Construct mesh by indexing into vertices with simplex indices
-    vertex_idxs = simplices.values[:, winding].astype(np.int64)
-    vals = vertices.values[vertex_idxs]
+    vertex_idxs = simplices.values[:, winding]
+    if not vertex_idxs.dtype == 'int64':
+        vertex_idxs = vertex_idxs.astype(np.int64)
+    vals = np.take(vertices.values, vertex_idxs, axis=0)
     vals = vals.reshape(np.prod(vals.shape[:2]), vals.shape[2])
     res = pd.DataFrame(vals, columns=vertices.columns)
 


### PR DESCRIPTION
Minor optimizations to ``_pd_mesh`` utility which computes the datastructure passed to the trimesh aggregation. Checking the type before casting has a modest improvement when the data is already of integer type and using ``np.take`` rather than fancy indexing a larger effect.

```python
n_verts = 1000000
vertices = hv.Points(np.random.randint(0, n_verts, (n_verts, 3)), vdims=['z'])
trimesh = hv.TriMesh.from_vertices(vertices)
vdf = vertices.dframe() 
simplices = trimesh.dframe()
print("Vertices: ", len(vdf))
print("Simplices: ", len(simplices))
```

    Vertices: 1000000
    Simplices: 1999965

```python
%%timeit
_pd_mesh(vdf, simplices, optimized=False)
```

    355 ms ± 10.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```
%%timeit
_pd_mesh(vdf, simplices, optimized=True)
```

    237 ms ± 21.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


![bokeh_plot](https://user-images.githubusercontent.com/1550771/35012204-ebf85c16-fb00-11e7-962b-201a86faabb3.png)


