### PR TITLE
Rasterdocs

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -341,6 +341,9 @@ class Canvas(object):
         else:
             fill_value = np.NaN
 
+        if self.x_range is None: self.x_range = (left,right)
+        if self.y_range is None: self.y_range = (bottom,top)
+            
         # window coordinates
         xmin = max(self.x_range[0], left)
         ymin = max(self.y_range[0], bottom)

--- a/examples/topics/landsat.ipynb
+++ b/examples/topics/landsat.ipynb
@@ -70,7 +70,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "file_path = '../data/MERCATOR_LC80210392016114LGN00_B%s.TIF'\n",
@@ -97,9 +99,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "nodata= 1\n",
+    "\n",
+    "def one_band(b):\n",
+    "    xs, ys = b['x'], b['y']\n",
+    "    b = ds.utils.orient_array(b)\n",
+    "    a = (np.where(np.logical_or(np.isnan(b),b<=nodata),0,255)).astype(np.uint8)    \n",
+    "    col, rows = b.shape\n",
+    "    return hv.RGB((xs, ys[::-1], b, b, b, a), vdims=list('RGBA'))\n",
+    "\n",
     "%opts RGB [width=600 height=600]\n",
     "tiles = gv.WMTS(STAMEN_TONER)\n",
-    "tiles * shade(regrid(hv.Image(bands[1])), cmap=['black', 'white']).redim(x='Longitude', y='Latitude')"
+    "tiles * shade(regrid(one_band(bands[1])), cmap=['black', 'white']).redim(x='Longitude', y='Latitude')"
    ]
   },
   {
@@ -114,7 +125,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from datashader.utils import ngjit\n",
@@ -144,7 +157,6 @@
     "    r = (normalize_data(r)).astype(np.uint8)\n",
     "    g = (normalize_data(g)).astype(np.uint8)\n",
     "    b = (normalize_data(b)).astype(np.uint8)\n",
-    "    col, rows = r.shape\n",
     "    return hv.RGB((xs, ys[::-1], r, g, b, a), vdims=list('RGBA'))"
    ]
   },
@@ -298,7 +310,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.3"
   },
   "widgets": {
    "state": {},

--- a/examples/user_guide/5_Rasters.ipynb
+++ b/examples/user_guide/5_Rasters.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[Datashader](http://datashader.org) renders data into regularly sampled arrays, a process known as [rasterization](https://en.wikipedia.org/wiki/Rasterisation), typically just before displaying it as an image.  In many cases, your data is *already* rasterized, such as data from imaging experiments, simulations on a regular grid, or other systematic processes.  Even so, often the rasters you have already are not the ones you need for a given purpose, having the wrong shape, range, or size to be suitable for overlaying with or comparing against other data or on maps.\n",
+    "[Datashader](http://datashader.org) renders data into regularly sampled arrays, a process known as [rasterization](https://en.wikipedia.org/wiki/Rasterisation), and then optionally converts that array into a viewable image.  In some cases, your data is *already* rasterized, such as data from imaging experiments, simulations on a regular grid, or other regularly sampled processes. Even so, the rasters you have already are not always the ones you need for a given purpose, having the wrong shape, range, or size to be suitable for overlaying with or comparing against other data, maps, and so on.\n",
     "\n",
     "Datashader provides fast methods for [\"regridding\"](https://climatedataguide.ucar.edu/climate-data-tools-and-analysis/regridding-overview)/[\"re-sampling\"](http://gisgeography.com/raster-resampling/)/\"re-rasterizing\" yuor gridded datasets, generating new rasters on demand that can be used together with those it generates for any other data types to implement complex cross-datatype analyses or visualizations.\n",
     "\n",
@@ -27,7 +27,7 @@
     "    ls  = np.linspace(*range_, n)\n",
     "    x,y = np.meshgrid(ls, ls)\n",
     "    z   = f(x,y)\n",
-    "    return xr.DataArray(z, coords={'x': ls, 'y': ls}, dims=('y', 'x'))\n",
+    "    return xr.DataArray(z, coords=[('y',ls), ('x',ls)])\n",
     "\n",
     "da = sample(f)"
    ]
@@ -36,7 +36,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "DataArrays happen to be the format used for datashader's own output, so you can now immediately turn this array into an image using ``tf.shade()`` just as you would for points or lines rasterized by datashader:"
+    "Here we are declaring that the first dimension of the ``DataArray`` (the rows) is called ``y`` and corresponds to the indicated continuous coordinate values in the list ``ls``, and similarly for the second dimension (the columns) called ``x``.  The coords argument is optional, but without it the default integer indexing from Numpy would be used, which would not match how this data was generated (sampling over each of the ``ls`` values). Datashader only supports rectilinear, 2D ``DataArray``s, and so will not accept the additional dimensions or non-separable coordinate arrays that xarray allows.\n",
+    "\n",
+    "DataArrays of this type happen to be the format used for datashader's own rasterized output, so you can now immediately turn this array into an image using ``tf.shade()`` just as you would for points or lines rasterized by datashader:"
    ]
   },
   {
@@ -117,6 +119,7 @@
     "tf.Images(tf.shade(cvs.raster(da2),                          name=\"mean downsampling (default)\"),\n",
     "          tf.shade(cvs.raster(da2, downsample_method='min'), name=\"min downsampling\"),\n",
     "          tf.shade(cvs.raster(da2, downsample_method='max'), name=\"max downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, downsample_method='mode'),name=\"mode downsampling\"),\n",
     "          tf.shade(cvs.raster(da2, downsample_method='std'), name=\"std downsampling\"))"
    ]
   },
@@ -124,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here the default downsampling function ``mean`` renders a faithful size-reduced version of the original, with all the raster grid points that overlap a given pixel being averaged to create the final pixel value.  The ``min`` and ``max`` aggregation functions take the minimum or maxiumum, respectively, of the values overlapping each pixel, and you can see here that the ``min`` version has larger light-blue regions towards the upper right (with each pixel reflecting the minimum of all grid cells it overlaps), while the ``max`` version has larger dark-blue regions towards the upper right.  The ``std`` version reports the standard deviation of the grid cells in each pixel, which is low towards the lower left where the function is smooth, and increases towards the upper right, where the function value varies significantly per pixel.\n",
+    "Here the default downsampling function ``mean`` renders a faithful size-reduced version of the original, with all the raster grid points that overlap a given pixel being averaged to create the final pixel value.  The ``min`` and ``max`` aggregation functions take the minimum or maxiumum, respectively, of the values overlapping each pixel, and you can see here that the ``min`` version has larger light-blue regions towards the upper right (with each pixel reflecting the minimum of all grid cells it overlaps), while the ``max`` version has larger dark-blue regions towards the upper right. The ``mode`` version computes the most common value that overlaps this pixel (not very useful for floating-point data as here, but important for categorical data where ``mean`` would not be valid; in that case you can also use `first` or `last` to take the first or last value found for a given pixel). The ``std`` version reports the standard deviation of the grid cells in each pixel, which is low towards the lower left where the function is smooth, and increases towards the upper right, where the function value varies significantly per pixel (i.e., has many samples in the original grid with different values).\n",
     "\n",
     "The differences between min and max are clearer if we look at a regime where the function varies so much that it can only barely be faithfully be represented in a grid of this size:"
    ]
@@ -156,6 +159,7 @@
     "tf.Images(tf.shade(cvs.raster(da3),                          name=\"mean downsampling (default)\"),\n",
     "          tf.shade(cvs.raster(da3, downsample_method='min'), name=\"min downsampling\"),\n",
     "          tf.shade(cvs.raster(da3, downsample_method='max'), name=\"max downsampling\"),\n",
+    "          tf.shade(cvs.raster(da3, downsample_method='mode'),name=\"mode downsampling\"),\n",
     "          tf.shade(cvs.raster(da3, downsample_method='std'), name=\"std downsampling\"))"
    ]
   },
@@ -165,9 +169,26 @@
    "source": [
     "Here you can see that the ``mean`` downsampling looks like a good approximation to the original array, locally averaging the original function values in each portion of the array.  However, if you were to zoom in and adjust for contrast, you would be able to see some of the inevitable aliasing artifacts that occur for any such representation in a too-small array.  These aliasing effects are clearly visible in the ``min`` and ``max`` aggregation, because they keep the local minimum or maxiumum rather than averaging out the artifacts.  Comparing ``mean`` and ``min`` or ``max`` (or subtracting ``min`` from ``max``) can help find regions of the array that are being poorly represented in the current view.\n",
     "\n",
-    "In practice, it is usually a good idea to view your data interactively at many different zoom levels to detect such problems; see [3 Timeseries](3_Timeseries.ipynb).  For such cases, you can define both upsampling and downsampling methods at the same time; whichever one is needed for a given zoom level and range of the data will be applied.\n",
+    "The above rasters are all very tiny, for illustration purposes, but Datashader's raster support is accelerated using Numba, and can re-sample much larger rasters easily.  For instance, rendering the above function into a 10000x10000 raster takes a few seconds on a four-core machine, but it can then be re-sampled using Datashader in under 0.1 sec:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time da4 = sample(f, n=10000, range_=(0,3))\n",
+    "%time tf.shade(cvs.raster(da4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In practice, it is usually a good idea to view your data interactively at many different zoom levels to see all the data available and to detect any sampling or aliasing issues, which you can do with Datashader as described in [3_Interactivity](3_Interactivity.ipynb).  For such cases, you can define both upsampling and downsampling methods at the same time; whichever one is needed for a given zoom level and range of the data will be applied.\n",
     "\n",
-    "You can see Datashader rasters at work in the [Landsat](../topics/Landsat.ipynb) example:\n",
+    "You can see Datashader rasters at work in the [Landsat](../topics/Landsat.ipynb) example notebook:\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/bokeh/datashader/master/docs/images/landsat.png\" width=1204 height=1150>"
    ]

--- a/examples/user_guide/5_Rasters.ipynb
+++ b/examples/user_guide/5_Rasters.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Datashader](http://datashader.org) renders data into regularly sampled arrays, a process known as [rasterization](https://en.wikipedia.org/wiki/Rasterisation), typically just before displaying it as an image.  In many cases, your data is *already* rasterized, such as data from imaging experiments, simulations on a regular grid, or other systematic processes.  Even so, often the rasters you have already are not the ones you need for a given purpose, having the wrong shape, range, or size to be suitable for overlaying with or comparing against other data or on maps.\n",
+    "\n",
+    "Datashader provides fast methods for [\"regridding\"](https://climatedataguide.ucar.edu/climate-data-tools-and-analysis/regridding-overview)/[\"re-sampling\"](http://gisgeography.com/raster-resampling/)/\"re-rasterizing\" yuor gridded datasets, generating new rasters on demand that can be used together with those it generates for any other data types to implement complex cross-datatype analyses or visualizations.\n",
+    "\n",
+    "To get started, let's declare a small raster using Numpy and wrap it up as an [xarray](http://xarray.pydata.org) DataArray: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np, datashader as ds, xarray as xr\n",
+    "from datashader import transfer_functions as tf\n",
+    "\n",
+    "def f(x,y):\n",
+    "    return np.cos((x**2+y**2)**2)\n",
+    "\n",
+    "def sample(fun, n=50, range_=(0.0,2.4)):\n",
+    "    ls  = np.linspace(*range_, n)\n",
+    "    x,y = np.meshgrid(ls, ls)\n",
+    "    z   = f(x,y)\n",
+    "    return xr.DataArray(z, coords={'x': ls, 'y': ls}, dims=('y', 'x'))\n",
+    "\n",
+    "da = sample(f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "DataArrays happen to be the format used for datashader's own output, so you can now immediately turn this array into an image using ``tf.shade()`` just as you would for points or lines rasterized by datashader:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.shade(da)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, what if we want a larger version?  We can do that by upsampling with either nearest-neighbor or bilinear interpolation (the default):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.Images(tf.shade(ds.Canvas().raster(da),                            name=\"linear upsampling (default)\"),\n",
+    "          tf.shade(ds.Canvas().raster(da, upsample_method='nearest'), name=\"nearest-neighbor upsampling\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, linear interpolation works well for smoothly varying values, like those in the lower left of this function, but doesn't help much for regions close to or beyond the sampling limits of the original raster.\n",
+    "\n",
+    "We can choose whatever output size we like and sample the grid over any range we like, though of course there won't be any data in regions outside of the original raster grid: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.shade(ds.Canvas(plot_height=200, plot_width=600, x_range=(-2,5), y_range=(-0.1,0.4)).raster(da))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The previous examples all use upsampling, from a smaller to a larger number of cells per unit distance in X or Y.  Downsampling works just as for points and lines in Datashader, supporting various aggregation functions.  These aggregation functions determine the result when more than one raster grid cell falls into a given pixel's region of the plane. To illustrate downsampling, let's first render a 500x500 version of the above 50x50 array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "da2 = sample(f, n=500)\n",
+    "tf.shade(da2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see that the version we upsampled to this size from the 50x50 samples is similar to this, but this one is much smoother and more accurately represents the underlying mathematical function, because it has sufficient resolution to avoid aliasing in the high-frequency portions of this function (towards the upper right).  Now that we have this larger array, we can downsample it using a variety of aggregation functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cvs = ds.Canvas(plot_width=150, plot_height=150)\n",
+    "tf.Images(tf.shade(cvs.raster(da2),                          name=\"mean downsampling (default)\"),\n",
+    "          tf.shade(cvs.raster(da2, downsample_method='min'), name=\"min downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, downsample_method='max'), name=\"max downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, downsample_method='std'), name=\"std downsampling\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here the default downsampling function ``mean`` renders a faithful size-reduced version of the original, with all the raster grid points that overlap a given pixel being averaged to create the final pixel value.  The ``min`` and ``max`` aggregation functions take the minimum or maxiumum, respectively, of the values overlapping each pixel, and you can see here that the ``min`` version has larger light blue regions towards the upper right (with each pixel reflecting the minimum of all grid cells it overlaps), while the ``max`` version has larger dark-blue-regions towards the upper right.  The ``std`` version reports the standard deviation of the grid cells in each pixel, which is low towards the lower left where the function is smooth, and increases towards the upper right, where the function value varies significantly per pixel.\n",
+    "\n",
+    "The differences between min and max are clearer if we look at a regime where the function varies so much that it can only barely be faithfully be represented in a grid of this size:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "da3 = sample(f, n=500, range_=(0,3))\n",
+    "tf.shade(da3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the upper right of this plot, you can see that the function is varying with such high frequency that any downsampled version will fail to represent it properly.  The aggregation functions in Datashader can help you see when that is happening:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cvs = ds.Canvas(plot_width=150, plot_height=150)\n",
+    "tf.Images(tf.shade(cvs.raster(da3),                          name=\"mean downsampling (default)\"),\n",
+    "          tf.shade(cvs.raster(da3, downsample_method='min'), name=\"min downsampling\"),\n",
+    "          tf.shade(cvs.raster(da3, downsample_method='max'), name=\"max downsampling\"),\n",
+    "          tf.shade(cvs.raster(da3, downsample_method='std'), name=\"std downsampling\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here you can see that the ``mean`` downsampling looks like a good approximation to the original array, locally averaging the original function values in each portion of the array.  However, if you were to zoom in and adjust for contrast, you would be able to see some of the inevitable aliasing artifacts that occur for any such representation in a too-small array.  These aliasing effects are clearly visible in the ``min`` and ``max`` aggregation, because they keep the local minimum or maxiumum rather than averaging out the artifacts.  Comparing ``mean`` and ``min`` or ``max`` (or subtracting ``min`` from ``max``) can help find regions of the array that are being poorly represented in the current view.\n",
+    "\n",
+    "In practice, it is usually a good idea to view your data interactively at many different zoom levels to detect such problems; see [3 Timeseries](3_Timeseries.ipynb).\n",
+    "\n",
+    "You can see Datashader rasters at work in the [Landsat](../topics/Landsat.ipynb) example:\n",
+    "\n",
+    "<img src=\"https://raw.githubusercontent.com/bokeh/datashader/master/docs/images/landsat.png\" width=1204 height=1150>"
+   ]
+  }
+ ],
+ "metadata": {
+  "extensions": {
+   "jupyter_dashboards": {
+    "activeView": "report_default",
+    "version": 1,
+    "views": {
+     "grid_default": {
+      "cellMargin": 10,
+      "defaultCellHeight": 20,
+      "maxColumns": 12,
+      "name": "grid",
+      "type": "grid"
+     },
+     "report_default": {
+      "name": "report",
+      "type": "report"
+     }
+    }
+   }
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/user_guide/5_Rasters.ipynb
+++ b/examples/user_guide/5_Rasters.ipynb
@@ -124,7 +124,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here the default downsampling function ``mean`` renders a faithful size-reduced version of the original, with all the raster grid points that overlap a given pixel being averaged to create the final pixel value.  The ``min`` and ``max`` aggregation functions take the minimum or maxiumum, respectively, of the values overlapping each pixel, and you can see here that the ``min`` version has larger light blue regions towards the upper right (with each pixel reflecting the minimum of all grid cells it overlaps), while the ``max`` version has larger dark-blue-regions towards the upper right.  The ``std`` version reports the standard deviation of the grid cells in each pixel, which is low towards the lower left where the function is smooth, and increases towards the upper right, where the function value varies significantly per pixel.\n",
+    "Here the default downsampling function ``mean`` renders a faithful size-reduced version of the original, with all the raster grid points that overlap a given pixel being averaged to create the final pixel value.  The ``min`` and ``max`` aggregation functions take the minimum or maxiumum, respectively, of the values overlapping each pixel, and you can see here that the ``min`` version has larger light-blue regions towards the upper right (with each pixel reflecting the minimum of all grid cells it overlaps), while the ``max`` version has larger dark-blue regions towards the upper right.  The ``std`` version reports the standard deviation of the grid cells in each pixel, which is low towards the lower left where the function is smooth, and increases towards the upper right, where the function value varies significantly per pixel.\n",
     "\n",
     "The differences between min and max are clearer if we look at a regime where the function varies so much that it can only barely be faithfully be represented in a grid of this size:"
    ]
@@ -165,7 +165,7 @@
    "source": [
     "Here you can see that the ``mean`` downsampling looks like a good approximation to the original array, locally averaging the original function values in each portion of the array.  However, if you were to zoom in and adjust for contrast, you would be able to see some of the inevitable aliasing artifacts that occur for any such representation in a too-small array.  These aliasing effects are clearly visible in the ``min`` and ``max`` aggregation, because they keep the local minimum or maxiumum rather than averaging out the artifacts.  Comparing ``mean`` and ``min`` or ``max`` (or subtracting ``min`` from ``max``) can help find regions of the array that are being poorly represented in the current view.\n",
     "\n",
-    "In practice, it is usually a good idea to view your data interactively at many different zoom levels to detect such problems; see [3 Timeseries](3_Timeseries.ipynb).\n",
+    "In practice, it is usually a good idea to view your data interactively at many different zoom levels to detect such problems; see [3 Timeseries](3_Timeseries.ipynb).  For such cases, you can define both upsampling and downsampling methods at the same time; whichever one is needed for a given zoom level and range of the data will be applied.\n",
     "\n",
     "You can see Datashader rasters at work in the [Landsat](../topics/Landsat.ipynb) example:\n",
     "\n",


### PR DESCRIPTION
Adds a raster section to the user guide.  Also fixes existing problem with the landsat raster example, and adds missing auto-ranging for rasters.  Rendered example is at: https://anaconda.org/jbednar/5_rasters