### PR TITLE
Fixed bug in parallel mode calculation for Canvas.raster()

### DIFF
--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -468,9 +468,13 @@ def _downsample_2d_mode(src, mask, use_mask, method, fill_value, mode_rank, out)
     scale_y = src_h / out_h
 
     max_value_count = int(scale_x + 1) * int(scale_y + 1)
-    values = np.zeros((max_value_count,), dtype=src.dtype)
-    frequencies = np.zeros((max_value_count,), dtype=np.uint32)
+    if mode_rank >= max_value_count:
+        raise ValueError("requested mode_rank too large for max_value_count being collected")
+
     for out_y in prange(out_h):
+        values = np.zeros((max_value_count,), dtype=src.dtype)
+        frequencies = np.zeros((max_value_count,), dtype=np.uint32)
+
         src_yf0 = scale_y * out_y
         src_yf1 = src_yf0 + scale_y
         src_y0 = int(src_yf0)


### PR DESCRIPTION
Previously, calling Canvas.raster(downsample_method='mode') was giving entirely corrupted results:

![image](https://user-images.githubusercontent.com/1695496/35292421-0a35781e-0036-11e8-9a40-0bde0000a02d.png)

Turns out that when Numba parallel was enabled for this file, the outermost loop in ``_downsample_2d_mode`` was switched to use ``prange`` without moving the values and frequencies arrays inside the loop, meaning that each parallel iteration of the loop was clobbering the same allocated values and frequencies arrays.  After moving the array allocation inside the loop all is well:

![image](https://user-images.githubusercontent.com/1695496/35292559-7db5b47a-0036-11e8-8e5c-2faa301cbcaf.png)

Also added an exception for when the user has requested a mode rank that could never be satisfied given the actual scaling factors for this call (e.g. asking for the 25th most common value when each pixel has only 4 source pixels and thus 4 source values).