### PR TITLE
New API for Canvas.raster

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -10,23 +10,7 @@ from collections import OrderedDict
 from .utils import Dispatcher, ngjit, calc_res, calc_bbox, orient_array, compute_coords, get_indices, dshape_from_pandas, dshape_from_dask, categorical_in_dtypes
 from .resampling import (resample_2d, US_NEAREST, US_LINEAR, DS_FIRST, DS_LAST,
                          DS_MEAN, DS_MODE, DS_VAR, DS_STD, DS_MIN, DS_MAX)
-
-
-class Expr(object):
-    """Base class for expression-like objects.
-
-    Implements hashing and equality checks. Subclasses should implement an
-    ``inputs`` attribute/property, containing a tuple of everything that fully
-    defines that expression.
-    """
-    def __hash__(self):
-        return hash((type(self), self.inputs))
-
-    def __eq__(self, other):
-        return type(self) is type(other) and self.inputs == other.inputs
-
-    def __ne__(self, other):
-        return not self == other
+from .utils import Expr # noqa (API import)
 
 
 class Axis(object):

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -306,9 +306,9 @@ class Canvas(object):
         upsample_methods = dict(nearest=US_NEAREST,
                                 linear=US_LINEAR)
 
-        downsample_methods = {'first':DS_FIRST,
-                              'last':DS_LAST,
-                              'mode':DS_MODE,
+        downsample_methods = {'first':DS_FIRST, rd.first:DS_FIRST,
+                              'last':DS_LAST,   rd.last:DS_LAST,
+                              'mode':DS_MODE,   rd.mode:DS_MODE,
                               'mean':DS_MEAN,   rd.mean:DS_MEAN,
                               'var':DS_VAR,     rd.var:DS_VAR,
                               'std':DS_STD,     rd.std:DS_STD,

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -293,8 +293,8 @@ class Canvas(object):
         source : xarray.DataArray or xr.Dataset
             2D or 3D labelled array (if Dataset, the agg reduction must
             define the data variable).
-        layer : int
-            Source layer number : optional default=None
+        layer : float
+            For a 3D array, value along the z dimension : optional default=None
         interpolate : str, optional  default=linear
             Resampling mode when upsampling raster.
             options include: nearest, linear.
@@ -368,7 +368,9 @@ class Canvas(object):
         ydim, xdim = source.dims[-2:]
         xvals, yvals = source[xdim].values, source[ydim].values
         left, bottom, right, top = calc_bbox(xvals, yvals, res)
-        array = orient_array(source, res, layer)
+        if layer is not None:
+            source=source.sel(**{source.dims[0]: layer})
+        array = orient_array(source, res)
         dtype = array.dtype
 
         if nan_value is not None:

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import, division
 from toolz import memoize
 import numpy as np
 
-from .core import Expr
-from .utils import ngjit, isreal
+from .utils import ngjit, isreal, Expr
 
 
 class Glyph(Expr):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -390,8 +390,6 @@ class first(Reduction):
     not an average or other numerical calculation.
     
     Currently only supported for rasters, externally to this class.
-    Due to parallel implementation, there are no guarantees on precisely 
-    which value will be returned.
 
     Parameters
     ----------
@@ -426,8 +424,6 @@ class last(Reduction):
     not an average or other numerical calculation.
     
     Currently only supported for rasters, externally to this class.
-    Due to parallel implementation, there are no guarantees on precisely 
-    which value will be returned.
 
     Parameters
     ----------

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -77,7 +77,7 @@ class OptionalFieldReduction(Reduction):
 
     @property
     def inputs(self):
-        return (extract(self.column),) if self.column else ()
+        return (extract(self.column),) if self.column is not None else ()
 
     def validate(self, in_dshape):
         pass
@@ -381,6 +381,115 @@ class std(Reduction):
         with np.errstate(divide='ignore', invalid='ignore'):
             x = np.sqrt(m2s/counts)
         return xr.DataArray(x, **kwargs)
+
+
+class first(Reduction):
+    """First value encountered in ``column``.
+
+    Useful for categorical data where an actual value must always be returned, 
+    not an average or other numerical calculation.
+    
+    Currently only supported for rasters, externally to this class.
+    Due to parallel implementation, there are no guarantees on precisely 
+    which value will be returned.
+
+    Parameters
+    ----------
+    column : str
+        Name of the column to aggregate over. If the data type is floating point, 
+        ``NaN`` values in the column are skipped.
+    """
+    _dshape = dshape(Option(ct.float64))
+
+    @staticmethod 
+    def _append(x, y, agg):
+        raise NotImplementedError("first is currently implemented only for rasters")
+    
+    @staticmethod 
+    def _create(shape):
+        raise NotImplementedError("first is currently implemented only for rasters")
+
+    @staticmethod
+    def _combine(aggs):
+        raise NotImplementedError("first is currently implemented only for rasters")
+
+    @staticmethod
+    def _finalize(bases, **kwargs):
+        raise NotImplementedError("first is currently implemented only for rasters")
+
+
+
+class last(Reduction):
+    """Last value encountered in ``column``.
+
+    Useful for categorical data where an actual value must always be returned, 
+    not an average or other numerical calculation.
+    
+    Currently only supported for rasters, externally to this class.
+    Due to parallel implementation, there are no guarantees on precisely 
+    which value will be returned.
+
+    Parameters
+    ----------
+    column : str
+        Name of the column to aggregate over. If the data type is floating point, 
+        ``NaN`` values in the column are skipped.
+    """
+    _dshape = dshape(Option(ct.float64))
+
+    @staticmethod 
+    def _append(x, y, agg):
+        raise NotImplementedError("last is currently implemented only for rasters")
+    
+    @staticmethod 
+    def _create(shape):
+        raise NotImplementedError("last is currently implemented only for rasters")
+
+    @staticmethod
+    def _combine(aggs):
+        raise NotImplementedError("last is currently implemented only for rasters")
+
+    @staticmethod
+    def _finalize(bases, **kwargs):
+        raise NotImplementedError("last is currently implemented only for rasters")
+
+
+
+class mode(Reduction):
+    """Mode (most common value) of all the values encountered in ``column``.
+
+    Useful for categorical data where an actual value must always be returned, 
+    not an average or other numerical calculation.
+    
+    Currently only supported for rasters, externally to this class.
+    Implementing it for other glyph types would be difficult due to potentially
+    unbounded data storage requirements to store indefinite point or line
+    data per pixel.
+
+    Parameters
+    ----------
+    column : str
+        Name of the column to aggregate over. If the data type is floating point, 
+        ``NaN`` values in the column are skipped.
+    """
+    _dshape = dshape(Option(ct.float64))
+
+    @staticmethod 
+    def _append(x, y, agg):
+        raise NotImplementedError("mode is currently implemented only for rasters")
+    
+    @staticmethod 
+    def _create(shape):
+        raise NotImplementedError("mode is currently implemented only for rasters")
+
+    @staticmethod
+    def _combine(aggs):
+        raise NotImplementedError("mode is currently implemented only for rasters")
+
+    @staticmethod
+    def _finalize(bases, **kwargs):
+        raise NotImplementedError("mode is currently implemented only for rasters")
+
 
 
 class summary(Expr):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -6,8 +6,7 @@ from datashape import coretypes as ct
 from toolz import concat, unique
 import xarray as xr
 
-from .core import Expr
-from .utils import ngjit
+from .utils import Expr, ngjit
 
 
 class Preprocess(Expr):

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -33,10 +33,12 @@ class category_codes(Preprocess):
 
 class Reduction(Expr):
     """Base class for per-bin reductions."""
-    def __init__(self, column):
+    def __init__(self, column=None):
         self.column = column
 
     def validate(self, in_dshape):
+        if not self.column in in_dshape.dict:
+            raise ValueError("specified column not found")
         if not isnumeric(in_dshape.measure[self.column]):
             raise ValueError("input must be numeric")
 

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -73,8 +73,13 @@ _NOMASK2D = np.ma.getmaskarray(np.ma.array([[0]], mask=[[0]]))
 
 _EPS = 1e-10
 
+upsample_methods   = dict(nearest=US_NEAREST, linear=US_LINEAR)
 
-def resample_2d(src, w, h, ds_method=DS_MEAN, us_method=US_LINEAR, fill_value=None, mode_rank=1, out=None):
+downsample_methods = dict(first=DS_FIRST, last=DS_LAST, mode=DS_MODE,
+                          mean=DS_MEAN,   var=DS_VAR,   std=DS_STD,
+                          min=DS_MIN,     max=DS_MAX)
+
+def resample_2d(src, w, h, ds_method='mean', us_method='linear', fill_value=None, mode_rank=1, out=None):
     """
     Resample a 2-D grid to a new resolution.
 
@@ -104,6 +109,10 @@ def resample_2d(src, w, h, ds_method=DS_MEAN, us_method=US_LINEAR, fill_value=No
         return src
     mask, use_mask = _get_mask(src)
     fill_value = _get_fill_value(fill_value, src, out)
+
+    us_method=upsample_methods[us_method]
+    ds_method=downsample_methods[ds_method]
+    
     return _mask_or_not(_resample_2d(src, mask, use_mask, ds_method, us_method, fill_value, mode_rank, out),
                         src, fill_value)
 

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -15,6 +15,23 @@ import datashape
 ngjit = nb.jit(nopython=True, nogil=True)
 
 
+class Expr(object):
+    """Base class for expression-like objects.
+
+    Implements hashing and equality checks. Subclasses should implement an
+    ``inputs`` attribute/property, containing a tuple of everything that fully
+    defines that expression.
+    """
+    def __hash__(self):
+        return hash((type(self), self.inputs))
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.inputs == other.inputs
+
+    def __ne__(self, other):
+        return not self == other
+
+
 class Dispatcher(object):
     """Simple single dispatch."""
     def __init__(self):

--- a/examples/user_guide/5_Rasters.ipynb
+++ b/examples/user_guide/5_Rasters.ipynb
@@ -117,10 +117,10 @@
    "source": [
     "cvs = ds.Canvas(plot_width=150, plot_height=150)\n",
     "tf.Images(tf.shade(cvs.raster(da2),                             name=\"mean downsampling (default)\"),\n",
-    "          tf.shade(cvs.raster(da2, agg=rd.min()), name=\"min downsampling\"),\n",
-    "          tf.shade(cvs.raster(da2, agg=rd.max()), name=\"max downsampling\"),\n",
-    "          tf.shade(cvs.raster(da2, agg='mode'),   name=\"mode downsampling\"),\n",
-    "          tf.shade(cvs.raster(da2, agg=rd.std()), name=\"std downsampling\"))"
+    "          tf.shade(cvs.raster(da2, agg=rd.min()),  name=\"min downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, agg=rd.max()),  name=\"max downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, agg=rd.mode()), name=\"mode downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, agg=rd.std()),  name=\"std downsampling\"))"
    ]
   },
   {
@@ -159,7 +159,7 @@
     "tf.Images(tf.shade(cvs.raster(da3),                             name=\"mean downsampling (default)\"),\n",
     "          tf.shade(cvs.raster(da3, agg=rd.min()), name=\"min downsampling\"),\n",
     "          tf.shade(cvs.raster(da3, agg=rd.max()), name=\"max downsampling\"),\n",
-    "          tf.shade(cvs.raster(da3, agg='mode'),   name=\"mode downsampling\"),\n",
+    "          tf.shade(cvs.raster(da3, agg=rd.mode()),name=\"mode downsampling\"),\n",
     "          tf.shade(cvs.raster(da3, agg=rd.std()), name=\"std downsampling\"))"
    ]
   },

--- a/examples/user_guide/5_Rasters.ipynb
+++ b/examples/user_guide/5_Rasters.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "import numpy as np, datashader as ds, xarray as xr\n",
-    "from datashader import transfer_functions as tf\n",
+    "from datashader import transfer_functions as tf, reductions as rd\n",
     "\n",
     "def f(x,y):\n",
     "    return np.cos((x**2+y**2)**2)\n",
@@ -63,8 +63,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tf.Images(tf.shade(ds.Canvas().raster(da),                            name=\"linear upsampling (default)\"),\n",
-    "          tf.shade(ds.Canvas().raster(da, upsample_method='nearest'), name=\"nearest-neighbor upsampling\"))"
+    "tf.Images(tf.shade(ds.Canvas().raster(da),                        name=\"linear interpolation (default)\"),\n",
+    "          tf.shade(ds.Canvas().raster(da, interpolate='nearest'), name=\"nearest-neighbor interpolation\"))"
    ]
   },
   {
@@ -116,11 +116,11 @@
    "outputs": [],
    "source": [
     "cvs = ds.Canvas(plot_width=150, plot_height=150)\n",
-    "tf.Images(tf.shade(cvs.raster(da2),                          name=\"mean downsampling (default)\"),\n",
-    "          tf.shade(cvs.raster(da2, downsample_method='min'), name=\"min downsampling\"),\n",
-    "          tf.shade(cvs.raster(da2, downsample_method='max'), name=\"max downsampling\"),\n",
-    "          tf.shade(cvs.raster(da2, downsample_method='mode'),name=\"mode downsampling\"),\n",
-    "          tf.shade(cvs.raster(da2, downsample_method='std'), name=\"std downsampling\"))"
+    "tf.Images(tf.shade(cvs.raster(da2),                             name=\"mean downsampling (default)\"),\n",
+    "          tf.shade(cvs.raster(da2, agg=rd.min()), name=\"min downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, agg=rd.max()), name=\"max downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, agg='mode'),   name=\"mode downsampling\"),\n",
+    "          tf.shade(cvs.raster(da2, agg=rd.std()), name=\"std downsampling\"))"
    ]
   },
   {
@@ -156,11 +156,11 @@
    "outputs": [],
    "source": [
     "cvs = ds.Canvas(plot_width=150, plot_height=150)\n",
-    "tf.Images(tf.shade(cvs.raster(da3),                          name=\"mean downsampling (default)\"),\n",
-    "          tf.shade(cvs.raster(da3, downsample_method='min'), name=\"min downsampling\"),\n",
-    "          tf.shade(cvs.raster(da3, downsample_method='max'), name=\"max downsampling\"),\n",
-    "          tf.shade(cvs.raster(da3, downsample_method='mode'),name=\"mode downsampling\"),\n",
-    "          tf.shade(cvs.raster(da3, downsample_method='std'), name=\"std downsampling\"))"
+    "tf.Images(tf.shade(cvs.raster(da3),                             name=\"mean downsampling (default)\"),\n",
+    "          tf.shade(cvs.raster(da3, agg=rd.min()), name=\"min downsampling\"),\n",
+    "          tf.shade(cvs.raster(da3, agg=rd.max()), name=\"max downsampling\"),\n",
+    "          tf.shade(cvs.raster(da3, agg='mode'),   name=\"mode downsampling\"),\n",
+    "          tf.shade(cvs.raster(da3, agg=rd.std()), name=\"std downsampling\"))"
    ]
   },
   {

--- a/examples/user_guide/5_Rasters.ipynb
+++ b/examples/user_guide/5_Rasters.ipynb
@@ -23,11 +23,11 @@
     "def f(x,y):\n",
     "    return np.cos((x**2+y**2)**2)\n",
     "\n",
-    "def sample(fun, n=50, range_=(0.0,2.4)):\n",
-    "    ls  = np.linspace(*range_, n)\n",
-    "    x,y = np.meshgrid(ls, ls)\n",
-    "    z   = f(x,y)\n",
-    "    return xr.DataArray(z, coords=[('y',ls), ('x',ls)])\n",
+    "def sample(fn, n=50, range_=(0.0,2.4)):\n",
+    "    xs = ys = np.linspace(*range_, n)\n",
+    "    x,y = np.meshgrid(xs, ys)\n",
+    "    z   = fn(x,y)\n",
+    "    return xr.DataArray(z, coords=[('y',ys), ('x',xs)])\n",
     "\n",
     "da = sample(f)"
    ]
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we are declaring that the first dimension of the ``DataArray`` (the rows) is called ``y`` and corresponds to the indicated continuous coordinate values in the list ``ls``, and similarly for the second dimension (the columns) called ``x``.  The coords argument is optional, but without it the default integer indexing from Numpy would be used, which would not match how this data was generated (sampling over each of the ``ls`` values). Datashader only supports rectilinear, 2D ``DataArray``s, and so will not accept the additional dimensions or non-separable coordinate arrays that xarray allows.\n",
+    "Here we are declaring that the first dimension of the ``DataArray`` (the rows) is called ``y`` and corresponds to the indicated continuous coordinate values in the list ``ys``, and similarly for the second dimension (the columns) called ``x``.  The coords argument is optional, but without it the default integer indexing from Numpy would be used, which would not match how this data was generated (sampling over each of the ``ys``). Datashader only supports rectilinear, 2D or 3D ``DataArray``s, and so will not accept the additional dimensions or non-separable coordinate arrays that xarray allows.\n",
     "\n",
     "DataArrays of this type happen to be the format used for datashader's own rasterized output, so you can now immediately turn this array into an image using ``tf.shade()`` just as you would for points or lines rasterized by datashader:"
    ]
@@ -54,6 +54,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Interpolation (upsampling)\n",
+    "\n",
     "So, what if we want a larger version?  We can do that by upsampling with either nearest-neighbor or bilinear interpolation (the default):"
    ]
   },
@@ -89,6 +91,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Aggregation (downsampling)\n",
+    "\n",
     "The previous examples all use upsampling, from a smaller to a larger number of cells per unit distance in X or Y.  Downsampling works just as for points and lines in Datashader, supporting various aggregation functions.  These aggregation functions determine the result when more than one raster grid cell falls into a given pixel's region of the plane. To illustrate downsampling, let's first render a 500x500 version of the above 50x50 array:"
    ]
   },
@@ -106,7 +110,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see that the version we upsampled to this size from the 50x50 samples is similar to this, but this one is much smoother and more accurately represents the underlying mathematical function, because it has sufficient resolution to avoid aliasing in the high-frequency portions of this function (towards the upper right).  Now that we have this larger array, we can downsample it using a variety of aggregation functions:"
+    "You can see that the version we upsampled to this size from the 50x50 samples is similar to this, but this one is much smoother and more accurately represents the underlying mathematical function, because it has sufficient resolution to avoid aliasing in the high-frequency portions of this function (towards the upper right).  \n",
+    "\n",
+    "Now that we have this larger array, we can downsample it using a variety of aggregation functions:"
    ]
   },
   {
@@ -156,7 +162,7 @@
    "outputs": [],
    "source": [
     "cvs = ds.Canvas(plot_width=150, plot_height=150)\n",
-    "tf.Images(tf.shade(cvs.raster(da3),                             name=\"mean downsampling (default)\"),\n",
+    "tf.Images(tf.shade(cvs.raster(da3),               name=\"mean downsampling (default)\"),\n",
     "          tf.shade(cvs.raster(da3, agg=rd.min()), name=\"min downsampling\"),\n",
     "          tf.shade(cvs.raster(da3, agg=rd.max()), name=\"max downsampling\"),\n",
     "          tf.shade(cvs.raster(da3, agg=rd.mode()),name=\"mode downsampling\"),\n",
@@ -169,7 +175,9 @@
    "source": [
     "Here you can see that the ``mean`` downsampling looks like a good approximation to the original array, locally averaging the original function values in each portion of the array.  However, if you were to zoom in and adjust for contrast, you would be able to see some of the inevitable aliasing artifacts that occur for any such representation in a too-small array.  These aliasing effects are clearly visible in the ``min`` and ``max`` aggregation, because they keep the local minimum or maxiumum rather than averaging out the artifacts.  Comparing ``mean`` and ``min`` or ``max`` (or subtracting ``min`` from ``max``) can help find regions of the array that are being poorly represented in the current view.\n",
     "\n",
-    "The above rasters are all very tiny, for illustration purposes, but Datashader's raster support is accelerated using Numba, and can re-sample much larger rasters easily.  For instance, rendering the above function into a 10000x10000 raster takes a few seconds on a four-core machine, but it can then be re-sampled using Datashader in under 0.1 sec:"
+    "## Collections of raster data\n",
+    "\n",
+    "The above examples all use a single 2D DataArray.  Datashader can also use a 3D DataArray as long as which \"layer\" along this third dimension is wanted is specified:"
    ]
   },
   {
@@ -178,17 +186,75 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%time da4 = sample(f, n=10000, range_=(0,3))\n",
-    "%time tf.shade(cvs.raster(da4))"
+    "def g(x, y, k=1):\n",
+    "    return np.cos(k*((x**2+y**2)**2))\n",
+    "\n",
+    "ks = [1.1,3.3,33]\n",
+    "xs = ys = np.linspace(0.0, 2.4, 200)\n",
+    "y,k,x = np.meshgrid(ys, ks, xs, indexing='xy')\n",
+    "\n",
+    "da4 = xr.DataArray(g(x,y,k), coords=[('k',ks), ('y',ys), ('x',xs)])\n",
+    "\n",
+    "tf.Images(tf.shade(ds.Canvas().raster(da4, layer=1), name=\"k=1.1\"),\n",
+    "          tf.shade(ds.Canvas().raster(da4, layer=2), name=\"k=3.3\"),\n",
+    "          tf.shade(ds.Canvas().raster(da4, layer=0), name=\"k=33\"))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here the factor \"k\" results in the function being evaluated at increasingly higher frequencies, eventually leading to complex [Moir&eacute; patterns](https://en.wikipedia.org/wiki/Moir%C3%A9_pattern) due to undersampling for k=33. 3D xarrays are useful for reading multi-layer image files, such as those from [xarray's rasterio-based support for reading from multilayer TIFFs](http://xarray.pydata.org/en/stable/io.html#rasterio).\n",
+    "\n",
+    "Similarly, Datashader can accept an xarray Dataset (a dictionary-like collection of aligned DataArrays), as long as the aggregation method specifies a suitable DataArray within the Dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def h(x,y): return np.sin((x**2+y**2)**2)\n",
+    "def m(x,y): return np.exp(x+y)\n",
+    "\n",
+    "dd = xr.Dataset({'cos': sample(f, n=150), \n",
+    "                 'sin': sample(h, n=150), \n",
+    "                 'exp': sample(m, n=150)})\n",
+    "\n",
+    "tf.Images(tf.shade(ds.Canvas().raster(dd, agg=rd.mean('cos')), name='cos ((x^2+y^2)^2)'),\n",
+    "          tf.shade(ds.Canvas().raster(dd, agg=rd.mean('sin')), name='sin ((x^2+y^2)^2)'),\n",
+    "          tf.shade(ds.Canvas().raster(dd, agg=rd.mean('exp')), name='exp (x+y)'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scaling up\n",
+    "\n",
+    "The above rasters are all relatively tiny, for illustration purposes, but Datashader's raster support is accelerated using multi-core machine-code generation from Numba, and can re-sample much larger rasters easily.  For instance, rendering the above function into a 10000x10000 raster takes a few seconds on a four-core machine using Numpy, but it can then be re-sampled using Datashader in under 0.1 sec:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time da5 = sample(m, n=10000, range_=(0,3))\n",
+    "%time tf.shade(cvs.raster(da5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interactivity\n",
+    "\n",
     "In practice, it is usually a good idea to view your data interactively at many different zoom levels to see all the data available and to detect any sampling or aliasing issues, which you can do with Datashader as described in [3_Interactivity](3_Interactivity.ipynb).  For such cases, you can define both upsampling and downsampling methods at the same time; whichever one is needed for a given zoom level and range of the data will be applied.\n",
     "\n",
-    "You can see Datashader rasters at work in the [Landsat](../topics/Landsat.ipynb) example notebook:\n",
+    "You can see Datashader rasters at work in the [Landsat](../topics/Landsat.ipynb) example notebook, which also has examples of reading raster data from multi-layer TIFF files using xarray and rasterio:\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/bokeh/datashader/master/docs/images/landsat.png\" width=1204 height=1150>"
    ]

--- a/examples/user_guide/5_Rasters.ipynb
+++ b/examples/user_guide/5_Rasters.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tf.Images(tf.shade(ds.Canvas().raster(da),                        name=\"linear interpolation (default)\"),\n",
+    "tf.Images(tf.shade(ds.Canvas().raster(da, interpolate='linear'),  name=\"linear interpolation (default)\"),\n",
     "          tf.shade(ds.Canvas().raster(da, interpolate='nearest'), name=\"nearest-neighbor interpolation\"))"
    ]
   },
@@ -116,7 +116,7 @@
    "outputs": [],
    "source": [
     "cvs = ds.Canvas(plot_width=150, plot_height=150)\n",
-    "tf.Images(tf.shade(cvs.raster(da2),                             name=\"mean downsampling (default)\"),\n",
+    "tf.Images(tf.shade(cvs.raster(da2),                name=\"mean downsampling (default)\"),\n",
     "          tf.shade(cvs.raster(da2, agg=rd.min()),  name=\"min downsampling\"),\n",
     "          tf.shade(cvs.raster(da2, agg=rd.max()),  name=\"max downsampling\"),\n",
     "          tf.shade(cvs.raster(da2, agg=rd.mode()), name=\"mode downsampling\"),\n",

--- a/examples/user_guide/5_Rasters.ipynb
+++ b/examples/user_guide/5_Rasters.ipynb
@@ -195,9 +195,9 @@
     "\n",
     "da4 = xr.DataArray(g(x,y,k), coords=[('k',ks), ('y',ys), ('x',xs)])\n",
     "\n",
-    "tf.Images(tf.shade(ds.Canvas().raster(da4, layer=1), name=\"k=1.1\"),\n",
-    "          tf.shade(ds.Canvas().raster(da4, layer=2), name=\"k=3.3\"),\n",
-    "          tf.shade(ds.Canvas().raster(da4, layer=0), name=\"k=33\"))"
+    "tf.Images(tf.shade(ds.Canvas().raster(da4, layer=1.1), name=\"k=1.1\"),\n",
+    "          tf.shade(ds.Canvas().raster(da4, layer=3.3), name=\"k=3.3\"),\n",
+    "          tf.shade(ds.Canvas().raster(da4, layer=33),  name=\"k=33\"))"
    ]
   },
   {
@@ -254,7 +254,7 @@
     "\n",
     "In practice, it is usually a good idea to view your data interactively at many different zoom levels to see all the data available and to detect any sampling or aliasing issues, which you can do with Datashader as described in [3_Interactivity](3_Interactivity.ipynb).  For such cases, you can define both upsampling and downsampling methods at the same time; whichever one is needed for a given zoom level and range of the data will be applied.\n",
     "\n",
-    "You can see Datashader rasters at work in the [Landsat](../topics/Landsat.ipynb) example notebook, which also has examples of reading raster data from multi-layer TIFF files using xarray and rasterio:\n",
+    "You can see Datashader rasters at work in the [Landsat](../topics/Landsat.ipynb) example notebook, which also has examples of reading raster data from TIFF files using xarray and rasterio:\n",
     "\n",
     "<img src=\"https://raw.githubusercontent.com/bokeh/datashader/master/docs/images/landsat.png\" width=1204 height=1150>"
    ]

--- a/examples/user_guide/6_Trimesh.ipynb
+++ b/examples/user_guide/6_Trimesh.ipynb
@@ -161,8 +161,8 @@
    "outputs": [],
    "source": [
     "from colorcet import rainbow as c\n",
-    "tf.Images(tf.shade(cvs.trimesh(verts, tris, interp=False), cmap=c, name='10 Vertices'),\n",
-    "          tf.shade(cvs.trimesh(verts, tris, interp=True),  cmap=c, name='10 Vertices Interpolated'))"
+    "tf.Images(tf.shade(cvs.trimesh(verts, tris, interpolate='nearest'), cmap=c, name='10 Vertices'),\n",
+    "          tf.shade(cvs.trimesh(verts, tris, interpolate='linear'),  cmap=c, name='10 Vertices Interpolated'))"
    ]
   },
   {


### PR DESCRIPTION
As mentioned in https://github.com/ioam/holoviews/issues/1909, the ``Canvas.raster()`` API does not match the rest of datashader, due to that code originating in an external project (gridtools). These differences make it difficult for external tools like HoloViews to provide a consistent interface for datashading across object types. Fully rewriting this code would be a lot of work, but this WIP PR represents a first pass at making the Canvas.raster() API more similar to the other Canvas glyph types.  The changes should all be backwards compatible for now, but the previous way of doing it will now be deprecated and removed in a later release.

API Changes:

- Renamed ``Canvas.raster(downsample_method=X)`` to ``Canvas.raster(agg=X)``: What gridtools calls "downsampling" is precisely the same concept as what datashader calls aggregation everywhere else.  "reduction" is perhaps even more accurate, but arguments like that are called ``agg`` elsewhere, so I've adopted that convention here as well.  ``downsample_method`` is still accepted as an alias for now, if ``agg`` is not present.
- Renamed ``Canvas.raster(upsample_method=X)`` to ``Canvas.raster(interpolate=X)``: "interpolate" seems like a better complement to "agg" than "upsample_method".  ``upsample_method`` is still accepted as an alias for now, if ``interpolate`` is not present.
- The ``agg`` argument of other calls accepts any object of type ``.reductions.Reduction``, but ``raster()`` accepted only string arguments.  It now accepts ``Reduction`` objects like ``rd.mean()``, extracting the "column" name, if any, and comparing it to the DataArray's name, if any (signaling an error if a "column" name is specified but doesn't match).  Of course, it's not really a "column", but it's the same idea.  Leaving off the explicit column is fine for a raster, since by definition an xarray DataArray can have only one data dimension, and so Reduction has been changed to allow instantiation without any argument.  String names are still accepted, for backwards compatibility, but would presumably eventually be removed.

Open issues:

- ``Canvas.raster`` supports three aggregations that are not available in ``.reductions``: ``mode``, ``first``, and ``last``.  All three are designed for use with categorical data where numerical averaging is not appropriate and an actual existing value must be returned.  For now, these can be accessed with strings, but that's confusing and inconsistent.  Options:
    1. Delete these three
    2. Keep using strings just for these three
    3. Add dummy reductions for these three raising NotImplementedError on use, just for API consistency
    4. Implement these three for the other Datashader operations.
- I think these three reductions are useful, so I don't want option i, but option ii is annoying.  Maybe we could do option iii with an eye to someday option iv?
- Relaxing ``Reduction`` to allow construction with no argument might make some user errors more obscure by failing to detect them early.  I added an explicit check for an argument when the reduction is used, and it seems to work ok, but we should be on the lookout for confusing errors of this type.