### PR TITLE
Allow trimesh()'s doctest to pass, while indicating that the output is untested.

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -198,7 +198,7 @@ class Canvas(object):
         ...                       columns=['v0', 'v1', 'v2'])
         >>> cvs = ds.Canvas(x_range=(verts.x.min(), verts.x.max()),
         ...                 y_range=(verts.y.min(), verts.y.max()))
-        >>> cvs.trimesh(verts, tris)
+        >>> untested = cvs.trimesh(verts, tris)
 
         Parameters
         ----------


### PR DESCRIPTION
Notes:
  * by "untested", I mean the values returned are untested - any exception would show up, though
  * tests here do not cover this issue, so no need to wait on the tests
  * there's probably a doctest way of ignoring output (something like https://docs.python.org/3/library/doctest.html#doctest.ELLIPSIS ?)