### PR TITLE
Handle Canvas.raster subpixel condition

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -395,8 +395,8 @@ class Canvas(object):
         if np.isclose(width_ratio, 0) or np.isclose(height_ratio, 0):
             raise ValueError('Canvas x_range or y_range values do not match closely enough with the data source to be able to accurately rasterize. Please provide ranges that are more accurate.')
 
-        w = int(np.ceil(self.plot_width * width_ratio))
-        h = int(np.ceil(self.plot_height * height_ratio))
+        w = max(int(np.ceil(self.plot_width * width_ratio)), 1)
+        h = max(int(np.ceil(self.plot_height * height_ratio)), 1)
         cmin, cmax = get_indices(xmin, xmax, xvals, res[0])
         rmin, rmax = get_indices(ymin, ymax, yvals, res[1])
 
@@ -429,8 +429,8 @@ class Canvas(object):
             lpad = xmin - self.x_range[0]
             rpad = self.x_range[1] - xmax
             lpct = lpad / (lpad + rpad) if lpad + rpad > 0 else 0
-            left = int(np.ceil(num_width * lpct))
-            right = num_width - left
+            left = max(int(np.ceil(num_width * lpct)), 0)
+            right = max(num_width - left, 0)
             lshape, rshape = (self.plot_height, left), (self.plot_height, right)
             if layers > 1:
                 lshape, rshape = lshape + (layers,), rshape + (layers,)
@@ -440,8 +440,8 @@ class Canvas(object):
             tpad = ymin - self.y_range[0]
             bpad = self.y_range[1] - ymax
             tpct = tpad / (tpad + bpad) if tpad + bpad > 0 else 0
-            top = int(np.ceil(num_height * tpct))
-            bottom = num_height - top
+            top = max(int(np.ceil(num_height * tpct)), 0)
+            bottom = max(num_height - top, 0)
             tshape, bshape = (top, w), (bottom, w)
             if layers > 1:
                 tshape, bshape = tshape + (layers,), bshape + (layers,)

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -315,6 +315,50 @@ def test_raster_float_nan_value_padding():
     assert np.allclose(agg.y.values, np.array([1/3., 1.0, 5/3.]))
 
 
+def test_raster_single_pixel_range():
+    """
+    Ensure that canvas range covering a single pixel are handled correctly.
+    """
+
+    cvs = ds.Canvas(plot_height=3, plot_width=3, x_range=(0, 0.1), y_range=(0, 0.1))
+    array = np.array([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
+    xr_array = xr.DataArray(array, dims=['y', 'x'],
+                            coords={'x': np.linspace(0, 1, 4),
+                                    'y': np.linspace(0, 1, 3)})
+
+    agg = cvs.raster(xr_array, downsample_method='max', nan_value=9999)
+    expected = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+
+    assert np.allclose(agg.data, expected)
+    assert agg.data.dtype.kind == 'i'
+    assert np.allclose(agg.x.values, np.array([1/60., 1/20., 1/12.]))
+    assert np.allclose(agg.y.values, np.array([1/60., 1/20., 1/12.]))
+
+
+
+def test_raster_single_pixel_range_with_padding():
+    """
+    Ensure that canvas range covering a single pixel and small area
+    beyond the defined data ranges is handled correctly.
+    """
+
+    cvs = ds.Canvas(plot_height=4, plot_width=4, x_range=(-0.5, 0.25), y_range=(-.5, 0.25))
+    array = np.array([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]], dtype='f')
+    xr_array = xr.DataArray(array, dims=['y', 'x'],
+                            coords={'x': np.linspace(0, 1, 4),
+                                    'y': np.linspace(0, 1, 3)})
+
+    agg = cvs.raster(xr_array, downsample_method='max', nan_value=np.NaN)
+    expected = np.array([[np.NaN, np.NaN, np.NaN, np.NaN], [np.NaN, 0, 0, 0],
+                         [np.NaN, 0, 0, 0], [np.NaN, 0, 0, 0]])
+
+    assert np.allclose(agg.data, expected, equal_nan=True)
+    assert agg.data.dtype.kind == 'f'
+    assert np.allclose(agg.x.values, np.array([-0.40625, -0.21875, -0.03125,  0.15625]))
+    assert np.allclose(agg.y.values, np.array([-0.40625, -0.21875, -0.03125,  0.15625]))
+
+
+
 def test_resample_methods():
     """Assert that an error is raised when incorrect upsample and/or downsample
     methods are provided to cvs.raster().

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -153,7 +153,10 @@ def get_indices(start, end, coords, res):
     vmin, vmax = coords.min(), coords.max()
     span = vmax-vmin
     start, end = start+half-vmin, end-half-vmin
-    return int((start/span)*size), int((end/span)*size)
+    sidx, eidx = int((start/span)*size), int((end/span)*size)
+    if eidx < sidx:
+        return sidx, sidx
+    return sidx, eidx
 
 
 def orient_array(raster, res=None, layer=None):


### PR DESCRIPTION
When Canvas.raster is requested to downsample a plot to subpixel range all kinds of errors can occur due to negative dimensions and inverted ranges, additionally the padding code can get confused due to zero sized padding arrays. This ensures that the src_window always has a non-zero shape and that the padding is robust to issues like these.

- [x] Add a number of unit tests