### PR TITLE
Switch to testing on top of defaults rather than conda-forge

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   global:
-    CHANNELS: "-c pyviz/label/dev -c conda-forge"
+    CHANNELS: "-c pyviz/label/dev"
   matrix:
     - PY: "2.7"
       CONDA: "C:\\Miniconda-x64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # TODO:
 #
-#  * try switch to defaults
 #  * restore previous sections
 language: generic
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ os:
 env:
   global:
     - PYENV_VERSION=3.6
-    - CHANS_DEV="-c pyviz/label/dev -c conda-forge"
-    - CHANS_REL="-c pyviz -c conda-forge"
+    - CHANS_DEV="-c pyviz/label/dev"
+    - CHANS_REL="-c pyviz"
     - PKG_TEST_PYTHON="--test-python=py27 --test-python=py36"
     # conda build fills up travis /tmp (tmpfs)
     - TMPDIR=$HOME/tmp


### PR DESCRIPTION
Switch to testing on top of defaults rather than conda-forge.

We'll test on top of conda-forge on their CI (see https://github.com/pyviz/pyct/issues/25)