### PR TITLE
Added license and readme to pip packages to fix automatic build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include LICENSE.txt
+include README.md
 include datashader/.version
 graft examples
 graft datashader/tests/data


### PR DESCRIPTION
Addresses issue with README.md not being included in the pip package, causing the automatic build to fail.  Should tag a dev version and see if pip packages now build properly.