### PR TITLE
Silenced inappropriate warnings

### DIFF
--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -4,8 +4,7 @@ import param
 __version__ = str(param.version.Version(fpath=__file__, archive_commit="$Format:%h$",reponame="datashader"))
 
 from .core import Canvas                                 # noqa (API import)
-from .reductions import (count, any, sum, min, max,      # noqa (API import)
-                         mean, std, var, count_cat, summary)
+from .reductions import *                                # noqa (API import)
 from .glyphs import Point                                # noqa (API import)
 from .pipeline import Pipeline                           # noqa (API import)
 from . import transfer_functions as tf                   # noqa (API import)

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -535,7 +535,11 @@ def bypixel(source, canvas, glyph, agg):
     glyph.validate(schema)
     agg.validate(schema)
     canvas.validate()
-    return bypixel.pipeline(source, schema, canvas, glyph, agg)
+
+    # All-NaN objects (e.g. chunks of arrays with no data) are valid in Datashader
+    with np.warnings.catch_warnings():
+        np.warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
+        return bypixel.pipeline(source, schema, canvas, glyph, agg)
 
 
 bypixel.pipeline = Dispatcher()

--- a/datashader/reductions.py
+++ b/datashader/reductions.py
@@ -221,8 +221,9 @@ class m2(FloatingReduction):
 
     @staticmethod
     def _combine(Ms, sums, ns):
-        mu = np.nansum(sums, axis=0) / ns.sum(axis=0)
-        return np.nansum(Ms + ns*(sums/ns - mu)**2, axis=0)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            mu = np.nansum(sums, axis=0) / ns.sum(axis=0)
+            return np.nansum(Ms + ns*(sums/ns - mu)**2, axis=0)
 
 
 class min(FloatingReduction):
@@ -521,3 +522,11 @@ class summary(Expr):
     @property
     def inputs(self):
         return tuple(unique(concat(v.inputs for v in self.values)))
+
+
+
+__all__ = list(set([_k for _k,_v in locals().items()
+                    if isinstance(_v,type) and issubclass(_v,Reduction)
+                    and _v not in [Reduction, OptionalFieldReduction,
+                                   FloatingReduction, m2]]))
+    


### PR DESCRIPTION
In Datashader, NaN is used to indicate "no data" in a pixel, and so it is common for there to be aggregations that are all NaN, indicating that there is no data in a given chunk of the output raster or the entire raster.  By default, Numpy warns when an "all-NaN slice" is encountered, because in many cases people use Numpy's NaN-aware functions (e.g. `np.nanmin`) when they want a numerical value as a result, rather than NaN.  Here, we want the minimum (or other aggregation) of any bin to be NaN if there was no data in that bin, correctly reporting the lack of data rather than indicating any problem with the numerical calculations.  Thus it's appropriate to turn off Numpy's NaN warnings as done here.

Note that it's possible that they should be turned off at a different *location* in the code. In this PR, the warnings are disabled when calling `bypixel`, which applies to all of the pipeline, as I didn't find a good spot to turn them off just for aggregations.  I suspect that there is nowhere such a warning would be relevant for Datashader, though, hence disabling the warning at such a global level.

This PR also disables warnings for division by zero and invalid values in the `std` and `var` reductions specifically, which appear to occur for empty bins.  The default behavior of Numpy (apart from the warnings) appears to be fine in those cases, so it seems appropriate to disable the "divide by zero encountered" and "invalid value encountered" warnings here as well.

Also added a few recently added reduction operators to the main namespace, for API consistency.

